### PR TITLE
Update score upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,17 @@ plus le pourcentage de bonnes réponses est élevé, plus la barre tend vers le 
 
 `sentrainer.html` demande désormais un pseudo lors du lancement. Ce pseudo est
 mémorisé dans le navigateur puis envoyé à un script Google Apps avec le score
-final pour être enregistré dans une feuille Sheets.
+final pour être enregistré dans une feuille Sheets. Le script attendu côté
+Google est :
+
+```javascript
+function doPost(e) {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  var data = JSON.parse(e.postData.contents);
+  sheet.appendRow([new Date(), data.pseudo, data.score]);
+  return ContentService.createTextOutput("OK");
+}
+```
+
+L'envoi se fait en mode `no-cors` pour éviter les blocages liés aux politiques
+de sécurité du navigateur.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -395,6 +395,7 @@ function sendScore() {
     if (!pseudo) return;
     fetch('https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec', {
         method: 'POST',
+        mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pseudo: pseudo, score: score })
     }).catch(() => {});


### PR DESCRIPTION
## Summary
- document the required Google Apps script for storing scores
- set `mode: no-cors` when posting quiz results

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6852c3a264d08331937b01be2054a9e4