### PR TITLE
Remove Autre category from videos page

### DIFF
--- a/videos.js
+++ b/videos.js
@@ -28,6 +28,7 @@ async function loadVideos(container) {
         rows.forEach(r => {
             const level = ((r[levelIdx] || '').trim()) || 'Autre';
             const cat = ((r[catIdx] || '').trim()) || 'Autre';
+            if (cat.toLowerCase() === 'autre') return; // skip generic category
             const url = (r[urlIdx] || '').trim();
             if (!url) return;
             const title = (r[titleIdx] || '').trim() || url;


### PR DESCRIPTION
## Summary
- ignore rows in `videos.js` that belong to the fallback "Autre" category

## Testing
- `node -p "require('./videos.js');"` *(fails: `ReferenceError: document is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_6867faab15b08331bffe26cc0cdd735f