### PR TITLE
Adjust QCM filter display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -398,6 +398,13 @@ details[open] summary::before {
     border-radius: 8px;
 }
 
+/* Chaque thème apparaît sur sa propre ligne et reste aligné à gauche */
+.filter-box label {
+    display: block;
+    text-align: left;
+    margin-bottom: 5px;
+}
+
 .filter-tab {
     position: absolute;
     top: -10px;


### PR DESCRIPTION
## Summary
- stack filter labels vertically in the QCM screen to display one theme per line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68516d0cf4888331abe2cd7261d9c6ac