### PR TITLE
Update QCM filters and show question count

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -224,8 +224,12 @@ function showFilterSelection() {
     const themes = [...new Set(allQuestions.map(q => q.theme || 'Autre'))];
     const niveaux = [...new Set(allQuestions.map(q => q.niveau || 'Indefini'))];
 
-    const themeBox = createFilterBox('Niveau', themes);
-    const levelBox = createFilterBox('Thème', niveaux);
+    const levelBox = createFilterBox('Niveau', niveaux);
+    const themeBox = createFilterBox('Thème', themes);
+
+    const countBox = document.createElement('div');
+    countBox.className = 'count-box';
+    countBox.textContent = `${allQuestions.length} questions disponibles`;
 
     const questionBox = document.createElement('div');
     questionBox.className = 'filter-box';
@@ -267,8 +271,9 @@ function showFilterSelection() {
         showRandomQuestion();
     });
 
-    container.appendChild(themeBox);
     container.appendChild(levelBox);
+    container.appendChild(themeBox);
+    container.appendChild(countBox);
     container.appendChild(questionBox);
     container.appendChild(start);
 }

--- a/styles.css
+++ b/styles.css
@@ -398,3 +398,10 @@ details[open] summary::before {
     border-radius: 8px;
 }
 
+/* Affichage du nombre de questions disponibles */
+.count-box {
+    text-align: right;
+    margin-bottom: 20px;
+    color: #fff;
+}
+


### PR DESCRIPTION
## Summary
- swap level and theme filters
- display total available questions under filters
- style question count element

## Testing
- `node --check sentrainer.js`

------
https://chatgpt.com/codex/tasks/task_e_68512cf7b57c8331a875348ff682c87c