### PR TITLE
Add per-question scoring star animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ function doPost(e) {
 L'envoi se fait en mode `no-cors` pour éviter les blocages liés aux politiques
 de sécurité du navigateur.
 
-Lorsqu'un utilisateur est connecté et termine un QCM, il gagne
-automatiquement **5 points**. Ces points sont ajoutés à son score stocké dans
-le navigateur et une nouvelle ligne est envoyée vers la feuille Google Sheets
-d'historique afin de tracer l'évolution des scores.
+Lorsqu'un utilisateur est connecté, chaque bonne réponse lui rapporte
+**1 point** ajouté immédiatement à son score. Une ligne est aussi envoyée vers
+la feuille Google Sheets d'historique afin de tracer l'évolution des scores.
 
-Une courte animation fait désormais apparaître des étoiles à la fin du quiz
-pour symboliser les points gagnés.
+Une courte animation fait désormais voler une étoile depuis la réponse
+sélectionnée jusqu'à l'icône de score pour symboliser les points gagnés.

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -81,10 +81,7 @@ function showRandomQuestion() {
         const percent = count ? Math.round((score / count) * 100) : 0;
         container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
         sendScore();
-        if (window.auth && typeof auth.addPoints === 'function') {
-            auth.addPoints(5);
-            showStarAnimation(5);
-        }
+        // Points are now awarded after each correct answer
 
         const results = history.reduce((acc, h) => {
             const t = h.theme || 'Autre';
@@ -211,7 +208,13 @@ function showRandomQuestion() {
         btn.className = 'quiz-btn';
         btn.addEventListener('click', () => {
             const correct = choice === current.answer;
-            if (correct) score++;
+            if (correct) {
+                score++;
+                if (window.auth && typeof auth.addPoints === 'function') {
+                    auth.addPoints(1);
+                }
+                flyStar(btn);
+            }
             history.push({
                 question: current.question,
                 selected: choice,
@@ -438,4 +441,33 @@ function showStarAnimation(points) {
     overlay.appendChild(box);
 
     document.body.appendChild(overlay);
+}
+
+function flyStar(fromElem) {
+    const target = document.querySelector('#score-cell .score-star');
+    if (!target) return;
+    const star = document.createElement('span');
+    star.className = 'flying-star';
+    star.textContent = '⭐';
+    document.body.appendChild(star);
+
+    const start = fromElem.getBoundingClientRect();
+    const end = target.getBoundingClientRect();
+    const startX = start.left + start.width / 2;
+    const startY = start.top + start.height / 2;
+    const endX = end.left + end.width / 2;
+    const endY = end.top + end.height / 2;
+
+    star.style.left = startX + 'px';
+    star.style.top = startY + 'px';
+    star.style.transform = 'translate(-50%, -50%)';
+
+    requestAnimationFrame(() => {
+        const dx = endX - startX;
+        const dy = endY - startY;
+        star.style.transform = `translate(-50%, -50%) translate(${dx}px, ${dy}px) scale(0.5)`;
+        star.style.opacity = '0';
+    });
+
+    star.addEventListener('transitionend', () => star.remove());
 }

--- a/styles.css
+++ b/styles.css
@@ -615,3 +615,11 @@ header {
     100% { transform: scale(1); opacity: 0; }
 }
 
+.flying-star {
+    position: fixed;
+    z-index: 10000;
+    pointer-events: none;
+    font-size: 2em;
+    transition: transform 0.6s ease-out, opacity 0.6s ease-out;
+}
+


### PR DESCRIPTION
## Summary
- update README to describe per-answer scoring
- award user points immediately for each correct answer
- animate a star from the selected answer to the score icon
- style `.flying-star` for the new animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a099a3be083319fa259f097a83db0