### PR TITLE
Improve star spending UI

### DIFF
--- a/depenser.js
+++ b/depenser.js
@@ -60,8 +60,23 @@ document.addEventListener('DOMContentLoaded', () => {
         boxes.forEach(b => {
             const pct = Math.min(100, Math.floor(u.score / b.reward.cost * 100));
             b.inner.style.width = pct + '%';
+
+            const ratio = pct / 100;
+            const r = Math.round(255 * (1 - ratio));
+            const g = Math.round(255 * ratio);
+            b.inner.style.backgroundColor = `rgb(${r}, ${g}, 0)`;
+
             b.info.textContent = `${Math.min(u.score, b.reward.cost)}/${b.reward.cost} ⭐`;
-            b.btn.disabled = u.score < b.reward.cost;
+
+            if (u.score >= b.reward.cost) {
+                b.btn.textContent = 'Acheter';
+                b.btn.disabled = false;
+                b.btn.classList.remove('unavailable');
+            } else {
+                b.btn.textContent = 'non disponible';
+                b.btn.disabled = true;
+                b.btn.classList.add('unavailable');
+            }
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -315,6 +315,13 @@ details[open] summary::before {
 
 .quiz-btn { margin: 5px; padding: 5px 10px; border: 1px solid #fff; border-radius: 5px; background:#1e90ff; color:#fff; }
 .quiz-btn:hover { background:#0000ff; }
+.quiz-btn.unavailable {
+    background: linear-gradient(to bottom, darkred, black);
+    cursor: not-allowed;
+}
+.quiz-btn.unavailable:hover {
+    background: linear-gradient(to bottom, darkred, black);
+}
 
 .question-block {
     position: relative;


### PR DESCRIPTION
## Summary
- show progress bar color fill for rewards
- disable purchase button with red/black style when insufficient stars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e0ae3d6988331b8afeca6b4949974