### PR TITLE
Add question count slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 "Terminée", "En cours" ou "A venir". Les filtres par classe et par rôle sont
 désormais présentés sous forme de cases à cocher, comme celui du statut.
 
-La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz.
+La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz. Un curseur permet en outre de choisir le nombre de questions (de 5 à 20) avant de commencer.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -66,12 +66,12 @@ let allQuestions = [];
 let current = null;
 let score = 0;
 let count = 0;
-const MAX_QUESTIONS = 5;
+let maxQuestions = 5;
 const HIGHLIGHT_DELAY = 1000; // temps avant la question suivante
 
 function showRandomQuestion() {
     const container = document.getElementById('quiz-container');
-    if (count >= MAX_QUESTIONS || !questions.length) {
+    if (count >= maxQuestions || !questions.length) {
         const percent = count ? Math.round((score / count) * 100) : 0;
         container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
         const restart = document.createElement('button');
@@ -150,6 +150,26 @@ function showFilterSelection() {
     const themeBox = createFilterBox('Thème', themes);
     const levelBox = createFilterBox('Niveau', niveaux);
 
+    const questionBox = document.createElement('div');
+    questionBox.className = 'filter-box';
+    const questionTab = document.createElement('span');
+    questionTab.className = 'filter-tab';
+    questionTab.textContent = 'Questions';
+    questionBox.appendChild(questionTab);
+    const qLabel = document.createElement('label');
+    qLabel.textContent = `Nombre de questions : ${maxQuestions}`;
+    const qRange = document.createElement('input');
+    qRange.type = 'range';
+    qRange.min = '5';
+    qRange.max = '20';
+    qRange.value = maxQuestions;
+    qRange.addEventListener('input', () => {
+        maxQuestions = parseInt(qRange.value, 10);
+        qLabel.textContent = `Nombre de questions : ${maxQuestions}`;
+    });
+    questionBox.appendChild(qLabel);
+    questionBox.appendChild(qRange);
+
     const start = document.createElement('button');
     start.textContent = 'Commencer le test';
     start.className = 'quiz-btn';
@@ -163,7 +183,7 @@ function showFilterSelection() {
         questions = shuffle(allQuestions.filter(q =>
             selectedThemes.includes(q.theme || 'Autre') &&
             selectedLevels.includes(q.niveau || 'Indefini')
-        ));
+        )).slice(0, maxQuestions);
         score = 0;
         count = 0;
         showRandomQuestion();
@@ -171,5 +191,6 @@ function showFilterSelection() {
 
     container.appendChild(themeBox);
     container.appendChild(levelBox);
+    container.appendChild(questionBox);
     container.appendChild(start);
 }


### PR DESCRIPTION
## Summary
- let users choose the number of questions for the quiz
- document the new slider in README

## Testing
- `node --check sentrainer.js`
- `tidy -q sentrainer.html`

------
https://chatgpt.com/codex/tasks/task_e_68501704dee483318bf3c31bcfcea2eb