### PR TITLE
Add course & mind map popups for quizzes

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -17,7 +17,9 @@ async function fetchQCM() {
                 image: r[3] || '',
                 choices: [r[4], r[5], r[6]].filter(Boolean),
                 answer: r[4] || '',
-                correction: r[7] || ''
+                correction: r[7] || '',
+                cours: r[8] || '',
+                carte: r[9] || ''
             }))
             .filter(q => q.question);
     } catch (e) {
@@ -29,7 +31,9 @@ async function fetchQCM() {
             choices: q.choices,
             answer: q.answer,
             correction: q.correction || '',
-            image: q.image || ''
+            image: q.image || '',
+            cours: q.cours || '',
+            carte: q.carte || ''
         }));
     }
 }
@@ -182,7 +186,22 @@ function showRandomQuestion() {
     container.innerHTML = '';
     const block = ce('div', 'question-block');
     block.appendChild(ce('span', 'question-tab', `Q${count}`));
-    block.appendChild(ce('p', '', current.question));
+
+    const qLine = ce('div', 'question-line');
+    qLine.appendChild(ce('p', '', current.question));
+    if (current.cours) {
+        const cIcon = ce('span', 'question-icon', '📖');
+        cIcon.title = 'Voir le cours';
+        cIcon.addEventListener('click', () => showTextPopup(current.cours));
+        qLine.appendChild(cIcon);
+    }
+    if (current.carte) {
+        const mIcon = ce('span', 'question-icon', '🗺️');
+        mIcon.title = 'Voir la carte mentale';
+        mIcon.addEventListener('click', () => showImagePopup(current.carte));
+        qLine.appendChild(mIcon);
+    }
+    block.appendChild(qLine);
 
     if (current.image) {
         const imgBox = ce('div', 'image-box');
@@ -462,4 +481,31 @@ function flyStar(fromElem) {
         target.classList.add('hit');
         target.addEventListener('animationend', () => target.classList.remove('hit'), {once: true});
     });
+}
+
+function showTextPopup(text) {
+    const overlay = ce('div');
+    overlay.id = 'info-popup';
+    const box = ce('div', 'popup-box');
+    const close = ce('span', 'close');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => overlay.remove());
+    box.appendChild(close);
+    box.appendChild(ce('p', '', text));
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+}
+
+function showImagePopup(src) {
+    const overlay = ce('div');
+    overlay.id = 'info-popup';
+    const box = ce('div', 'popup-box');
+    const close = ce('span', 'close');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => overlay.remove());
+    const img = imgElem(src);
+    box.appendChild(close);
+    box.appendChild(img);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
 }

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -17,7 +17,9 @@ async function fetchQCM() {
                 image: r[3] || '',
                 choices: [r[4], r[5], r[6]].filter(Boolean),
                 answer: r[4] || '',
-                correction: r[7] || ''
+                correction: r[7] || '',
+                cours: r[8] || '',
+                carte: r[9] || ''
             }))
             .filter(q => q.question);
     } catch (e) {
@@ -29,7 +31,9 @@ async function fetchQCM() {
             choices: q.choices,
             answer: q.answer,
             correction: q.correction || '',
-            image: q.image || ''
+            image: q.image || '',
+            cours: q.cours || '',
+            carte: q.carte || ''
         }));
     }
 }
@@ -182,7 +186,22 @@ function showRandomQuestion() {
     container.innerHTML = '';
     const block = ce('div', 'question-block');
     block.appendChild(ce('span', 'question-tab', `Q${count}`));
-    block.appendChild(ce('p', '', current.question));
+
+    const qLine = ce('div', 'question-line');
+    qLine.appendChild(ce('p', '', current.question));
+    if (current.cours) {
+        const cIcon = ce('span', 'question-icon', '📖');
+        cIcon.title = 'Voir le cours';
+        cIcon.addEventListener('click', () => showTextPopup(current.cours));
+        qLine.appendChild(cIcon);
+    }
+    if (current.carte) {
+        const mIcon = ce('span', 'question-icon', '🗺️');
+        mIcon.title = 'Voir la carte mentale';
+        mIcon.addEventListener('click', () => showImagePopup(current.carte));
+        qLine.appendChild(mIcon);
+    }
+    block.appendChild(qLine);
 
     if (current.image) {
         const imgBox = ce('div', 'image-box');
@@ -462,4 +481,31 @@ function flyStar(fromElem) {
         target.classList.add('hit');
         target.addEventListener('animationend', () => target.classList.remove('hit'), {once: true});
     });
+}
+
+function showTextPopup(text) {
+    const overlay = ce('div');
+    overlay.id = 'info-popup';
+    const box = ce('div', 'popup-box');
+    const close = ce('span', 'close');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => overlay.remove());
+    box.appendChild(close);
+    box.appendChild(ce('p', '', text));
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
+}
+
+function showImagePopup(src) {
+    const overlay = ce('div');
+    overlay.id = 'info-popup';
+    const box = ce('div', 'popup-box');
+    const close = ce('span', 'close');
+    close.innerHTML = '&times;';
+    close.addEventListener('click', () => overlay.remove());
+    const img = imgElem(src);
+    box.appendChild(close);
+    box.appendChild(img);
+    overlay.appendChild(box);
+    document.body.appendChild(overlay);
 }

--- a/styles.css
+++ b/styles.css
@@ -359,6 +359,19 @@ details[open] summary::before {
     height: auto;
 }
 
+.question-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.question-icon {
+    cursor: pointer;
+    font-size: 1.2em;
+}
+
 .image-box {
     background-color: #fff;
     padding: 10px;
@@ -552,6 +565,37 @@ header {
     background: rgba(0, 0, 0, 0.8);
     animation: fadeIn 0.5s ease forwards;
     z-index: 10000;
+}
+
+#info-popup {
+    display: flex;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.8);
+    animation: fadeIn 0.5s ease forwards;
+    z-index: 10000;
+}
+
+#info-popup .popup-box {
+    position: relative;
+    background: #222;
+    padding: 20px 40px;
+    border-radius: 8px;
+    text-align: center;
+    color: #fff;
+}
+
+#info-popup .close {
+    position: absolute;
+    top: 5px;
+    right: 10px;
+    cursor: pointer;
+    font-size: 1.5em;
 }
 
 #points-popup .popup-box {


### PR DESCRIPTION
## Summary
- extend CSV parsing to handle `cours` and `carte mentale`
- add icons next to quiz questions to open text or image popups
- create helper popup functions in quiz scripts
- style question line, icons and new popup overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cb4c5d714833181edcc6ad42e66a9