### PR TITLE
Embed sheet directly in suivi_projet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ publique. Depuis `classroom-screen.html`, les tâches sont récupérées via l'U
 publiée de la feuille sans utiliser de clé API. L'URL inclut `tqx=out:json` pour
 obtenir les données au format JSON.
 
-La page `suivi_projet.html` charge elle aussi les données de cette feuille.
-Elle met désormais à jour le tableau automatiquement toutes les minutes afin
-d'afficher les modifications récentes sans avoir à recharger la page.
+La page `suivi_projet.html` n'extrait plus les valeurs de la feuille mais
+l'intègre directement via un `iframe`. Les modifications dans le document sont
+donc visibles instantanément sans script côté client.

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Suivi Projet</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="suivi_projet.js" defer></script>
+    <!-- La feuille Google Sheets est désormais intégrée directement -->
 </head>
 <body>
     <header>
@@ -21,11 +21,11 @@
         </nav>
     </header>
     <main>
-        <label for="class-filter">Filtrer par classe :</label>
-        <select id="class-filter">
-            <option value="">Toutes</option>
-        </select>
-        <div id="sheet-container">Chargement...</div>
+        <iframe
+            src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pubhtml?gid=0&amp;single=true"
+            style="width:100%;height:600px;border:0;"
+            allowfullscreen
+            loading="lazy"></iframe>
     </main>
     <footer>
         <p>© Lycée XXXX - Tous droits réservés.</p>


### PR DESCRIPTION
## Summary
- embed the Google Sheet directly in `suivi_projet.html`
- update README to describe the new behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847f3d130a88331a1917e31b7e2dcd5