### PR TITLE
Improve SNT credit social page layout

### DIFF
--- a/SNT_P1A.html
+++ b/SNT_P1A.html
@@ -44,20 +44,17 @@
                         <li>Vidéo (2 à 3&nbsp;min)</li>
                         <li>Site web (3 pages minimum en HTML/CSS)</li>
                     </ul>
+                </div>
+            </article>
 
-                    <h2>Répartition des rôles dans l’équipe</h2>
-                    <p>Chaque élève aura un rôle spécifique évalué individuellement sur 20&nbsp;points.</p>
-                    <ul>
-                        <li><strong>Expert juridique</strong> : analyse les lois et institutions encadrant la protection des données en Chine et en France.</li>
-                        <li><strong>Expert technique</strong> : explique le fonctionnement du système et les technologies mises en œuvre.</li>
-                        <li><strong>Expert éthique</strong> : réfléchit aux implications morales et sociales du dispositif.</li>
-                        <li><strong>Chef de projet</strong> : coordonne le groupe et garantit la cohérence du travail.</li>
-                        <li><strong>Expert média</strong> : conçoit la mise en forme finale du projet.</li>
-                    </ul>
+            <h2>Répartition des rôles dans l’équipe</h2>
+            <p>Chaque élève aura un rôle spécifique évalué individuellement sur 20&nbsp;points.</p>
 
-                    <h2>Critères d'évaluation par rôle (/20)</h2>
-                    <p>Chaque critère est noté sur 4 points pour obtenir une note finale sur 20.</p>
+            <h2>Critères d'évaluation par rôle (/20)</h2>
+            <p>Chaque rôle est présenté ci-dessous avec les critères correspondants.</p>
 
+            <article class="atelier">
+                <div class="atelier-content">
                     <h3>Expert juridique</h3>
                     <ul>
                         <li>Identification des lois chinoises pertinentes (Cybersecurity Law, Personal Information Protection Law…) et explication de leur rôle pour la vie privée et la surveillance.</li>
@@ -66,68 +63,70 @@
                         <li>Vulgarisation compréhensible des notions juridiques complexes.</li>
                         <li>Utilisation de sources fiables décrites et analysées de façon critique.</li>
                     </ul>
