### PR TITLE
Restrict diaporama button visibility

### DIFF
--- a/at08.html
+++ b/at08.html
@@ -68,7 +68,6 @@
                                 <a href="https://docs.google.com/document/d/14PPTFn0BJDZpfzTXsN0bZfboeVF3zemjEOZdITZ4ZEs/edit?usp=sharing" target="_blank">Le sujet</a>
                                 <a href="https://drive.google.com/file/d/1DYYgTS_JFg0El78xQHUn5yoBpXi_y51a/view?usp=sharing" target="_blank">Le plan</a>
                                 <a href="https://docs.google.com/document/d/1uTNSmAs6L1d86xbMDxmshpRpb5vJI64uGVZs_q-_Wzk/edit?usp=sharing" target="_blank">Le cours</a>
-                                <a href="powerpoint.html">Le diaporama</a>
       			</div>
             </article>
              <article class="atelier">
@@ -92,7 +91,6 @@
 			</div>
                         <a href="https://docs.google.com/document/d/1dV_TsoFUDr5pVxVIrHSlU0bIEvWkXPuNU1ASJDIFTKI/edit?usp=sharing" target="_blank">Le sujet</a>
                         <a href="https://docs.google.com/document/d/1XfzVlgF-WCY35UmXkpypr_FIwuq3kI98kJVkOkRgmYg/edit?usp=sharing" target="_blank">Le cours</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 		</div>
             </article>
              <article class="atelier">

--- a/at15.html
+++ b/at15.html
@@ -41,7 +41,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1hhOdsgrHuIEw0k9HwFxl_t4TmDyOeyTQuu872ofCS9Y/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>
        </article>
         <article class="atelier">
@@ -65,7 +64,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1iOI3NEUkxxvs1JU_TcZvOfOfU32oeuIm7N8-SA1hom4/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>
        </article>
         <article class="atelier">
@@ -89,7 +87,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1BJBgx0YvnwEE-GNJrQ2Zivvk67Q6-YqxOBIqHbB8q2g/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>
        </article>
         <article class="atelier">
@@ -114,7 +111,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1nIbLflXJdKeRAIvKymH0PQ-44Jl9dPUXMdlJPshOjwM/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>	
        </article>
         <article class="atelier">
@@ -138,7 +134,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1pGkkHxKBO9aQOBonx41vorfj7jxkfBIxIqWFbjGd714/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>	
        </article>
         <article class="atelier">
@@ -162,7 +157,6 @@
 			<span>Rappels sur le programme de Technologie (analyse besoins, solution technique, capteurs, actionneurs, charte graphique...)</span>
 		</div>
 		<a href="https://docs.google.com/document/d/1ODbo8eJUbHiBfisWCTCenckFDuAwJWJdhfjSyBGVxrM/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
 	</div>
        </article>
       </section>

--- a/at17.html
+++ b/at17.html
@@ -59,7 +59,6 @@
       				<span>CT5.3 - Lire et utiliser des représentations numériques d’objets.</span>
       			</div>
       			<a href="https://docs.google.com/document/d/1-cz8NEVHOzwBH3mgtI0Mn3HQrRPSuECvh7s9PKL9maE/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article>         
       	
@@ -80,7 +79,6 @@
       				<span>CT2.2 -  Identifier le(s) matériau(x), les flux d’énergie et d’information dans le cadre d’une production technique sur un objet et décrire les transformations qui s’opèrent.</span>
       			</div>
       			<a href="https://docs.google.com/document/d/1eTLMXU8jAwGr96NJwYU6rQUzun9Q0BGhymoQdctl31U/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article> 
 	
@@ -101,7 +99,6 @@
       				<span>CT5.1 - Simuler numériquement le comportement d’un objet</span>
       			</div>
       			<a href="https://docs.google.com/document/d/1LYzwT_SC66TKWnfxHLkKmAFym1wamIuhbOERiI-0sXg/edit?usp=sharing" target="_blank">Le sujet</a>
-                        <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article>    
 	    <article class="atelier">

--- a/at24.html
+++ b/at24.html
@@ -59,7 +59,6 @@
 					<span>CT5.3 - Savoir lier croquis, dessin technique et modélisation 3D en réalisant un croquis de votre nichoir puis en veillant à ce que la modélisation 3D reste fidèle à votre dessin initial.</span>
 				</div>
 				<a href="https://docs.google.com/document/d/1iaFal0MLStSZod6MSbbPz-jb_394V53e9XZWR6ZkRqc/edit?usp=sharing" target="_blank">Le sujet</a>
-                                <a href="powerpoint.html">Le diaporama</a>  
       			</div>
             </article>
              <article class="atelier">
@@ -79,7 +78,6 @@
 						<span>CT3.2 - Identifier les flux d'énergie et d'information au sein de votre système, en détaillant les transformations effectuées, puis procéder à une étude fonctionnelle de votre système, du diagramme FAST jusqu'à la représentation de la chaîne d'information et d'énergie. </span>
 					</div>
       					<a href="https://docs.google.com/document/d/1WQZOLUNmKC3QRjPZIGxAZ2lDDF5Qw13ha4E_rB9f3Dg/edit?usp=sharing" target="_blank">Le sujet</a>
