### PR TITLE
Ajout d'une page QCM interactive

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
                 <li><a href="SNT.html">SNT</a></li>
                 <li><a href="classroom-screen.html">Classe</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
+                <li><a href="sentrainer.html">S'entrainer</a></li>
             </ul>
         </nav>
     </header>

--- a/sentrainer.html
+++ b/sentrainer.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>S'entrainer</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>S'entrainer</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">ICN</a></li>
+                <li><a href="techno.html">Technologie</a></li>
+                <li><a href="SNT.html">SNT</a></li>
+                <li><a href="classroom-screen.html">Classe</a></li>
+                <li><a href="suivi_projet.html">Suivi Projet</a></li>
+                <li><a href="sentrainer.html">S'entrainer</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section id="quiz-container">
+            <p>Chargement du QCM...</p>
+        </section>
+    </main>
+    <script src="sentrainer.js"></script>
+</body>
+</html>

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -1,0 +1,49 @@
+async function fetchQCM() {
+    const url = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/gviz/tq?gid=1246434759&pub=1&tqx=out:json';
+    const res = await fetch(url);
+    const text = await res.text();
+    const match = text.match(/setResponse\((.*)\)/);
+    if (!match) return [];
+    const obj = JSON.parse(match[1]);
+    return obj.table.rows.map(r => ({
+        question: r.c[0]?.v || '',
+        choices: [r.c[1]?.v || '', r.c[2]?.v || '', r.c[3]?.v || ''],
+        answer: r.c[4]?.v
+    }));
+}
+
+let questions = [];
+let current = 0;
+let score = 0;
+
+function showQuestion() {
+    const container = document.getElementById('quiz-container');
+    if (current >= questions.length) {
+        container.innerHTML = `<p>Score : ${score} / ${questions.length}</p>`;
+        return;
+    }
+    const q = questions[current];
+    const options = q.choices
+        .map((choice, idx) => `<label><input type="radio" name="opt" value="${idx}"> ${choice}</label><br>`)
+        .join('');
+    container.innerHTML = `
+        <p>${q.question}</p>
+        ${options}
+        <button id="next-btn">Valider</button>
+    `;
+    document.getElementById('next-btn').addEventListener('click', () => {
+        const checked = document.querySelector('input[name="opt"]:checked');
+        if (checked) {
+            if (String(checked.value) === String(q.answer)) {
+                score++;
+            }
+            current++;
+            showQuestion();
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+    questions = await fetchQCM();
+    showQuestion();
+});


### PR DESCRIPTION
## Notes
- Mise à jour du menu principal pour ajouter la page **S'entrainer**.
- Nouvelle page `sentrainer.html` qui charge un QCM depuis Google Sheets et affiche les questions de façon interactive.
- Script `sentrainer.js` permettant de récupérer les données via l'API Google et de gérer le quiz.


------
https://chatgpt.com/codex/tasks/task_e_684fd72a4c348331ae33f3405706371d