### PR TITLE
Improve cours popup transitions

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -397,7 +397,10 @@ function showStarAnimation(points, bonus = false) {
 
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
 
     const message = ce('p', 'points-text', `Vous avez gagné ${points} points !`);
 
@@ -487,7 +490,10 @@ function showTextPopup(text) {
     const box = ce('div', 'popup-box');
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
     box.appendChild(close);
     const content = ce('div');
     content.innerHTML = text;
@@ -502,7 +508,10 @@ function showImagePopup(src) {
     const box = ce('div', 'popup-box');
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
     const img = imgElem(src);
     box.appendChild(close);
     box.appendChild(img);

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -397,7 +397,10 @@ function showStarAnimation(points, bonus = false) {
 
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
 
     const message = ce('p', 'points-text', `Vous avez gagné ${points} points !`);
 
@@ -488,7 +491,10 @@ function showTextPopup(text) {
     const icon = ce('span', 'lightbulb-icon', '💡');
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
     box.appendChild(close);
     box.appendChild(icon);
     const content = ce('div');
@@ -504,7 +510,10 @@ function showImagePopup(src) {
     const box = ce('div', 'popup-box');
     const close = ce('span', 'close');
     close.innerHTML = '&times;';
-    close.addEventListener('click', () => overlay.remove());
+    close.addEventListener('click', () => {
+        overlay.classList.add('fade-out');
+        overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
+    });
     const img = imgElem(src);
     box.appendChild(close);
     box.appendChild(img);

--- a/styles.css
+++ b/styles.css
@@ -587,7 +587,8 @@ header {
 
 #info-popup .popup-box {
     position: relative;
-    background: linear-gradient(to bottom, rgba(30, 144, 255, 0.3), rgba(0, 0, 0, 0.6));
+    /* Slightly less transparent background */
+    background: linear-gradient(to bottom, rgba(30, 144, 255, 0.5), rgba(0, 0, 0, 0.8));
     border: 1px solid rgba(255, 255, 255, 0.5);
     padding: 20px 40px;
     border-radius: 8px;
@@ -655,6 +656,16 @@ header {
 .lightbulb-icon {
     color: gold;
     animation: shine 1.5s infinite alternate;
+}
+
+/* Fade-out animation for the course popup */
+#info-popup.fade-out {
+    animation: fadeOut 0.5s ease forwards;
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
 }
 
 


### PR DESCRIPTION
## Summary
- make cours popup less transparent
- add fade-out animation for cours popups
- hook fade-out in quiz scripts

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cc6875894833195e4f4383eb3b9b7