### PR TITLE
Show animated lightbulb in quizzes

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -194,16 +194,10 @@ function showRandomQuestion() {
     const qLine = ce('div', 'question-line');
     qLine.appendChild(ce('p', '', current.question));
     if (current.cours) {
-        const cIcon = ce('span', 'question-icon', '📖');
+        const cIcon = ce('span', 'question-icon lightbulb-icon', '💡');
         cIcon.title = 'Voir le cours';
         cIcon.addEventListener('click', () => showTextPopup(current.cours));
         qLine.appendChild(cIcon);
-    }
-    if (current.carte) {
-        const mIcon = ce('span', 'question-icon', '🗺️');
-        mIcon.title = 'Voir la carte mentale';
-        mIcon.addEventListener('click', () => showImagePopup(current.carte));
-        qLine.appendChild(mIcon);
     }
     block.appendChild(qLine);
 

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -194,16 +194,10 @@ function showRandomQuestion() {
     const qLine = ce('div', 'question-line');
     qLine.appendChild(ce('p', '', current.question));
     if (current.cours) {
-        const cIcon = ce('span', 'question-icon', '📖');
+        const cIcon = ce('span', 'question-icon lightbulb-icon', '💡');
         cIcon.title = 'Voir le cours';
         cIcon.addEventListener('click', () => showTextPopup(current.cours));
         qLine.appendChild(cIcon);
-    }
-    if (current.carte) {
-        const mIcon = ce('span', 'question-icon', '🗺️');
-        mIcon.title = 'Voir la carte mentale';
-        mIcon.addEventListener('click', () => showImagePopup(current.carte));
-        qLine.appendChild(mIcon);
     }
     block.appendChild(qLine);
 

--- a/styles.css
+++ b/styles.css
@@ -371,6 +371,10 @@ details[open] summary::before {
     cursor: pointer;
     font-size: 1.2em;
 }
+.question-icon.lightbulb-icon {
+    color: gold;
+    animation: shine 1.5s infinite alternate;
+}
 
 .image-box {
     background-color: #fff;
@@ -646,6 +650,8 @@ header {
     top: 5px;
     left: 10px;
     font-size: 2em;
+}
+.lightbulb-icon {
     color: gold;
     animation: shine 1.5s infinite alternate;
 }


### PR DESCRIPTION
## Summary
- add animated lightbulb style for quiz course links
- use the lightbulb icon instead of the book icon
- remove the mental map icon from all quizzes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cc00674d88331975063369854cbb6