### PR TITLE
Highlight evaluation rows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -225,6 +225,10 @@ details[open] summary::before {
     background-color: rgba(0, 0, 255, 0.4);
 }
 
+.evaluation-row {
+    background-color: rgba(255, 0, 0, 0.5);
+}
+
 /* Filtre des classes dans suivi_projet.html */
 #class-filter {
     margin-top: 10px;

--- a/suivi_projet.js
+++ b/suivi_projet.js
@@ -68,6 +68,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const table = document.createElement('table');
     table.className = 'sheet-table';
 
+    const evalIdxs = cols
+      .map((c, i) => (c && c.toLowerCase().includes('evalu') ? i : -1))
+      .filter(i => i !== -1);
+
     classIdx = cols.findIndex(c => c && c.toLowerCase().trim() === 'classe');
     const classes = classIdx !== -1
       ? Array.from(new Set(rows.map(r => (r[classIdx] || '').trim()).filter(Boolean))).sort()
@@ -91,6 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
         td.textContent = cell;
         tr.appendChild(td);
       });
+      const hasEval = evalIdxs.some(i => row[i] && row[i].trim());
+      if (hasEval) tr.classList.add('evaluation-row');
       tbody.appendChild(tr);
     });
     table.appendChild(tbody);


### PR DESCRIPTION
## Summary
- detect evaluation columns in `suivi_projet.js`
- mark rows containing an evaluation with the `evaluation-row` class
- add corresponding style so those lines appear with a red background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68480efce8688331906135dc8988451a