### PR TITLE
Fix crossword definitions when header uses accents

### DIFF
--- a/jeux.js
+++ b/jeux.js
@@ -29,8 +29,9 @@ function parseCSV(text) {
     const rows = lines.map(l => l.split(','));
     if (!rows.length) return [];
     const header = rows[0];
-    const wordIdx = header.findIndex(h => h.toLowerCase().includes('mot'));
-    const clueIdx = header.findIndex(h => h.toLowerCase().includes('def'));
+    const norm = s => s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase();
+    const wordIdx = header.findIndex(h => norm(h).includes('mot'));
+    const clueIdx = header.findIndex(h => norm(h).includes('def'));
     const res = [];
     for (let i = 1; i < rows.length; i++) {
         const row = rows[i];


### PR DESCRIPTION
## Summary
- ensure crossword parser handles accented column headers

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685164946bd88331acd49d5fe2535400