-                                <a href="powerpoint.html">Le diaporama</a>
       				</div>
             </article>
             

--- a/at25.html
+++ b/at25.html
@@ -43,7 +43,6 @@
 		  	</p>
 			
       			<a href="https://docs.google.com/document/d/1Wby12vqs4K6_TK19XkZxrvdN0iV3JQ83vY1Rf4Mkf1k/edit?usp=sharing" target="_blank">Le sujet</a>
-                            <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article>         
             <article class="atelier">
@@ -55,7 +54,6 @@
       </p>
 			
       			<a href="https://docs.google.com/document/d/1nUWH-nkxlarY5wBFMg4KI3YF3ppS80c2fUQ7eCxWZSE/edit?usp=sharing" target="_blank">Le sujet</a>
-                            <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article> 
 		
@@ -70,7 +68,6 @@
 			
 	              
       			<a href="https://docs.google.com/document/d/1Cb75q2XsNOac3RMN8skdyk4nwMR90S6IjMqiPGGzOxo/edit?usp=sharing" target="_blank">Le sujet</a>
-                            <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article> 
       	

--- a/at26.html
+++ b/at26.html
@@ -70,7 +70,6 @@
 				</div>
                                 <a href="https://docs.google.com/document/d/1bghornMB5aPi8ImpuQIGNZzE4YC03Rr7Ms8ynz-JKVA/edit?usp=sharing" target="_blank">Le sujet</a>
                                 <a href="https://docs.google.com/document/d/1uTNSmAs6L1d86xbMDxmshpRpb5vJI64uGVZs_q-_Wzk/edit?usp=sharing" target="_blank">Le cours</a>
-                                <a href="powerpoint.html">Le diaporama</a>
       			</div>
             </article>
              <article class="atelier">
@@ -97,7 +96,6 @@
 					</div>
                                         <a href="https://docs.google.com/document/d/1fWcQHZLf_8lrbUeQ-Gp-yGc6g2PzaWfFxqn67UfJ5Ic/edit?usp=sharing" target="_blank">Le sujet</a>
                                         <a href="https://docs.google.com/document/d/1XfzVlgF-WCY35UmXkpypr_FIwuq3kI98kJVkOkRgmYg/edit?usp=sharing" target="_blank">Le cours</a>
-                                        <a href="powerpoint.html">Le diaporama</a>
       				</div>
             </article>
 	    <article class="atelier">

--- a/at29.html
+++ b/at29.html
@@ -61,7 +61,6 @@
         					<span>CT5.3 - Lire, utiliser et produire des représentations numériques d’objets.</span>
         				</div>
 				        <a href="https://docs.google.com/document/d/1YgKt3D6U1sVCuCWdxj8MXXoUFzIPJCq8T80rkfwE8_M/edit?usp=sharing" target="_blank">Le sujet</a>
-                                             <a href="powerpoint.html">Le diaporama</a>  
       			</div>
             </article>
             
@@ -83,7 +82,6 @@
         					<span>CT5.4/CT5.5 - Piloter un système connecté localement ou à distance.</span>
         				</div>
 				        <a href="https://docs.google.com/document/d/1PX5ax6QI7E5JFZ0kGSnu5-tu4YAeL974J0Dz2E7V5Z4/edit?usp=sharing" target="_blank">Le sujet</a>
-                                             <a href="powerpoint.html">Le diaporama</a>  
       			</div>
             </article>
             

--- a/at31.html
+++ b/at31.html
@@ -43,7 +43,6 @@
 		  	</p>
 			
       			<a href="https://docs.google.com/document/d/1esVtcz3iPCSPIzfUYcqn0-a4ysZmr5hEUrJiaaPRn-I/edit?usp=sharing" target="_blank">Le sujet</a>
-                             <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article>         
       	
@@ -60,7 +59,6 @@
 		  	</p>
 			
       			<a href="https://docs.google.com/document/d/1acwpnfWxt1G7jDHv9c32VDe40m2aS1EaExtv3BtbCds/edit?usp=sharing" target="_blank">Le sujet</a>
-                             <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article> 
 		
@@ -76,7 +74,6 @@
 			
 	              
       			<a href="https://docs.google.com/document/d/1DAxXF-BzuMASsMuawY1RRVmnza-X5u1GDKG0qXUK8WQ/edit?usp=sharing" target="_blank">Le sujet</a>
-                             <a href="powerpoint.html">Le diaporama</a>
       		</div>
             </article> 
       		<div class="atelier-content">


### PR DESCRIPTION
## Summary
- keep the diaporama link only for the "Chef de projet" sections
- remove the diaporama link from other roles and activities

## Testing
- `grep -n "Le diaporama" -r | grep -v .git`

------
https://chatgpt.com/codex/tasks/task_e_6843f359c3908331a62fc6d6775fef19