### PR TITLE
Fix auto refresh behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Comme le partage se fait au format CSV, `suivi_projet.js` télécharge ce
 fichier, reconstruit le tableau et applique un filtrage par classe et par rôle.
 Si le téléchargement échoue ou renvoie un contenu inattendu (par exemple si la
 feuille n'est plus publique), le script utilise automatiquement le fichier local
-`suivi_projet_data.json` comme secours. Les données se rafraîchissent
-automatiquement toutes les minutes. Le tableau comporte désormais une colonne
+`suivi_projet_data.json` comme secours. Les données sont chargées au
+démarrage de la page uniquement. Le tableau comporte désormais une colonne
 supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 "Terminée", "En cours" ou "A venir".

--- a/suivi_projet.js
+++ b/suivi_projet.js
@@ -243,5 +243,4 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
   loadData();
-  setInterval(loadData, 60000);
 });


### PR DESCRIPTION
## Summary
- stop automatic refresh on `suivi_projet.html`
- document that refresh only happens at load time

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849284200888331b54029e88a33bd8a