### PR TITLE
Add QCM theme progress summary

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -79,6 +79,33 @@ function showRandomQuestion() {
     if (count >= maxQuestions || !questions.length) {
         const percent = count ? Math.round((score / count) * 100) : 0;
         container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
+
+        const results = history.reduce((acc, h) => {
+            const t = h.theme || 'Autre';
+            if (!acc[t]) acc[t] = {total: 0, correct: 0};
+            acc[t].total++;
+            if (h.isCorrect) acc[t].correct++;
+            return acc;
+        }, {});
+
+        const resultsDiv = document.createElement('div');
+        Object.entries(results).forEach(([theme, res]) => {
+            const pct = Math.round((res.correct / res.total) * 100);
+            const line = document.createElement('div');
+            line.className = 'progress-container';
+            const label = document.createElement('p');
+            label.textContent = `${theme} : ${pct}% (${res.correct}/${res.total})`;
+            line.appendChild(label);
+            const bar = document.createElement('div');
+            bar.className = 'progress-bar';
+            const inner = document.createElement('div');
+            inner.className = 'progress-bar-inner';
+            inner.style.width = pct + '%';
+            bar.appendChild(inner);
+            line.appendChild(bar);
+            resultsDiv.appendChild(line);
+        });
+        container.appendChild(resultsDiv);
         const historyDiv = document.createElement('div');
         history.forEach((h, i) => {
             const block = document.createElement('div');
@@ -172,6 +199,7 @@ function showRandomQuestion() {
                 correct: current.answer,
                 correction: current.correction || '',
                 image: current.image || '',
+                theme: current.theme || 'Autre',
                 isCorrect: correct
             });
             btn.style.backgroundColor = correct ? '#00a000' : '#ff0000';

--- a/styles.css
+++ b/styles.css
@@ -416,3 +416,20 @@ details[open] summary::before {
     color: #fff;
 }
 
+/* Barres de progression pour le bilan du QCM */
+.progress-container {
+    margin-bottom: 10px;
+}
+
+.progress-bar {
+    background: #555;
+    border-radius: 8px;
+    overflow: hidden;
+    height: 1em;
+}
+
+.progress-bar-inner {
+    background: linear-gradient(to right, #00ff00, #006400);
+    height: 100%;
+}
+


### PR DESCRIPTION
## Summary
- track the theme of each answer in `sentrainer.js`
- compute per-theme statistics at the end of the quiz
- show progress bars for each theme in the QCM summary
- style new progress bars in `styles.css`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68513005e52c83319185d34a234bd9f8