### PR TITLE
Implement score bonus after QCM completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,8 @@ function doPost(e) {
 
 L'envoi se fait en mode `no-cors` pour éviter les blocages liés aux politiques
 de sécurité du navigateur.
+
+Lorsqu'un utilisateur est connecté et termine un QCM, il gagne
+automatiquement **5 points**. Ces points sont ajoutés à son score stocké dans
+le navigateur et une nouvelle ligne est envoyée vers la feuille Google Sheets
+d'historique afin de tracer l'évolution des scores.

--- a/auth.js
+++ b/auth.js
@@ -1,5 +1,6 @@
 (function(){
     const SHEET_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQCSH8hh-ykxl1L9joc4opVRARLGfcqi6uTW1bRXyyzsu99zo1OXuOYFwCBzxISzEjt2q3Abd9yU-NJ/pub?gid=1003065620&single=true&output=csv';
+    const SCORE_HISTORY_URL = 'https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec';
     let users = null;
 
     async function loadUsers(){
@@ -72,6 +73,20 @@
         });
     }
 
+    function addPoints(points){
+        const user = getUser();
+        if(!user) return;
+        const newScore = user.score + points;
+        localStorage.setItem('userScore', newScore);
+        fetch(SCORE_HISTORY_URL, {
+            method: 'POST',
+            mode: 'no-cors',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ pseudo: user.pseudo, score: points })
+        }).catch(() => {});
+        updateUserInfo();
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
         updateUserInfo();
         const btn = document.getElementById('login-btn');
@@ -94,5 +109,5 @@
         }
     });
 
-    window.auth = {login, logout, promptLogin, updateUserInfo, getUser};
+    window.auth = {login, logout, promptLogin, updateUserInfo, getUser, addPoints};
 })();

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -81,6 +81,9 @@ function showRandomQuestion() {
         const percent = count ? Math.round((score / count) * 100) : 0;
         container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
         sendScore();
+        if (window.auth && typeof auth.addPoints === 'function') {
+            auth.addPoints(5);
+        }
 
         const results = history.reduce((acc, h) => {
             const t = h.theme || 'Autre';


### PR DESCRIPTION
## Summary
- add score history recording in auth module
- award 5 points to logged users after QCM and record to Sheets
- document new behaviour in README

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852c6eb1e288331b4b7a6579f04f17e