### PR TITLE
Handle HTML in quiz course popups

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -164,7 +164,11 @@ function showResults(container) {
         }
         block.appendChild(ce('p', '', `Votre réponse : ${h.selected}`));
         if (!h.isCorrect) block.appendChild(ce('p', '', `Bonne réponse : ${h.correct}`));
-        if (h.correction) block.appendChild(ce('p', '', `Correction : ${h.correction}`));
+        if (h.correction) {
+            const p = ce('p');
+            p.innerHTML = `Correction : ${h.correction}`;
+            block.appendChild(p);
+        }
         historyDiv.appendChild(block);
     });
     container.appendChild(historyDiv);
@@ -491,7 +495,9 @@ function showTextPopup(text) {
     close.innerHTML = '&times;';
     close.addEventListener('click', () => overlay.remove());
     box.appendChild(close);
-    box.appendChild(ce('p', '', text));
+    const content = ce('div');
+    content.innerHTML = text;
+    box.appendChild(content);
     overlay.appendChild(box);
     document.body.appendChild(overlay);
 }

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -164,7 +164,11 @@ function showResults(container) {
         }
         block.appendChild(ce('p', '', `Votre réponse : ${h.selected}`));
         if (!h.isCorrect) block.appendChild(ce('p', '', `Bonne réponse : ${h.correct}`));
-        if (h.correction) block.appendChild(ce('p', '', `Correction : ${h.correction}`));
+        if (h.correction) {
+            const p = ce('p');
+            p.innerHTML = `Correction : ${h.correction}`;
+            block.appendChild(p);
+        }
         historyDiv.appendChild(block);
     });
     container.appendChild(historyDiv);
@@ -491,7 +495,9 @@ function showTextPopup(text) {
     close.innerHTML = '&times;';
     close.addEventListener('click', () => overlay.remove());
     box.appendChild(close);
-    box.appendChild(ce('p', '', text));
+    const content = ce('div');
+    content.innerHTML = text;
+    box.appendChild(content);
     overlay.appendChild(box);
     document.body.appendChild(overlay);
 }


### PR DESCRIPTION
## Summary
- allow displaying HTML tags in course popups
- show HTML corrections in quiz results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cba36a5f08331b90b60d69a2ff789