### PR TITLE
Refine QCM results layout

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -88,6 +88,14 @@ function showRandomQuestion() {
             return acc;
         }, {});
 
+        const resultsBox = document.createElement('div');
+        resultsBox.className = 'filter-box';
+        resultsBox.style.marginBottom = '30px';
+        const resultsTab = document.createElement('span');
+        resultsTab.className = 'filter-tab';
+        resultsTab.textContent = 'Bilan par thème';
+        resultsBox.appendChild(resultsTab);
+
         const resultsDiv = document.createElement('div');
         Object.entries(results).forEach(([theme, res]) => {
             const pct = Math.round((res.correct / res.total) * 100);
@@ -105,7 +113,8 @@ function showRandomQuestion() {
             line.appendChild(bar);
             resultsDiv.appendChild(line);
         });
-        container.appendChild(resultsDiv);
+        resultsBox.appendChild(resultsDiv);
+        container.appendChild(resultsBox);
         const historyDiv = document.createElement('div');
         history.forEach((h, i) => {
             const block = document.createElement('div');


### PR DESCRIPTION
## Summary
- group quiz results by theme into a box with a `Bilan par thème` tab
- insert spacing before the history list

## Testing
- `node --check sentrainer.js`


------
https://chatgpt.com/codex/tasks/task_e_6851378a7e3c8331bb87310465a3a113