### PR TITLE
Ajout du thème dans l'onglet des questions du quiz 6E

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -155,7 +155,8 @@ function showResults(container) {
     const historyDiv = ce('div');
     history.forEach((h, i) => {
         const block = ce('div', 'question-block ' + (h.isCorrect ? 'correct' : 'incorrect'));
-        block.appendChild(ce('span', 'question-tab', `Q${i + 1}`));
+        const qTheme = h.theme || 'Autre';
+        block.appendChild(ce('span', 'question-tab', `Q${i + 1} - ${qTheme}`));
         block.appendChild(ce('p', '', h.question));
         if (h.image) {
             const imgBox = ce('div', 'image-box');
@@ -189,7 +190,8 @@ function showRandomQuestion() {
     count++;
     container.innerHTML = '';
     const block = ce('div', 'question-block');
-    block.appendChild(ce('span', 'question-tab', `Q${count}`));
+    const themeLabel = current.theme || 'Autre';
+    block.appendChild(ce('span', 'question-tab', `Q${count} - ${themeLabel}`));
 
     const qLine = ce('div', 'question-line');
     qLine.appendChild(ce('p', '', current.question));


### PR DESCRIPTION
## Résumé
- dans le quiz `revision6E`, ajout de l'affichage du thème à côté du numéro de chaque question
- même affichage dans l'historique des résultats

## Testing
- `node --check revision6E.js`

------
https://chatgpt.com/codex/tasks/task_e_686cec2d12948331b1268a5afcadef53