### PR TITLE
Add crossword letter feedback

### DIFF
--- a/jeux.html
+++ b/jeux.html
@@ -11,6 +11,8 @@
         table.crossword { border-collapse: collapse; margin-bottom: 20px; }
         table.crossword td { width: 30px; height: 30px; border: 1px solid #888; position: relative; }
         table.crossword td.empty { background: transparent; border: none; }
+        table.crossword td.correct { background: linear-gradient(to bottom, rgba(0, 160, 0, 0.3), rgba(0, 0, 0, 0.6)); }
+        table.crossword td.incorrect { background: linear-gradient(to bottom, rgba(255, 0, 0, 0.3), rgba(0, 0, 0, 0.6)); }
         table.crossword td input { width: 100%; height: 100%; border: none; text-align: center; background: transparent; color: #fff; font-size: 18px; }
         table.crossword td.start .number { position: absolute; top: 0; left: 2px; font-size: 10px; color: #fff; }
         #message { display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; align-items: center; justify-content: center; background: rgba(0,0,0,0.8); font-size: 3em; color: #fff; z-index: 10; }

--- a/jeux.js
+++ b/jeux.js
@@ -143,8 +143,20 @@ function drawGrid(grid, placed) {
                 input.dataset.row = r;
                 input.dataset.col = c;
                 input.dataset.dir = cell.dir;
+                input.dataset.letter = cell.letter;
                 input.addEventListener('input', () => {
                     input.value = input.value.toUpperCase();
+
+                    const tdEl = input.parentElement;
+                    if (!input.value) {
+                        tdEl.classList.remove('correct', 'incorrect');
+                    } else if (input.value === input.dataset.letter) {
+                        tdEl.classList.add('correct');
+                        tdEl.classList.remove('incorrect');
+                    } else {
+                        tdEl.classList.add('incorrect');
+                        tdEl.classList.remove('correct');
+                    }
 
                     if (input.value) {
                         const dir = input.dataset.dir;


### PR DESCRIPTION
## Summary
- highlight crossword cells in green/red when letters are correct/incorrect
- store expected letter in the crossword inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529ebf77dc83318a3148f6f04e493d