### PR TITLE
Improve QCM filter UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 "Terminée", "En cours" ou "A venir". Les filtres par classe et par rôle sont
 désormais présentés sous forme de cases à cocher, comme celui du statut.
 
-La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont sélectionnables séparément grâce à deux listes de cases à cocher.
+La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -120,6 +120,26 @@ document.addEventListener('DOMContentLoaded', async () => {
     showFilterSelection();
 });
 
+function createFilterBox(title, values) {
+    const box = document.createElement('div');
+    box.className = 'filter-box';
+    const tab = document.createElement('span');
+    tab.className = 'filter-tab';
+    tab.textContent = title;
+    box.appendChild(tab);
+    values.forEach(val => {
+        const label = document.createElement('label');
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = val;
+        cb.checked = true;
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(' ' + val + ' '));
+        box.appendChild(label);
+    });
+    return box;
+}
+
 function showFilterSelection() {
     const container = document.getElementById('quiz-container');
     container.innerHTML = '';
@@ -127,29 +147,8 @@ function showFilterSelection() {
     const themes = [...new Set(allQuestions.map(q => q.theme || 'Autre'))];
     const niveaux = [...new Set(allQuestions.map(q => q.niveau || 'Indefini'))];
 
-    const themeBox = document.createElement('div');
-    themes.forEach(t => {
-        const label = document.createElement('label');
-        const cb = document.createElement('input');
-        cb.type = 'checkbox';
-        cb.value = t;
-        cb.checked = true;
-        label.appendChild(cb);
-        label.appendChild(document.createTextNode(' ' + t + ' '));
-        themeBox.appendChild(label);
-    });
-
-    const levelBox = document.createElement('div');
-    niveaux.forEach(n => {
-        const label = document.createElement('label');
-        const cb = document.createElement('input');
-        cb.type = 'checkbox';
-        cb.value = n;
-        cb.checked = true;
-        label.appendChild(cb);
-        label.appendChild(document.createTextNode(' ' + n + ' '));
-        levelBox.appendChild(label);
-    });
+    const themeBox = createFilterBox('Thème', themes);
+    const levelBox = createFilterBox('Niveau', niveaux);
 
     const start = document.createElement('button');
     start.textContent = 'Commencer le test';

--- a/styles.css
+++ b/styles.css
@@ -336,3 +336,24 @@ details[open] summary::before {
     font-weight: bold;
 }
 
+/* Boîtes de sélection pour les filtres du QCM */
+.filter-box {
+    position: relative;
+    margin-bottom: 10px;
+    padding: 20px;
+    background: linear-gradient(to bottom, rgba(30, 144, 255, 0.3), rgba(0, 0, 0, 0.6));
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 8px;
+}
+
+.filter-tab {
+    position: absolute;
+    top: -10px;
+    left: 10px;
+    background: linear-gradient(to bottom, rgba(30, 144, 255, 0.6), rgba(0, 0, 0, 0.8));
+    color: #fff;
+    padding: 2px 8px;
+    border-radius: 5px 5px 0 0;
+    font-weight: bold;
+}
+


### PR DESCRIPTION
## Summary
- wrap QCM level and theme filters in boxes with labelled tabs
- add styles for the new filter boxes
- document the new interface in README

## Testing
- `node -c sentrainer.js`

------
https://chatgpt.com/codex/tasks/task_e_685013b3088c833184ed2b5e2c52c0cb