### PR TITLE
Fix alignment for long QCM answers

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -222,6 +222,11 @@ function showRandomQuestion() {
         answerBox.appendChild(btn);
     });
 
+    // Align buttons to the left if any answer text is long
+    if (answers.some(c => c.length > 40)) {
+        answerBox.classList.add('align-left');
+    }
+
     block.appendChild(answerBox);
 
     container.appendChild(block);

--- a/styles.css
+++ b/styles.css
@@ -379,6 +379,15 @@ details[open] summary::before {
     margin: 5px;
 }
 
+/* Align buttons to the left when answers are long */
+.answer-box.align-left {
+    justify-content: flex-start;
+}
+
+.answer-box.align-left .quiz-btn {
+    text-align: left;
+}
+
 /* Boîtes de sélection pour les filtres du QCM */
 .filter-box {
     position: relative;


### PR DESCRIPTION
## Summary
- add CSS class for left-aligned answer boxes
- auto-apply the class in the quiz script when an answer is long

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68514201496c8331a74131f0aabe4aca