### PR TITLE
Add Suivi Projet page with embedded Google Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
                 <li><a href="techno.html">Technologie</a></li>
                 <li><a href="SNT.html">SNT</a></li>
                 <li><a href="classroom-screen.html">Classe</a></li>
+                <li><a href="suivi_projet.html">Suivi Projet</a></li>
             </ul>
         </nav>
     </header>

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Suivi Projet</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Suivi Projet</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">ICN</a></li>
+                <li><a href="techno.html">Technologie</a></li>
+                <li><a href="SNT.html">SNT</a></li>
+                <li><a href="classroom-screen.html">Classe</a></li>
+                <li><a href="suivi_projet.html" class="active">Suivi Projet</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pubhtml?widget=true&amp;headers=false" style="width:100%; height:80vh; border:0;"></iframe>
+    </main>
+    <footer>
+        <p>© Lycée XXXX - Tous droits réservés.</p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Suivi Projet page showing the published Google Sheet in an iframe
- link the new page from the main index menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846b63452e08331a2be58f75dad6be8