### PR TITLE
Add image column support in QCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 désormais présentés sous forme de cases à cocher, comme celui du statut.
 
 La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz. Un curseur permet en outre de choisir le nombre de questions (de 5 à 20) avant de commencer.
+Les questions peuvent désormais comporter une colonne **Image** indiquant le nom d'un fichier PNG à afficher entre l'énoncé et les propositions.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -15,7 +15,8 @@ async function fetchQCM() {
             question: r[2] || '',
             choices: [r[3] || '', r[4] || '', r[5] || ''],
             answer: r[3] || '',
-            correction: r[6] || ''
+            correction: r[6] || '',
+            image: r[7] || ''
         })).filter(q => q.question);
     } catch (e) {
         const localRes = await fetch('sentrainer_data.json');
@@ -26,7 +27,8 @@ async function fetchQCM() {
             question: q.question,
             choices: q.choices,
             answer: q.answer,
-            correction: q.correction || ''
+            correction: q.correction || '',
+            image: q.image || ''
         }));
     }
 }
@@ -126,6 +128,16 @@ function showRandomQuestion() {
     const p = document.createElement('p');
     p.textContent = current.question;
     block.appendChild(p);
+
+    if (current.image) {
+        const img = document.createElement('img');
+        let src = current.image;
+        if (!src.includes('/')) src = 'photos/' + src;
+        img.src = src;
+        img.alt = '';
+        img.className = 'question-image';
+        block.appendChild(img);
+    }
 
     const answers = shuffle([...current.choices]);
     answers.forEach(choice => {

--- a/sentrainer_data.json
+++ b/sentrainer_data.json
@@ -5,7 +5,8 @@
     "question": "Quelle est la capitale de la France ?",
     "choices": ["Paris", "Lyon", "Marseille"],
     "answer": "Paris",
-    "correction": "Paris est la capitale de la France."
+    "correction": "Paris est la capitale de la France.",
+    "image": ""
   },
   {
     "niveau": "Facile",
@@ -13,7 +14,8 @@
     "question": "Combien font 2 + 2 ?",
     "choices": ["3", "4", "5"],
     "answer": "4",
-    "correction": "2 + 2 = 4"
+    "correction": "2 + 2 = 4",
+    "image": ""
   },
   {
     "niveau": "Facile",
@@ -21,6 +23,7 @@
     "question": "Quel est le langage utilisé pour structurer les pages web ?",
     "choices": ["HTML", "Python", "CSS"],
     "answer": "HTML",
-    "correction": "On emploie le langage HTML pour structurer une page."
+    "correction": "On emploie le langage HTML pour structurer une page.",
+    "image": ""
   }
 ]

--- a/styles.css
+++ b/styles.css
@@ -352,6 +352,13 @@ details[open] summary::before {
     background: linear-gradient(to bottom, rgba(255, 0, 0, 0.6), rgba(0, 0, 0, 0.8));
 }
 
+.question-image {
+    display: block;
+    margin: 10px auto;
+    max-width: 100%;
+    height: auto;
+}
+
 /* Boîtes de sélection pour les filtres du QCM */
 .filter-box {
     position: relative;


### PR DESCRIPTION
## Summary
- handle new **Image** column in `sentrainer.js`
- center question images with new `.question-image` class
- keep local dataset compatible with empty `image` fields
- document the Image column in README

## Testing
- `node --check sentrainer.js`

------
https://chatgpt.com/codex/tasks/task_e_685123b3a5d4833197c94a2b9780caca