### PR TITLE
Fix class filter options on project page

### DIFF
--- a/suivi_projet.js
+++ b/suivi_projet.js
@@ -19,10 +19,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const table = document.createElement('table');
   table.className = 'sheet-table';
 
-  // Determine index of the "Classe" column for filtering
-  const classIdx = cols.indexOf('Classe');
+  // Determine index of the "Classe" column for filtering (case insensitive)
+  const classIdx = cols.findIndex(c => c && c.toLowerCase().trim() === 'classe');
   const classes = classIdx !== -1
-    ? Array.from(new Set(rows.map(r => r[classIdx]).filter(Boolean))).sort()
+    ? Array.from(new Set(rows
+        .map(r => (r[classIdx] || '').trim())
+        .filter(Boolean)))
+        .sort()
     : [];
 
   const thead = document.createElement('thead');


### PR DESCRIPTION
## Summary
- handle column name "Classe" in a case-insensitive way when building filter options
- trim values and sort unique class names before adding to the select menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e69b6b7c8331813fa65b22645155