### PR TITLE
Adapt project tracker to CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ publique. Depuis `classroom-screen.html`, les tâches sont récupérées via l'U
 publiée de la feuille sans utiliser de clé API. L'URL inclut `tqx=out:json` pour
 obtenir les données au format JSON.
 
-La page `suivi_projet.html` n'extrait plus les valeurs de la feuille mais
-l'intègre directement via un `iframe`. Les modifications dans le document sont
-donc visibles instantanément sans script côté client.
+La page `suivi_projet.html` charge elle aussi les données de cette feuille.
+Comme le partage se fait au format CSV, `suivi_projet.js` télécharge ce
+fichier, reconstruit le tableau et applique un filtrage par classe. Les données
+se rafraîchissent automatiquement toutes les minutes.

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Suivi Projet</title>
     <link rel="stylesheet" href="styles.css">
-    <!-- La feuille Google Sheets est désormais intégrée directement -->
+    <script src="suivi_projet.js" defer></script>
 </head>
 <body>
     <header>
@@ -21,11 +21,11 @@
         </nav>
     </header>
     <main>
-        <iframe
-            src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pubhtml?gid=0&amp;single=true"
-            style="width:100%;height:600px;border:0;"
-            allowfullscreen
-            loading="lazy"></iframe>
+        <label for="class-filter">Filtrer par classe :</label>
+        <select id="class-filter">
+            <option value="">Toutes</option>
+        </select>
+        <div id="sheet-container">Chargement...</div>
     </main>
     <footer>
         <p>© Lycée XXXX - Tous droits réservés.</p>


### PR DESCRIPTION
## Summary
- fetch project tracking data in CSV format
- restore dynamic table layout for project tracker
- document how the project tracker refreshes from CSV

## Testing
- `node --check suivi_projet.js`
- `node --check classroom-screen.js`


------
https://chatgpt.com/codex/tasks/task_e_6847f607f18c8331aaec08abc7dae836