### PR TITLE
Display QCM images inside white boxes

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -90,6 +90,18 @@ function showRandomQuestion() {
             const q = document.createElement('p');
             q.textContent = h.question;
             block.appendChild(q);
+            if (h.image) {
+                const imgBox = document.createElement('div');
+                imgBox.className = 'image-box';
+                const img = document.createElement('img');
+                let src = h.image;
+                if (!src.includes('/')) src = 'photos/' + src;
+                img.src = src;
+                img.alt = '';
+                img.className = 'question-image';
+                imgBox.appendChild(img);
+                block.appendChild(imgBox);
+            }
             const sel = document.createElement('p');
             sel.innerHTML = `<strong>Votre réponse :</strong> ${h.selected}`;
             block.appendChild(sel);
@@ -130,13 +142,16 @@ function showRandomQuestion() {
     block.appendChild(p);
 
     if (current.image) {
+        const imgBox = document.createElement('div');
+        imgBox.className = 'image-box';
         const img = document.createElement('img');
         let src = current.image;
         if (!src.includes('/')) src = 'photos/' + src;
         img.src = src;
         img.alt = '';
         img.className = 'question-image';
-        block.appendChild(img);
+        imgBox.appendChild(img);
+        block.appendChild(imgBox);
     }
 
     const answers = shuffle([...current.choices]);
@@ -152,6 +167,7 @@ function showRandomQuestion() {
                 selected: choice,
                 correct: current.answer,
                 correction: current.correction || '',
+                image: current.image || '',
                 isCorrect: correct
             });
             btn.style.backgroundColor = correct ? '#00a000' : '#ff0000';

--- a/styles.css
+++ b/styles.css
@@ -359,6 +359,15 @@ details[open] summary::before {
     height: auto;
 }
 
+.image-box {
+    background-color: #fff;
+    padding: 10px;
+    border-radius: 8px;
+    margin: 10px auto;
+    max-width: 90%;
+    box-shadow: 0 0 5px rgba(0,0,0,0.3);
+}
+
 /* Boîtes de sélection pour les filtres du QCM */
 .filter-box {
     position: relative;


### PR DESCRIPTION
## Summary
- add a white `image-box` wrapper for images
- show question images in quiz history

## Testing
- `node --check sentrainer.js`

------
https://chatgpt.com/codex/tasks/task_e_685129ab21848331ba6c7eda19ec7f0f