### PR TITLE
Add project status column

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,6 @@ fichier, reconstruit le tableau et applique un filtrage par classe et par rôle.
 Si le téléchargement échoue ou renvoie un contenu inattendu (par exemple si la
 feuille n'est plus publique), le script utilise automatiquement le fichier local
 `suivi_projet_data.json` comme secours. Les données se rafraîchissent
-automatiquement toutes les minutes.
+automatiquement toutes les minutes. Le tableau comporte désormais une colonne
+supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
+"Terminée", "En cours" ou "A venir".

--- a/suivi_projet.js
+++ b/suivi_projet.js
@@ -122,11 +122,15 @@ document.addEventListener('DOMContentLoaded', () => {
       th.textContent = label;
       headRow.appendChild(th);
     });
+    const statusTh = document.createElement('th');
+    statusTh.textContent = 'Statut';
+    headRow.appendChild(statusTh);
     thead.appendChild(headRow);
     table.appendChild(thead);
 
     tbody = document.createElement('tbody');
     rowElements = [];
+    const statusCells = [];
     rows.forEach(row => {
       const tr = document.createElement('tr');
       row.forEach(cell => {
@@ -134,6 +138,10 @@ document.addEventListener('DOMContentLoaded', () => {
         td.textContent = cell;
         tr.appendChild(td);
       });
+      const statusTd = document.createElement('td');
+      statusTd.textContent = 'A venir';
+      tr.appendChild(statusTd);
+      statusCells.push(statusTd);
 
       const taskValue = tacheIdx !== -1 ? row[tacheIdx] || '' : '';
       const normalizedTask = normalize(taskValue);
@@ -170,8 +178,10 @@ document.addEventListener('DOMContentLoaded', () => {
           const nextDate = next ? next.date : new Date(8640000000000000);
           if (cur.date && nextDate && cur.date < today && nextDate < today) {
             rowElements[cur.index].classList.add('completed-row');
+            statusCells[cur.index].textContent = 'Terminée';
           } else if (cur.date && nextDate && cur.date <= today && nextDate > today) {
             rowElements[cur.index].classList.add('current-row');
+            statusCells[cur.index].textContent = 'En cours';
           }
         }
       }


### PR DESCRIPTION
## Summary
- update README to document the new status column in the project tracker
- display a new **Statut** column in `suivi_projet.js` with values `Terminée`, `En cours` or `A venir`

## Testing
- `node --check suivi_projet.js`


------
https://chatgpt.com/codex/tasks/task_e_6848317964a48331b869260a60655cd2