### PR TITLE
Add QCM block in Technologie page

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
                 <li><a href="techno.html">Technologie</a></li>
                 <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
-                <li><a href="sentrainer.html">S'entrainer</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
             </ul>
         </nav>

--- a/jeux.html
+++ b/jeux.html
@@ -33,7 +33,6 @@
                 <li><a href="techno.html">Technologie</a></li>
                 <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
-                <li><a href="sentrainer.html">S'entrainer</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
             </ul>
         </nav>

--- a/sentrainer.html
+++ b/sentrainer.html
@@ -15,7 +15,6 @@
                 <li><a href="techno.html">Technologie</a></li>
                 <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
-                <li><a href="sentrainer.html">S'entrainer</a></li>
             </ul>
         </nav>
     </header>

--- a/techno.html
+++ b/techno.html
@@ -24,19 +24,29 @@
         <section class="description-ateliers">
             <h2>Apprendre et s'entrainer</h2>
             <article class="atelier">
-      				<img src="photos/cours.jpg" alt="sweethome3D">
-      				<div class="atelier-content">
-      					<h3>Apprendre le cours et s'entrainer</h3>
-      					<p>
+                                <img src="photos/cours.jpg" alt="sweethome3D">
+                                <div class="atelier-content">
+                                        <h3>Apprendre le cours et s'entrainer</h3>
+                                        <p>
                             L'ensemble des cours et des exercices d'entrainement
                         </p>
-      					<a href="cours.html">Les cours</a>
-      				</div>
+                                        <a href="cours.html">Les cours</a>
+                                </div>
             </article>
             <article class="atelier">
-      				<img src="photos/DNB.jpg" alt="sweethome3D">
-      				<div class="atelier-content">
-      					<h3>Se préparer au Brevet</h3>
+                                <img src="photos/cours.jpg" alt="sweethome3D">
+                                <div class="atelier-content">
+                                        <h3>S'entrainer en QCM</h3>
+                                        <p>
+                            Cet espace vous permet de vous entraîner et de vérifier vos acquis en technologie. Utilisez les filtres ci-dessous pour générer un quiz personnalisé selon votre niveau et les compétences visées.
+                        </p>
+                                        <a href="sentrainer.html">Lancer un QCM</a>
+                                </div>
+            </article>
+            <article class="atelier">
+                                <img src="photos/DNB.jpg" alt="sweethome3D">
+                                <div class="atelier-content">
+                                        <h3>Se préparer au Brevet</h3>
       					<p>
                             Des ressources poiur s'entrainer au brevet de Technologie (Sujet + corrigé)
                         </p>


### PR DESCRIPTION
## Summary
- add a QCM block inside `techno.html`
- remove the "S'entrainer" navigation link from pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852e05b64ec833182a600696ab8ea96