### PR TITLE
Remove bullet markers from crossword clues

### DIFF
--- a/jeux.html
+++ b/jeux.html
@@ -14,6 +14,8 @@
         table.crossword td input { width: 100%; height: 100%; border: none; text-align: center; background: transparent; color: #fff; font-size: 18px; }
         table.crossword td.start .number { position: absolute; top: 0; left: 2px; font-size: 10px; color: #fff; }
         #message { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; align-items: center; justify-content: center; background: rgba(0,0,0,0.8); font-size: 3em; color: #fff; z-index: 10; }
+        /* Hide bullet markers for crossword clues */
+        #clues { list-style: none; padding-left: 0; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- tweak crossword clues style to hide bullet markers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685279a922cc8331b4047f47b383653d