### PR TITLE
Fix role filter fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,8 @@ obtenir les données au format JSON.
 
 La page `suivi_projet.html` charge elle aussi les données de cette feuille.
 Comme le partage se fait au format CSV, `suivi_projet.js` télécharge ce
-fichier, reconstruit le tableau et applique un filtrage par classe. Les données
-se rafraîchissent automatiquement toutes les minutes.
+fichier, reconstruit le tableau et applique un filtrage par classe et par rôle.
+Si le téléchargement échoue ou renvoie un contenu inattendu (par exemple si la
+feuille n'est plus publique), le script utilise automatiquement le fichier local
+`suivi_projet_data.json` comme secours. Les données se rafraîchissent
+automatiquement toutes les minutes.


### PR DESCRIPTION
## Summary
- ensure "suivi_projet.js" falls back to local data when the remote CSV is invalid
- document this fallback behaviour in README

## Testing
- `node --check suivi_projet.js`

------
https://chatgpt.com/codex/tasks/task_e_684828686924833184ac8e8905e87269