### PR TITLE
Add level filter for QCM page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ démarrage de la page uniquement. Le tableau comporte désormais une colonne
 supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 "Terminée", "En cours" ou "A venir". Les filtres par classe et par rôle sont
 désormais présentés sous forme de cases à cocher, comme celui du statut.
+
+La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont sélectionnables séparément grâce à deux listes de cases à cocher.

--- a/sentrainer_data.json
+++ b/sentrainer_data.json
@@ -1,17 +1,20 @@
 [
   {
+    "niveau": "Facile",
     "theme": "Géographie",
     "question": "Quelle est la capitale de la France ?",
     "choices": ["Paris", "Lyon", "Marseille"],
     "answer": "Paris"
   },
   {
+    "niveau": "Facile",
     "theme": "Maths",
     "question": "Combien font 2 + 2 ?",
     "choices": ["3", "4", "5"],
     "answer": "4"
   },
   {
+    "niveau": "Facile",
     "theme": "Web",
     "question": "Quel est le langage utilisé pour structurer les pages web ?",
     "choices": ["HTML", "Python", "CSS"],


### PR DESCRIPTION
## Summary
- include a `niveau` field in the fallback data file
- parse the level column when reading the CSV and from local data
- allow filtering by theme and level before starting the quiz
- document the new behaviour in README

## Testing
- `node -e "require('./sentrainer.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ff370ec888331b73136db52171d71