### PR TITLE
Add star icon to score display

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -105,13 +105,13 @@
             scoreCell.style.display = '';
             badgesCell.style.display = '';
             pseudoCell.textContent = user.pseudo;
-            scoreCell.textContent = 'Score: ' + user.score;
+            scoreCell.innerHTML = user.score + ' <span class="score-star">⭐</span>';
         }else{
             pseudoCell.style.display = 'none';
             scoreCell.style.display = 'none';
             badgesCell.style.display = 'none';
             pseudoCell.textContent = '';
-            scoreCell.textContent = '';
+            scoreCell.innerHTML = '';
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -475,6 +475,10 @@ header {
     border-radius: 4px;
 }
 
+#score-cell .score-star {
+    margin-left: 4px;
+}
+
 #login-btn,
 #logout-btn,
 #badges-btn {


### PR DESCRIPTION
## Summary
- adjust score display in `auth.js` to show a star icon
- style star icon for score cell

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686918e27bcc83319444dadf48ec254c