### PR TITLE
Improve project tracking page styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -217,7 +217,7 @@ details[open] summary::before {
 
 .sheet-table th,
 .sheet-table td {
-    border: 1px solid rgba(255, 255, 255, 0.5);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     padding: 8px;
 }
 

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Suivi Projet</title>
     <link rel="stylesheet" href="styles.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Poppins', Arial, sans-serif; }
+    </style>
     <script src="suivi_projet.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add Poppins Google Font to project tracking page
- use Poppins font on that page only
- use subtle 1px rgba(255,255,255,0.1) borders in the Google Sheet table

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684942f77a108331ac7f4a9860242b2c