### PR TITLE
Improve QCM history display

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -80,7 +80,7 @@ function showRandomQuestion() {
         const historyDiv = document.createElement('div');
         history.forEach((h, i) => {
             const block = document.createElement('div');
-            block.className = 'question-block';
+            block.className = 'question-block ' + (h.isCorrect ? 'correct' : 'incorrect');
             const tab = document.createElement('span');
             tab.className = 'question-tab';
             tab.textContent = `Q${i + 1}`;
@@ -91,9 +91,11 @@ function showRandomQuestion() {
             const sel = document.createElement('p');
             sel.innerHTML = `<strong>Votre réponse :</strong> ${h.selected}`;
             block.appendChild(sel);
-            const ans = document.createElement('p');
-            ans.innerHTML = `<strong>Bonne réponse :</strong> ${h.correct}`;
-            block.appendChild(ans);
+            if (!h.isCorrect) {
+                const ans = document.createElement('p');
+                ans.innerHTML = `<strong>Bonne réponse :</strong> ${h.correct}`;
+                block.appendChild(ans);
+            }
             if (h.correction) {
                 const cor = document.createElement('p');
                 cor.innerHTML = `<strong>Correction :</strong> ${h.correction}`;
@@ -137,7 +139,8 @@ function showRandomQuestion() {
                 question: current.question,
                 selected: choice,
                 correct: current.answer,
-                correction: current.correction || ''
+                correction: current.correction || '',
+                isCorrect: correct
             });
             btn.style.backgroundColor = correct ? '#00a000' : '#ff0000';
             Array.from(block.querySelectorAll('button')).forEach(b => b.disabled = true);

--- a/styles.css
+++ b/styles.css
@@ -325,6 +325,14 @@ details[open] summary::before {
     border-radius: 8px;
 }
 
+.question-block.correct {
+    background: linear-gradient(to bottom, rgba(0, 160, 0, 0.3), rgba(0, 0, 0, 0.6));
+}
+
+.question-block.incorrect {
+    background: linear-gradient(to bottom, rgba(255, 0, 0, 0.3), rgba(0, 0, 0, 0.6));
+}
+
 .question-tab {
     position: absolute;
     top: -10px;
@@ -334,6 +342,14 @@ details[open] summary::before {
     padding: 2px 8px;
     border-radius: 5px 5px 0 0;
     font-weight: bold;
+}
+
+.question-block.correct .question-tab {
+    background: linear-gradient(to bottom, rgba(0, 160, 0, 0.6), rgba(0, 0, 0, 0.8));
+}
+
+.question-block.incorrect .question-tab {
+    background: linear-gradient(to bottom, rgba(255, 0, 0, 0.6), rgba(0, 0, 0, 0.8));
 }
 
 /* Boîtes de sélection pour les filtres du QCM */


### PR DESCRIPTION
## Summary
- highlight history answers in green or red
- hide the correct answer when user's choice is correct

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68511ab252788331bfe83a294009848e