### PR TITLE
Ajout filtres QCM

### DIFF
--- a/sentrainer_data.json
+++ b/sentrainer_data.json
@@ -1,15 +1,18 @@
 [
   {
+    "theme": "Géographie",
     "question": "Quelle est la capitale de la France ?",
     "choices": ["Paris", "Lyon", "Marseille"],
     "answer": "Paris"
   },
   {
+    "theme": "Maths",
     "question": "Combien font 2 + 2 ?",
     "choices": ["3", "4", "5"],
     "answer": "4"
   },
   {
+    "theme": "Web",
     "question": "Quel est le langage utilisé pour structurer les pages web ?",
     "choices": ["HTML", "Python", "CSS"],
     "answer": "HTML"


### PR DESCRIPTION
## Summary
- ajoute la colonne `theme` dans la base locale du QCM
- affiche le choix du ou des thèmes avant de commencer
- ajoute un bouton `Commencer le test`
- à la fin du résultat, proposer `Nouveau test`

## Testing
- `node -c sentrainer.js`


------
https://chatgpt.com/codex/tasks/task_e_684ff1512b808331b7c3db33899f4262