### PR TITLE
Update login data parsing for class column

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -8,8 +8,9 @@
         const text = await res.text();
         const lines = text.trim().split(/\n+/).slice(1);
         users = lines.map(l => {
-            const [pseudo, pass, score, badges] = l.split(',');
+            const [classe, pseudo, pass, score, badges] = l.split(',');
             return {
+                classe: (classe||'').trim(),
                 pseudo: pseudo.trim(),
                 pass: (pass||'').trim(),
                 score: parseInt(score,10)||0,
@@ -25,6 +26,7 @@
             localStorage.setItem('pseudo', user.pseudo);
             localStorage.setItem('userScore', user.score);
             localStorage.setItem('userBadges', user.badges);
+            localStorage.setItem('userClasse', user.classe);
             updateUserInfo();
             const loginBtn = document.getElementById('login-btn');
             if(loginBtn) loginBtn.style.display = 'none';
@@ -39,6 +41,7 @@
         localStorage.removeItem('pseudo');
         localStorage.removeItem('userScore');
         localStorage.removeItem('userBadges');
+        localStorage.removeItem('userClasse');
         updateUserInfo();
         const loginBtn = document.getElementById('login-btn');
         if(loginBtn) loginBtn.style.display = '';
@@ -51,7 +54,8 @@
         if(!pseudo) return null;
         const score = parseInt(localStorage.getItem('userScore')||'0',10);
         const badges = (localStorage.getItem('userBadges')||'');
-        return {pseudo, score, badges};
+        const classe = (localStorage.getItem('userClasse')||'');
+        return {pseudo, score, badges, classe};
     }
 
     function updateUserInfo(){
@@ -128,6 +132,7 @@
             if(up){
                 localStorage.setItem('userScore', up.score);
                 localStorage.setItem('userBadges', up.badges);
+                localStorage.setItem('userClasse', up.classe);
             }
         } catch(e) {}
     }

--- a/badges.html
+++ b/badges.html
@@ -65,7 +65,7 @@
             const counts = {};
             lines.forEach(l => {
                 const parts = l.split(',');
-                const badges = (parts[3] || '').trim();
+                const badges = (parts[4] || '').trim();
                 badges.split(/\s+/).forEach(b => {
                     if(!b) return;
                     counts[b] = (counts[b] || 0) + 1;


### PR DESCRIPTION
## Summary
- parse new **Classe** field from the Google Sheet
- store the class in `localStorage` during login
- keep user class updated when refreshing score
- adjust badges page to read the correct column

## Testing
- `node --check auth.js`
- `tidy -qe badges.html`


------
https://chatgpt.com/codex/tasks/task_e_6864ab15fa908331b3d0b7270d35cf48