### PR TITLE
Organize videos by level and category

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -522,6 +522,18 @@ header {
     border: 1px solid rgba(255,255,255,0.5);
 }
 
+.video-box {
+    margin-bottom: 30px;
+    padding: 20px;
+    background: linear-gradient(to bottom, rgba(30, 144, 255, 0.2), rgba(0, 0, 0, 0.6));
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 8px;
+}
+
+.video-subbox {
+    margin-bottom: 20px;
+}
+
 .video-title {
     margin-top: 5px;
     font-size: 0.9em;

--- a/videos.html
+++ b/videos.html
@@ -23,7 +23,7 @@
     <main>
         <section class="description-ateliers">
             <h2>Sélection de vidéos</h2>
-            <div id="videos-grid" class="video-grid"></div>
+            <div id="videos-grid"></div>
         </section>
     </main>
     <script src="auth.js"></script>

--- a/videos.js
+++ b/videos.js
@@ -1,14 +1,15 @@
 // Video page script
 
 document.addEventListener('DOMContentLoaded', () => {
-    const grid = document.getElementById('videos-grid');
-    if (!grid) return;
+    const container = document.getElementById('videos-grid');
+    if (!container) return;
     if (!window.auth || !auth.getUser()) return;
-    loadVideos(grid);
+    loadVideos(container);
 });
 
 async function loadVideos(container) {
-    const SHEET_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRi1sJUVl5z4tPh_spOSkZDMlyhl9OqrEdXp34u3xBYVmnc0YWMPBfurz8tsCv50QMDnckKxeL4ci6l/pub?output=csv';
+    const SHEET_URL =
+        'https://docs.google.com/spreadsheets/d/e/2PACX-1vRi1sJUVl5z4tPh_spOSkZDMlyhl9OqrEdXp34u3xBYVmnc0YWMPBfurz8tsCv50QMDnckKxeL4ci6l/pub?output=csv';
     try {
         const res = await fetch(SHEET_URL + '&t=' + Date.now());
         if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -19,27 +20,63 @@ async function loadVideos(container) {
         const urlIdx = header.findIndex(h => h === 'url');
         const titleIdx = header.findIndex(h => h.startsWith('titre'));
         const thumbIdx = header.findIndex(h => h.startsWith('mini') || h.includes('thumb'));
-        container.classList.add('video-grid');
+        const levelIdx = header.findIndex(h => h === 'niveau' || h === 'level');
+        const catIdx = header.findIndex(h => h.startsWith('cat'));
+
+        const groups = {};
         rows.forEach(r => {
+            const level = ((r[levelIdx] || '').trim()) || 'Autre';
+            const cat = ((r[catIdx] || '').trim()) || 'Autre';
             const url = (r[urlIdx] || '').trim();
+            if (!url) return;
             const title = (r[titleIdx] || '').trim() || url;
             let thumb = thumbIdx !== -1 ? (r[thumbIdx] || '').trim() : '';
             if (!thumb && url.includes('youtu')) {
                 const m = url.match(/(?:v=|youtu\.be\/)([\w-]+)/);
                 if (m) thumb = `https://img.youtube.com/vi/${m[1]}/hqdefault.jpg`;
             }
-            const a = document.createElement('a');
-            a.href = url;
-            a.target = '_blank';
-            const img = document.createElement('img');
-            img.src = thumb || 'background.png';
-            img.alt = title;
-            const caption = document.createElement('div');
-            caption.textContent = title;
-            caption.className = 'video-title';
-            a.appendChild(img);
-            a.appendChild(caption);
-            container.appendChild(a);
+            if (!groups[level]) groups[level] = {};
+            if (!groups[level][cat]) groups[level][cat] = [];
+            groups[level][cat].push({ url, title, thumb });
+        });
+
+        container.innerHTML = '';
+        Object.keys(groups).forEach(level => {
+            const levelBox = document.createElement('div');
+            levelBox.className = 'video-box';
+            const levelTitle = document.createElement('h3');
+            levelTitle.textContent = level;
+            levelBox.appendChild(levelTitle);
+
+            Object.keys(groups[level]).forEach(cat => {
+                const catBox = document.createElement('div');
+                catBox.className = 'video-subbox';
+                const catTitle = document.createElement('h4');
+                catTitle.textContent = cat;
+                catBox.appendChild(catTitle);
+                const grid = document.createElement('div');
+                grid.className = 'video-grid';
+
+                groups[level][cat].forEach(v => {
+                    const a = document.createElement('a');
+                    a.href = v.url;
+                    a.target = '_blank';
+                    const img = document.createElement('img');
+                    img.src = v.thumb || 'background.png';
+                    img.alt = v.title;
+                    const caption = document.createElement('div');
+                    caption.textContent = v.title;
+                    caption.className = 'video-title';
+                    a.appendChild(img);
+                    a.appendChild(caption);
+                    grid.appendChild(a);
+                });
+
+                catBox.appendChild(grid);
+                levelBox.appendChild(catBox);
+            });
+
+            container.appendChild(levelBox);
         });
     } catch (e) {
         container.textContent = 'Impossible de charger les vidéos';


### PR DESCRIPTION
## Summary
- reorganize video page structure
- add categories and levels when loading videos
- tweak CSS for new boxes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68677aa955ac833190a1fcb3b4df32b3