### PR TITLE
Adjust user info layout

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -49,19 +49,26 @@
     function updateUserInfo(){
         const header = document.querySelector('header');
         if(!header) return;
-        let div = document.getElementById('user-info');
-        if(!div){
-            div = document.createElement('div');
-            div.id = 'user-info';
-            header.appendChild(div);
+        let container = document.getElementById('user-info');
+        if(!container){
+            container = document.createElement('div');
+            container.id = 'user-info';
+            header.appendChild(container);
         }
+        let boxes = document.getElementById('user-boxes');
+        if(!boxes){
+            boxes = document.createElement('div');
+            boxes.id = 'user-boxes';
+            container.prepend(boxes);
+        }
+
         const user = getUser();
         if(user){
-            div.innerHTML =
+            boxes.innerHTML =
                 '<div class="user-box">' + user.pseudo + '</div>' +
                 '<div class="user-box">Score: ' + user.score + '</div>';
         }else{
-            div.innerHTML = '';
+            boxes.innerHTML = '';
         }
     }
 
@@ -106,11 +113,20 @@
             await refreshUserScore(user.pseudo);
         }
         updateUserInfo();
-        const btn = document.getElementById('login-btn');
-        if(btn){
-            if(getUser()) btn.style.display='none';
-            btn.addEventListener('click', promptLogin);
+        const container = document.getElementById('user-info');
+
+        let btn = document.getElementById('login-btn');
+        if(!btn){
+            btn = document.createElement('button');
+            btn.id = 'login-btn';
+            btn.textContent = 'Se connecter';
+        } else if(btn.parentNode !== container){
+            btn.parentNode.removeChild(btn);
         }
+        btn.addEventListener('click', promptLogin);
+        container.appendChild(btn);
+        if(getUser()) btn.style.display = 'none'; else btn.style.display = '';
+
         let logoutBtn = document.getElementById('logout-btn');
         if(!logoutBtn){
             logoutBtn = document.createElement('button');
@@ -118,12 +134,12 @@
             logoutBtn.textContent = 'Se d\u00e9connecter';
             logoutBtn.style.display = 'none';
             logoutBtn.addEventListener('click', logout);
-            const header = document.querySelector('header');
-            if(header) header.appendChild(logoutBtn);
+        } else if(logoutBtn.parentNode !== container){
+            logoutBtn.parentNode.removeChild(logoutBtn);
         }
-        if(getUser()) {
-            logoutBtn.style.display = '';
-        }
+        container.appendChild(logoutBtn);
+        if(getUser()) logoutBtn.style.display = '';
+        else logoutBtn.style.display = 'none';
     });
 
     window.auth = {login, logout, promptLogin, updateUserInfo, getUser, addPoints};

--- a/styles.css
+++ b/styles.css
@@ -460,14 +460,19 @@ header {
     font-weight: bold;
     color: #fff;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
-    gap: 10px;
+    gap: 5px;
+}
+
+#user-boxes {
+    display: flex;
+    flex-direction: row;
+    gap: 0;
 }
 
 .user-box {
-    margin-bottom: 0;
-    margin-right: 5px;
+    margin: 0;
     padding: 3px 8px;
     background: linear-gradient(to bottom, #1e3c72, #000000);
     border: 1px solid rgba(255, 255, 255, 0.5);
@@ -476,14 +481,23 @@ header {
 
 #login-btn,
 #logout-btn {
-    position: absolute;
-    top: 45px;
-    right: 10px;
     padding: 5px 10px;
     border: 1px solid rgba(255, 255, 255, 0.5);
     background: linear-gradient(to bottom, #1e3c72, #000000);
     color: #fff;
     border-radius: 4px;
     cursor: pointer;
+    position: static;
+    animation: none;
+}
+
+#login-btn:hover,
+#logout-btn:hover {
+    animation: highlight 0.6s forwards;
+}
+
+@keyframes highlight {
+    from { box-shadow: 0 0 0 rgba(255,255,255,0.5); }
+    to { box-shadow: 0 0 10px 4px rgba(255,255,255,0.8); }
 }
 


### PR DESCRIPTION
## Summary
- stack user pseudo and score inside new `#user-boxes`
- center login/logout buttons below and add highlight animation
- adjust JS to insert buttons inside the new container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852e6889d548331840734845e617aa1