### PR TITLE
Fix duplicate score logging

### DIFF
--- a/sentrainer.js
+++ b/sentrainer.js
@@ -95,7 +95,9 @@ let pointsAwarded = false; // évite un ajout multiple de points
 function showResults(container) {
     const percent = count ? Math.round((score / count) * 100) : 0;
     container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
-    sendScore();
+    if (!(window.auth && typeof auth.getUser === 'function' && auth.getUser())) {
+        sendScore();
+    }
     showStarAnimation(score);
 
     const results = history.reduce((acc, h) => {


### PR DESCRIPTION
## Summary
- avoid duplicate score entries when user is logged in by only calling `sendScore` for anonymous users

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686ad6a624648331aacadb37c1109b11