### PR TITLE
Adjust QCM CSV field order

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ désormais présentés sous forme de cases à cocher, comme celui du statut.
 
 La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz. Un curseur permet en outre de choisir le nombre de questions (de 5 à 20) avant de commencer.
 Les questions peuvent désormais comporter une colonne **Image** indiquant le nom d'un fichier PNG à afficher entre l'énoncé et les propositions.
+Le fichier CSV utilisé pour le QCM suit l'ordre suivant : **Thème**, **Niveau**, **Question**, **Image**, **Réponse correcte**, **Réponse fausse A**, **Réponse fausse B**, **Correction**.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -10,13 +10,13 @@ async function fetchQCM() {
         if (!rows.length) throw new Error('no data');
         rows.shift(); // enleve l'en-tete
         return rows.map(r => ({
-            niveau: r[0] || 'Indefini',
-            theme: r[1] || 'Autre',
+            theme: r[0] || 'Autre',
+            niveau: r[1] || 'Indefini',
             question: r[2] || '',
-            choices: [r[3] || '', r[4] || '', r[5] || ''],
-            answer: r[3] || '',
-            correction: r[6] || '',
-            image: r[7] || ''
+            image: r[3] || '',
+            choices: [r[4] || '', r[5] || '', r[6] || ''],
+            answer: r[4] || '',
+            correction: r[7] || ''
         })).filter(q => q.question);
     } catch (e) {
         const localRes = await fetch('sentrainer_data.json');


### PR DESCRIPTION
## Summary
- update `sentrainer.js` to parse questions using new CSV column order
- document the expected order in `README.md`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6851274de7348331aea983feb7c40cce