+                    <section class="expert-juridique">
+                        <h2>Détail du rôle d'expert juridique</h2>
+                        <p>L'expert juridique est chargé d'analyser en profondeur les lois et institutions encadrant la protection des données en Chine et en France. Il doit vulgariser ces notions pour l'ensemble de l'équipe et appuyer son travail sur des sources fiables.</p>
+                        <details>
+                            <summary>Travail attendu</summary>
+                            <ul>
+                                <li>Rechercher les textes de loi chinois et français pertinents et en résumer le contenu.</li>
+                                <li>Expliquer le rôle des institutions concernées (par exemple la CNIL en France).</li>
+                                <li>Comparer les différents systèmes de protection de la vie privée et leurs conséquences.</li>
+                                <li>Rédiger une synthèse claire et accessible pour le support final (affiche, site, etc.).</li>
+                            </ul>
+                        </details>
+                        <details>
+                            <summary>Critères d'évaluation (/20)</summary>
+                            <ol>
+                                <li><strong>Identification des lois chinoises pertinentes</strong>
+                                    <ul>
+                                        <li>Présence d’une ou plusieurs références légales concrètes (ex.&nbsp;: Cybersecurity Law, Personal Information Protection Law, etc.).</li>
+                                        <li>Explication claire du contenu et du rôle de ces lois.</li>
+                                        <li>Mise en relation explicite avec la notion de vie privée et de surveillance.</li>
+                                        <li>Utilisation d’un vocabulaire juridique adapté.</li>
+                                    </ul>
+                                </li>
+                                <li><strong>Analyse du cadre légal français et européen</strong>
+                                    <ul>
+                                        <li>Présence du RGPD et de la loi Informatique et Libertés, correctement identifiés et contextualisés.</li>
+                                        <li>Mention et explication du rôle d’institutions clés (CNIL, Conseil d’État…).</li>
+                                        <li>Mise en relation avec la problématique du contrôle des données personnelles.</li>
+                                        <li>Pertinence des notions juridiques mobilisées (consentement, finalité, droits des usagers…).</li>
+                                    </ul>
+                                </li>
+                                <li><strong>Comparaison claire entre les systèmes juridiques chinois et français</strong>
+                                    <ul>
+                                        <li>Présence d’éléments comparatifs organisés (similitudes, différences).</li>
+                                        <li>Mise en évidence de points de divergence sur la protection de la vie privée.</li>
+                                        <li>Présentation structurée d’une réflexion critique ou argumentative.</li>
+                                        <li>Clarté dans la formulation, avec des exemples ou cas concrets si possible.</li>
+                                    </ul>
+                                </li>
+                                <li><strong>Capacité à vulgariser les notions juridiques complexes</strong>
+                                    <ul>
+                                        <li>Reformulation compréhensible des notions juridiques essentielles.</li>
+                                        <li>Explications pédagogiques accompagnées d’exemples ou de métaphores accessibles.</li>
+                                        <li>Absence de copier-coller ou de jargon excessif.</li>
+                                        <li>Texte fluide, structuré, et adapté à un public de non-spécialistes.</li>
+                                    </ul>
+                                </li>
+                                <li><strong>Utilisation de sources fiables et regard critique</strong>
+                                    <ul>
+                                        <li>Présence de sources variées et pertinentes (textes officiels, publications d’experts, institutions reconnues…).</li>
+                                        <li>Présentation contextualisée des sources (auteur, date, nature du support…).</li>
+                                        <li>Analyse de la fiabilité des sources (autorité, objectivité, mise à jour).</li>
+                                        <li>Regard critique sur les limites ou les biais potentiels des documents utilisés.</li>
+                                    </ul>
+                                </li>
+                            </ol>
+                        </details>
+                    </section>
+                </div>
+            </article>
 
