### PR TITLE
Improve QCM display

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -85,9 +85,19 @@ function showRandomQuestion() {
     current = questions.splice(index, 1)[0];
     count++;
     container.innerHTML = '';
+    const block = document.createElement('div');
+    block.className = 'question-block';
+
+    const tab = document.createElement('span');
+    tab.className = 'question-tab';
+    tab.textContent = `Q${count}`;
+    block.appendChild(tab);
+
     const p = document.createElement('p');
-    p.textContent = `Question ${count} : ${current.question}`;
-    container.appendChild(p);
+    p.textContent = current.question;
+    block.appendChild(p);
+
+    container.appendChild(block);
     const answers = shuffle([...current.choices]);
     answers.forEach(choice => {
         const btn = document.createElement('button');

--- a/styles.css
+++ b/styles.css
@@ -316,3 +316,23 @@ details[open] summary::before {
 .quiz-btn { margin: 5px; padding: 5px 10px; border: 1px solid #fff; border-radius: 5px; background:#1e90ff; color:#fff; }
 .quiz-btn:hover { background:#0000ff; }
 
+.question-block {
+    position: relative;
+    margin-bottom: 10px;
+    padding: 20px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 8px;
+}
+
+.question-tab {
+    position: absolute;
+    top: -10px;
+    left: 10px;
+    background-color: #1e90ff;
+    color: #fff;
+    padding: 2px 8px;
+    border-radius: 5px 5px 0 0;
+    font-weight: bold;
+}
+


### PR DESCRIPTION
## Summary
- show the question inside a styled block with a tab showing the current number
- style the new block and tab in the global stylesheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ff960f1bc833185c949bb046ef4f3