### PR TITLE
Add color-coded progress bars in QCM summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ désormais présentés sous forme de cases à cocher, comme celui du statut.
 La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz. Un curseur permet en outre de choisir le nombre de questions (de 5 à 20) avant de commencer.
 Les questions peuvent désormais comporter une colonne **Image** indiquant le nom d'un fichier PNG à afficher entre l'énoncé et les propositions.
 Le fichier CSV utilisé pour le QCM suit l'ordre suivant : **Thème**, **Niveau**, **Question**, **Image**, **Réponse correcte**, **Réponse fausse A**, **Réponse fausse B**, **Correction**.
+Une fois le test terminé, un bilan par thème affiche des barres de progression colorées :
+plus le pourcentage de bonnes réponses est élevé, plus la barre tend vers le vert, alors qu'elle reste rouge si le score est faible.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -109,6 +109,10 @@ function showRandomQuestion() {
             const inner = document.createElement('div');
             inner.className = 'progress-bar-inner';
             inner.style.width = pct + '%';
+            const ratio = pct / 100;
+            const r = Math.round(255 * (1 - ratio));
+            const g = Math.round(255 * ratio);
+            inner.style.backgroundColor = `rgb(${r}, ${g}, 0)`;
             bar.appendChild(inner);
             line.appendChild(bar);
             resultsDiv.appendChild(line);

--- a/styles.css
+++ b/styles.css
@@ -429,7 +429,6 @@ details[open] summary::before {
 }
 
 .progress-bar-inner {
-    background: linear-gradient(to right, #00ff00, #006400);
     height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- color progress bars from red to green based on the score
- remove fixed gradient style
- document the new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68513bf6859c8331a8675032ec0357fa