-<!-- Section détaillée pour l'expert juridique -->
-<section class="expert-juridique">
-    <h2>Détail du rôle d'expert juridique</h2>
-    <p>L'expert juridique est chargé d'analyser en profondeur les lois et institutions encadrant la protection des données en Chine et en France. Il doit vulgariser ces notions pour l'ensemble de l'équipe et appuyer son travail sur des sources fiables.</p>
-    <details>
-        <summary>Travail attendu</summary>
-        <ul>
-            <li>Rechercher les textes de loi chinois et français pertinents et en résumer le contenu.</li>
-            <li>Expliquer le rôle des institutions concernées (par exemple la CNIL en France).</li>
-            <li>Comparer les différents systèmes de protection de la vie privée et leurs conséquences.</li>
-            <li>Rédiger une synthèse claire et accessible pour le support final (affiche, site, etc.).</li>
-        </ul>
-    </details>
-    <details>
-        <summary>Critères d'évaluation (/20)</summary>
-        <ol>
-            <li><strong>Identification des lois chinoises pertinentes</strong>
-                <ul>
-                    <li>Présence d’une ou plusieurs références légales concrètes (ex.&nbsp;: Cybersecurity Law, Personal Information Protection Law, etc.).</li>
-                    <li>Explication claire du contenu et du rôle de ces lois.</li>
-                    <li>Mise en relation explicite avec la notion de vie privée et de surveillance.</li>
-                    <li>Utilisation d’un vocabulaire juridique adapté.</li>
-                </ul>
-            </li>
-            <li><strong>Analyse du cadre légal français et européen</strong>
-                <ul>
-                    <li>Présence du RGPD et de la loi Informatique et Libertés, correctement identifiés et contextualisés.</li>
-                    <li>Mention et explication du rôle d’institutions clés (CNIL, Conseil d’État…).</li>
-                    <li>Mise en relation avec la problématique du contrôle des données personnelles.</li>
-                    <li>Pertinence des notions juridiques mobilisées (consentement, finalité, droits des usagers…).</li>
-                </ul>
-            </li>
-            <li><strong>Comparaison claire entre les systèmes juridiques chinois et français</strong>
-                <ul>
-                    <li>Présence d’éléments comparatifs organisés (similitudes, différences).</li>
-                    <li>Mise en évidence de points de divergence sur la protection de la vie privée.</li>
-                    <li>Présentation structurée d’une réflexion critique ou argumentative.</li>
-                    <li>Clarté dans la formulation, avec des exemples ou cas concrets si possible.</li>
-                </ul>
-            </li>
-            <li><strong>Capacité à vulgariser les notions juridiques complexes</strong>
-                <ul>
-                    <li>Reformulation compréhensible des notions juridiques essentielles.</li>
-                    <li>Explications pédagogiques accompagnées d’exemples ou de métaphores accessibles.</li>
-                    <li>Absence de copier-coller ou de jargon excessif.</li>
-                    <li>Texte fluide, structuré, et adapté à un public de non-spécialistes.</li>
-                </ul>
-            </li>
-            <li><strong>Utilisation de sources fiables et regard critique</strong>
-                <ul>
-                    <li>Présence de sources variées et pertinentes (textes officiels, publications d’experts, institutions reconnues…).</li>
-                    <li>Présentation contextualisée des sources (auteur, date, nature du support…).</li>
-                    <li>Analyse de la fiabilité des sources (autorité, objectivité, mise à jour).</li>
-                    <li>Regard critique sur les limites ou les biais potentiels des documents utilisés.</li>
-                </ul>
-            </li>
-        </ol>
-    </details>
-</section>
-
-<h3>Expert technique</h3>
+            <article class="atelier">
+                <div class="atelier-content">
+                    <h3>Expert technique</h3>
                     <ul>
                         <li>Explication structurée du principe général du crédit social et des acteurs impliqués.</li>
                         <li>Description des technologies mobilisées : intelligence artificielle, big data, reconnaissance faciale…</li>
@@ -135,7 +134,11 @@
                         <li>Vulgarisation accessible des notions techniques pour un public non spécialiste.</li>
                         <li>Appui sur des sources spécialisées et analyse critique de leur fiabilité.</li>
                     </ul>
+                </div>
+            </article>
 
+            <article class="atelier">
+                <div class="atelier-content">
                     <h3>Expert éthique</h3>
                     <ul>
                         <li>Identification des enjeux éthiques majeurs : surveillance, sanctions automatiques, liberté.</li>
@@ -144,7 +147,11 @@
                         <li>Présentation claire des concepts éthiques à l'aide d'exemples parlants.</li>
                         <li>Recours à des sources reconnues et analyse critique de leur fiabilité.</li>
                     </ul>
+                </div>
+            </article>
 
+            <article class="atelier">
+                <div class="atelier-content">
                     <h3>Chef de projet</h3>
                     <ul>
                         <li>Organisation du travail et gestion du temps.</li>
@@ -153,7 +160,11 @@
                         <li>Cohérence globale de la production finale.</li>
                         <li>Bilan du projet et prise de recul.</li>
                     </ul>
+                </div>
+            </article>
 
+            <article class="atelier">
+                <div class="atelier-content">
                     <h3>Expert média</h3>
                     <ul>
                         <li>Qualité visuelle de la production.</li>


### PR DESCRIPTION
## Summary
- refactor SNT project 1A page about credit social
- break down each role into separate sections using the same style as Technology projects
- include detailed section for the legal expert

## Testing
- `tidy -errors SNT_P1A.html`

------
https://chatgpt.com/codex/tasks/task_e_68440419954c83318429d4763eaa8b99