### PR TITLE
Fix login table display

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -97,9 +97,15 @@
 
         const user = getUser();
         if(user){
+            pseudoCell.style.display = '';
+            scoreCell.style.display = '';
+            badgesCell.style.display = '';
             pseudoCell.textContent = user.pseudo;
             scoreCell.textContent = 'Score: ' + user.score;
         }else{
+            pseudoCell.style.display = 'none';
+            scoreCell.style.display = 'none';
+            badgesCell.style.display = 'none';
             pseudoCell.textContent = '';
             scoreCell.textContent = '';
         }

--- a/styles.css
+++ b/styles.css
@@ -456,7 +456,7 @@ header {
 #user-info {
     position: absolute;
     top: 10px;
-    right: 120px;
+    right: 10px;
     font-weight: bold;
     color: #fff;
     display: grid;


### PR DESCRIPTION
## Summary
- align user info block closer to the right
- hide pseudo and score when no user is logged in

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853f0b458e88331a6ea7785ecd88cc8