### PR TITLE
Mise à jour du suivi de projet

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -205,3 +205,22 @@ summary::before {
 details[open] summary::before {
     content: " \25BC";
 }
+
+/* Tableau issu de Google Sheets */
+.sheet-table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    margin-top: 20px;
+}
+
+.sheet-table th,
+.sheet-table td {
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    padding: 8px;
+}
+
+.sheet-table th {
+    background-color: rgba(0, 0, 255, 0.4);
+}

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Suivi Projet</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="suivi_projet.js" defer></script>
 </head>
 <body>
     <header>
@@ -20,7 +21,7 @@
         </nav>
     </header>
     <main>
-        <iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pubhtml?widget=true&amp;headers=false" style="width:100%; height:80vh; border:0;"></iframe>
+        <div id="sheet-container">Chargement...</div>
     </main>
     <footer>
         <p>© Lycée XXXX - Tous droits réservés.</p>

--- a/suivi_projet.js
+++ b/suivi_projet.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/gviz/tq?gid=0&pub=1&tqx=out:json';
+  try {
+    const res = await fetch(url);
+    const text = await res.text();
+    const m = text.match(/setResponse\(([^)]+)\)/);
+    if (!m) throw new Error('Bad response');
+    const data = JSON.parse(m[1]);
+    const cols = data.table.cols.map(c => c.label);
+    const rows = data.table.rows;
+
+    const table = document.createElement('table');
+    table.className = 'sheet-table';
+
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    cols.forEach(label => {
+      const th = document.createElement('th');
+      th.textContent = label;
+      headRow.appendChild(th);
+    });
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      cols.forEach((_, i) => {
+        const td = document.createElement('td');
+        td.textContent = r.c[i] ? r.c[i].v : '';
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+
+    const container = document.getElementById('sheet-container');
+    container.innerHTML = '';
+    container.appendChild(table);
+  } catch (e) {
+    const container = document.getElementById('sheet-container');
+    container.textContent = 'Erreur de chargement des données';
+  }
+});


### PR DESCRIPTION
## Notes
- La page `suivi_projet.html` n’intègre plus directement la feuille Google Sheets via un iframe.
- Un script `suivi_projet.js` récupère les données JSON de la feuille et construit dynamiquement un tableau HTML.
- Les nouvelles règles `.sheet-table` dans `styles.css` reprennent la charte graphique du site pour l’affichage.

## Testing
- No test suite provided – simply ensured that `git status` shows a clean working tree after commit.

------
https://chatgpt.com/codex/tasks/task_e_6846bfdf5d3483319d2d2119787d65f4