### PR TITLE
Center QCM answers

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -155,6 +155,10 @@ function showRandomQuestion() {
     }
 
     const answers = shuffle([...current.choices]);
+
+    const answerBox = document.createElement('div');
+    answerBox.className = 'answer-box';
+
     answers.forEach(choice => {
         const btn = document.createElement('button');
         btn.textContent = choice;
@@ -174,8 +178,10 @@ function showRandomQuestion() {
             Array.from(block.querySelectorAll('button')).forEach(b => b.disabled = true);
             setTimeout(showRandomQuestion, HIGHLIGHT_DELAY);
         });
-        block.appendChild(btn);
+        answerBox.appendChild(btn);
     });
+
+    block.appendChild(answerBox);
 
     container.appendChild(block);
 }

--- a/styles.css
+++ b/styles.css
@@ -368,6 +368,17 @@ details[open] summary::before {
     box-shadow: 0 0 5px rgba(0,0,0,0.3);
 }
 
+.answer-box {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.answer-box .quiz-btn {
+    display: block;
+    margin: 5px;
+}
+
 /* Boîtes de sélection pour les filtres du QCM */
 .filter-box {
     position: relative;


### PR DESCRIPTION
## Summary
- center quiz answers in `sentrainer.html`
- allow answer buttons to wrap on small screens

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68512eded9188331a10ff49f278b8614