### PR TITLE
Add bonus for perfect quiz results

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ la feuille Google Sheets d'historique afin de tracer l'évolution des scores.
 
 Une courte animation fait désormais voler une étoile depuis la réponse
 sélectionnée jusqu'à l'icône de score pour symboliser les points gagnés.
+Si toutes les réponses sont correctes, les points remportés sont doublés et
+l'animation affiche des étoiles brillantes en plus grand nombre.

--- a/revision6E.js
+++ b/revision6E.js
@@ -94,11 +94,13 @@ let pointsAwarded = false; // évite un ajout multiple de points
 
 function showResults(container) {
     const percent = count ? Math.round((score / count) * 100) : 0;
-    container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
+    const bonus = percent === 100;
+    const bonusText = bonus ? ' - Score parfait ! Points doublés !' : '';
+    container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)${bonusText}</p>`;
     if (!(window.auth && typeof auth.getUser === 'function' && auth.getUser())) {
         sendScore();
     }
-    showStarAnimation(score);
+    showStarAnimation(bonus ? score * 2 : score, bonus);
 
     const results = history.reduce((acc, h) => {
         const t = h.theme || 'Autre';
@@ -355,7 +357,7 @@ function sendScore() {
     }).catch(() => {});
 }
 
-function showStarAnimation(points) {
+function showStarAnimation(points, bonus = false) {
     const overlay = ce('div');
     overlay.id = 'points-popup';
 
@@ -374,7 +376,8 @@ function showStarAnimation(points) {
 
     const stars = [];
     for (let i = 0; i < points; i++) {
-        const star = ce('div', 'falling-star', '⭐');
+        const starClass = bonus ? 'falling-star bonus-star' : 'falling-star';
+        const star = ce('div', starClass, '⭐');
         box.appendChild(star);
         const rect = box.getBoundingClientRect();
         const x = Math.random() * (rect.width - 20);

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -94,11 +94,13 @@ let pointsAwarded = false; // évite un ajout multiple de points
 
 function showResults(container) {
     const percent = count ? Math.round((score / count) * 100) : 0;
-    container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)</p>`;
+    const bonus = percent === 100;
+    const bonusText = bonus ? ' - Score parfait ! Points doublés !' : '';
+    container.innerHTML = `<p>Quiz terminé ! Score : ${score} / ${count} (${percent}%)${bonusText}</p>`;
     if (!(window.auth && typeof auth.getUser === 'function' && auth.getUser())) {
         sendScore();
     }
-    showStarAnimation(score);
+    showStarAnimation(bonus ? score * 2 : score, bonus);
 
     const results = history.reduce((acc, h) => {
         const t = h.theme || 'Autre';
@@ -355,7 +357,7 @@ function sendScore() {
     }).catch(() => {});
 }
 
-function showStarAnimation(points) {
+function showStarAnimation(points, bonus = false) {
     const overlay = ce('div');
     overlay.id = 'points-popup';
 
@@ -374,7 +376,8 @@ function showStarAnimation(points) {
 
     const stars = [];
     for (let i = 0; i < points; i++) {
-        const star = ce('div', 'falling-star', '⭐');
+        const starClass = bonus ? 'falling-star bonus-star' : 'falling-star';
+        const star = ce('div', starClass, '⭐');
         box.appendChild(star);
         const rect = box.getBoundingClientRect();
         const x = Math.random() * (rect.width - 20);

--- a/styles.css
+++ b/styles.css
@@ -586,5 +586,16 @@ header {
     user-select: none;
 }
 
+#points-popup .bonus-star {
+    color: gold;
+    filter: drop-shadow(0 0 5px gold);
+    animation: shine 1s infinite alternate;
+}
+
+@keyframes shine {
+    from { filter: drop-shadow(0 0 5px gold); }
+    to { filter: drop-shadow(0 0 15px gold); }
+}
+
 
 


### PR DESCRIPTION
## Summary
- add double points and shiny star bonus when the quiz score is 100%
- style bonus stars with a shining effect
- document the perfect score bonus in README

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686b62102d2c8331ae33ef4c52f684ae