### PR TITLE
Add badge display page

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -8,8 +8,13 @@
         const text = await res.text();
         const lines = text.trim().split(/\n+/).slice(1);
         users = lines.map(l => {
-            const [pseudo, pass, score] = l.split(',');
-            return {pseudo: pseudo.trim(), pass: (pass||'').trim(), score: parseInt(score,10)||0};
+            const [pseudo, pass, score, badges] = l.split(',');
+            return {
+                pseudo: pseudo.trim(),
+                pass: (pass||'').trim(),
+                score: parseInt(score,10)||0,
+                badges: (badges||'').trim()
+            };
         });
     }
 
@@ -19,6 +24,7 @@
         if(user){
             localStorage.setItem('pseudo', user.pseudo);
             localStorage.setItem('userScore', user.score);
+            localStorage.setItem('userBadges', user.badges);
             updateUserInfo();
             const loginBtn = document.getElementById('login-btn');
             if(loginBtn) loginBtn.style.display = 'none';
@@ -32,6 +38,7 @@
     function logout(){
         localStorage.removeItem('pseudo');
         localStorage.removeItem('userScore');
+        localStorage.removeItem('userBadges');
         updateUserInfo();
         const loginBtn = document.getElementById('login-btn');
         if(loginBtn) loginBtn.style.display = '';
@@ -43,7 +50,8 @@
         const pseudo = localStorage.getItem('pseudo');
         if(!pseudo) return null;
         const score = parseInt(localStorage.getItem('userScore')||'0',10);
-        return {pseudo, score};
+        const badges = (localStorage.getItem('userBadges')||'');
+        return {pseudo, score, badges};
     }
 
     function updateUserInfo(){
@@ -86,7 +94,10 @@
         try {
             await loadUsers();
             const up = users.find(u => u.pseudo === pseudo);
-            if(up) localStorage.setItem('userScore', up.score);
+            if(up){
+                localStorage.setItem('userScore', up.score);
+                localStorage.setItem('userBadges', up.badges);
+            }
         } catch(e) {}
     }
 
@@ -140,6 +151,22 @@
         container.appendChild(logoutBtn);
         if(getUser()) logoutBtn.style.display = '';
         else logoutBtn.style.display = 'none';
+
+        let badgeBtn = document.getElementById('badges-btn');
+        if(!badgeBtn){
+            badgeBtn = document.createElement('button');
+            badgeBtn.id = 'badges-btn';
+            badgeBtn.textContent = 'Mes badges';
+            badgeBtn.style.display = 'none';
+            badgeBtn.addEventListener('click', () => {
+                window.location.href = 'badges.html';
+            });
+        } else if(badgeBtn.parentNode !== container){
+            badgeBtn.parentNode.removeChild(badgeBtn);
+        }
+        container.appendChild(badgeBtn);
+        if(getUser()) badgeBtn.style.display = '';
+        else badgeBtn.style.display = 'none';
     });
 
     window.auth = {login, logout, promptLogin, updateUserInfo, getUser, addPoints};

--- a/badges.html
+++ b/badges.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mes badges</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        #badge-list { display:flex; flex-wrap:wrap; gap:10px; justify-content:center; padding:20px; }
+        #badge-list img { width:80px; height:80px; object-fit:contain; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Mes badges</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">ICN</a></li>
+                <li><a href="techno.html">Technologie</a></li>
+                <li><a href="SNT.html">SNT</a></li>
+                <li><a href="suivi_projet.html">Suivi Projet</a></li>
+                <li><a href="jeux.html">Jeux</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <div id="badge-list"></div>
+        <p id="no-badges" style="display:none; text-align:center;">Aucun badge pour le moment.</p>
+    </main>
+    <script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const user = window.auth ? auth.getUser() : null;
+        const list = document.getElementById('badge-list');
+        const no = document.getElementById('no-badges');
+        if(!user){
+            no.textContent = 'Vous devez être connecté pour voir vos badges.';
+            no.style.display = 'block';
+            return;
+        }
+        if(user.badges){
+            user.badges.split(/\s+/).forEach(name => {
+                if(!name) return;
+                const img = document.createElement('img');
+                img.src = 'photos/' + name;
+                img.alt = name;
+                list.appendChild(img);
+            });
+            if(!list.children.length){
+                no.style.display = 'block';
+            }
+        }else{
+            no.style.display = 'block';
+        }
+    });
+    </script>
+    <script src="auth.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -480,7 +480,8 @@ header {
 }
 
 #login-btn,
-#logout-btn {
+#logout-btn,
+#badges-btn {
     padding: 5px 10px;
     border: 1px solid rgba(255, 255, 255, 0.5);
     background: linear-gradient(to bottom, #1e3c72, #000000);
@@ -492,7 +493,8 @@ header {
 }
 
 #login-btn:hover,
-#logout-btn:hover {
+#logout-btn:hover,
+#badges-btn:hover {
     animation: highlight 0.6s forwards;
 }
 


### PR DESCRIPTION
## Summary
- parse user badges from the Google Sheet in `auth.js`
- save badges in local storage and refresh them
- add a "Mes badges" button beside the logout button
- style the new button in `styles.css`
- create `badges.html` to show badge images for the logged‑in user

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853cc0df31c83318bf29df063fc77ae