### PR TITLE
Update reward layout

### DIFF
--- a/depenser.js
+++ b/depenser.js
@@ -48,6 +48,8 @@ document.addEventListener('DOMContentLoaded', () => {
             imgBox.appendChild(imgElem(r.image));
             box.appendChild(imgBox);
 
+            const details = ce('div', 'reward-details');
+
             const progC = ce('div', 'progress-container');
             const bar = ce('div', 'progress-bar');
             const inner = ce('div', 'progress-bar-inner');
@@ -55,11 +57,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const info = ce('p');
             progC.appendChild(bar);
             progC.appendChild(info);
-            box.appendChild(progC);
+            details.appendChild(progC);
 
             const btn = ce('button', 'quiz-btn', 'Acheter');
             btn.addEventListener('click', () => spend(r));
-            box.appendChild(btn);
+            details.appendChild(btn);
+
+            box.appendChild(details);
 
             boxes.push({ reward: r, inner, btn, info });
             section.appendChild(box);

--- a/styles.css
+++ b/styles.css
@@ -367,10 +367,11 @@ details[open] summary::before {
 }
 
 .reward-image {
-    display: block;
-    margin: 0 auto 10px;
-    max-width: 150px;
-    height: auto;
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 50%;
+    flex-shrink: 0;
 }
 
 .question-line {
@@ -397,6 +398,26 @@ details[open] summary::before {
     margin: 10px auto;
     max-width: 90%;
     box-shadow: 0 0 5px rgba(0,0,0,0.3);
+}
+
+.reward-box .image-box {
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+    max-width: none;
+    box-shadow: none;
+}
+.reward-box {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+
+.reward-details {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .answer-box {


### PR DESCRIPTION
## Summary
- tweak `depenser.js` to align reward boxes horizontally
- style reward boxes similar to workshop boxes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e1305cee48331a8e46aeca3193141