### PR TITLE
Add auto-advance in crossword cells

### DIFF
--- a/jeux.js
+++ b/jeux.js
@@ -142,8 +142,20 @@ function drawGrid(grid, placed) {
                 input.maxLength = 1;
                 input.dataset.row = r;
                 input.dataset.col = c;
+                input.dataset.dir = cell.dir;
                 input.addEventListener('input', () => {
                     input.value = input.value.toUpperCase();
+
+                    if (input.value) {
+                        const dir = input.dataset.dir;
+                        const nextRow = parseInt(input.dataset.row) + (dir === 'V' ? 1 : 0);
+                        const nextCol = parseInt(input.dataset.col) + (dir === 'H' ? 1 : 0);
+                        const nextInput = document.querySelector(`input[data-row="${nextRow}"][data-col="${nextCol}"]`);
+                        if (nextInput) {
+                            nextInput.focus();
+                        }
+                    }
+
                     checkCompletion(placed);
                 });
                 td.appendChild(input);


### PR DESCRIPTION
## Summary
- update crossword inputs to move focus automatically to the next cell

## Testing
- `node --check jeux.js`

------
https://chatgpt.com/codex/tasks/task_e_68529226525883318fb1a2546d3953e3