### PR TITLE
Fix display of username and score

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -456,7 +456,7 @@ header {
 #user-info {
     position: absolute;
     top: 10px;
-    right: 10px;
+    right: 120px;
     font-weight: bold;
     color: #fff;
 }


### PR DESCRIPTION
## Summary
- show username box offset from the logout button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852c4b138e88331a44245d6e53ff291