### PR TITLE
Add random QCM from Google Sheet

### DIFF
--- a/sentrainer_data.json
+++ b/sentrainer_data.json
@@ -1,0 +1,17 @@
+[
+  {
+    "question": "Quelle est la capitale de la France ?",
+    "choices": ["Paris", "Lyon", "Marseille"],
+    "answer": "Paris"
+  },
+  {
+    "question": "Combien font 2 + 2 ?",
+    "choices": ["3", "4", "5"],
+    "answer": "4"
+  },
+  {
+    "question": "Quel est le langage utilisé pour structurer les pages web ?",
+    "choices": ["HTML", "Python", "CSS"],
+    "answer": "HTML"
+  }
+]

--- a/styles.css
+++ b/styles.css
@@ -312,3 +312,7 @@ details[open] summary::before {
     min-height: 1.5em;
 }
 
+
+.quiz-btn { margin: 5px; padding: 5px 10px; border: 1px solid #fff; border-radius: 5px; background:#1e90ff; color:#fff; }
+.quiz-btn:hover { background:#0000ff; }
+


### PR DESCRIPTION
## Summary
- load quiz questions from the published Google Sheet CSV, with a fallback file
- shuffle answers and display a single random question as buttons
- style quiz buttons
- include fallback quiz data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fdc053fe48331ac7a161431c23cb8