### PR TITLE
Add bonus info message to quiz 6E

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -313,6 +313,13 @@ function showFilterSelection() {
 
     questionBox.appendChild(countBox);
 
+    const bonusInfo = ce(
+        'p',
+        'bonus-info',
+        'Points doublés si tous les thèmes sont cochés et si vous faites 100 % de bonnes réponses.'
+    );
+    questionBox.appendChild(bonusInfo);
+
     function updateAvailableCount() {
         const selectedThemes = Array.from(themeBox.querySelectorAll('input[type="checkbox"]'))
             .filter(cb => cb.checked)

--- a/styles.css
+++ b/styles.css
@@ -456,6 +456,14 @@ details[open] summary::before {
     color: #fff;
 }
 
+.bonus-info {
+    font-size: 0.9em;
+    margin-top: -10px;
+    margin-bottom: 10px;
+    color: #fff;
+    text-align: center;
+}
+
 /* Barres de progression pour le bilan du QCM */
 .progress-container {
     margin-bottom: 10px;


### PR DESCRIPTION
## Summary
- highlight double-points bonus condition in the quiz settings
- style bonus info message

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686e0c66778083319b69df3ce470e594