### PR TITLE
Update project tracking dataset with Projet column

### DIFF
--- a/suivi_projet_data.json
+++ b/suivi_projet_data.json
@@ -1,9 +1,9 @@
 {
-  "cols": ["Date", "Classe", "Rôle", "Tâche"],
+  "cols": ["Date", "Classe", "Projet", "Rôle", "Tâche"],
   "rows": [
-    ["09/06/2025", "4ieme 1", "Chef de projet", "Prise en main du sujet"],
-    ["09/06/2025", "4ieme 1", "Concepteur 3D", "xxx"],
-    ["09/06/2025", "4ieme 2", "Concepteur 3D", "xxx 4e2"],
-    ["09/06/2025", "4ieme 2", "Concepteur PC", ""]
+    ["09/06/2025", "4ieme 1", "Projet 1", "Chef de projet", "Prise en main du sujet"],
+    ["09/06/2025", "4ieme 1", "Projet 1", "Concepteur 3D", "xxx"],
+    ["09/06/2025", "4ieme 2", "Projet 2", "Concepteur 3D", "xxx 4e2"],
+    ["09/06/2025", "4ieme 2", "Projet 2", "Concepteur PC", ""]
   ]
 }


### PR DESCRIPTION
## Summary
- expand fallback dataset for project tracking with new **Projet** column

## Testing
- `node - <<'NODE'
const data = require('./suivi_projet_data.json');
console.log(data.cols);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6846ed6ff4ec8331957f7c2591f0e66e