### PR TITLE
Update classroom screen to use public Google Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # ICN_GGSB
 Site pour l'ICN
 
-## Clé API Google Sheets
+## Google Sheets
 
-Certaines pages utilisent l'API Google Sheets pour afficher des données.
-Dans `classroom-screen.js`, remplacez la valeur `TA_CLE_API` par votre clé API
-Google. Cette clé doit être liée à un projet ayant l'API **Google Sheets API**
-activée. Ne committez jamais votre clé privée dans le dépôt public.
+Certaines pages affichent des données issues d'une feuille Google Sheets
+publique. Depuis `classroom-screen.html`, les tâches sont récupérées via l'URL
+publiée de la feuille sans utiliser de clé API.

--- a/classroom-screen.css
+++ b/classroom-screen.css
@@ -51,17 +51,17 @@
     }
 }
 
-#class-select {
+#classe-select {
     margin-bottom: 10px;
     padding: 5px;
     font-size: 1em;
 }
 
-#tasks {
+#taches {
     list-style: none;
     padding-left: 0;
 }
 
-#tasks li {
+#taches li {
     margin-bottom: 5px;
 }

--- a/classroom-screen.html
+++ b/classroom-screen.html
@@ -29,8 +29,10 @@
             <div class="screen-sections">
                 <div class="section">
                     <h2>Tâches du jour</h2>
-                    <select id="class-select"></select>
-                    <ul id="tasks"></ul>
+                    <select id="classe-select">
+                        <option value="">-- Classe --</option>
+                    </select>
+                    <ul id="taches"></ul>
                 </div>
                 <div class="section">
                     <h2>Infos importantes</h2>


### PR DESCRIPTION
## Summary
- fetch task list from public Google Sheet without API key
- show class selector and tasks with new element IDs
- update CSS selectors for new IDs
- document Google Sheets usage in README

## Testing
- `npx eslint classroom-screen.js` *(fails: no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_6846b0ca87f883318195c94a7bfd962f