### PR TITLE
Fix points popup closing and blue theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -606,7 +606,7 @@ header {
 
 #points-popup .popup-box {
     position: relative;
-    background: #222;
+    background: linear-gradient(to bottom, #1e3c72, #000000);
     padding: 20px 40px;
     border-radius: 8px;
     text-align: center;
@@ -658,7 +658,8 @@ header {
     animation: shine 1.5s infinite alternate;
 }
 
-/* Fade-out animation for the course popup */
+/* Fade-out animation for the popups */
+#points-popup.fade-out,
 #info-popup.fade-out {
     animation: fadeOut 0.5s ease forwards;
 }


### PR DESCRIPTION
## Summary
- ensure the points popup fades out correctly on close
- style the points popup with a blue gradient to match the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cca6a75e88331a442ed9efbc8ea0d