### PR TITLE
Fix class list retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ Site pour l'ICN
 
 Certaines pages affichent des données issues d'une feuille Google Sheets
 publique. Depuis `classroom-screen.html`, les tâches sont récupérées via l'URL
-publiée de la feuille sans utiliser de clé API.
+publiée de la feuille sans utiliser de clé API. L'URL inclut `tqx=out:json` pour
+obtenir les données au format JSON.

--- a/classroom-screen.js
+++ b/classroom-screen.js
@@ -44,11 +44,13 @@ document.getElementById('reset-btn').addEventListener('click', resetTimer);
 updateTimer();
 
 async function fetchRows() {
-    const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/gviz/tq?gid=0&pub=1';
+    const url =
+        'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/gviz/tq?gid=0&pub=1&tqx=out:json';
     const res = await fetch(url);
     const text = await res.text();
-    const raw = text.match(/setResponse\\(([\s\S]+)\\)/)[1];
-    const obj = JSON.parse(raw);
+    const rawMatch = text.match(/setResponse\(([^)]+)\)/);
+    if (!rawMatch) return [];
+    const obj = JSON.parse(rawMatch[1]);
     return obj.table.rows;
 }
 


### PR DESCRIPTION
## Summary
- ensure classroom-screen fetches JSON from Google Sheets by adding `tqx=out:json`
- document `tqx=out:json` usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846b2367fe4833187d61eaa0a02f8fa