### PR TITLE
Adjust badge display size and gray unearned

### DIFF
--- a/badges.html
+++ b/badges.html
@@ -123,7 +123,10 @@
             const img = ce('img','');
             img.src = 'photos/' + def.badge;
             img.alt = def.badge;
-            if(!owned.includes(def.badge)) img.classList.add('badge-unearned');
+            if(!owned.includes(def.badge)) {
+                img.classList.add('badge-unearned');
+                box.classList.add('badge-unearned');
+            }
             imgBox.appendChild(img);
             box.appendChild(imgBox);
 

--- a/styles.css
+++ b/styles.css
@@ -613,6 +613,24 @@ header {
     padding: 15px;
 }
 
+/* Smaller layout for badges */
+.badge-grid .reward-box {
+    flex-direction: column;
+    align-items: center;
+    width: 140px;
+    padding: 10px;
+    gap: 10px;
+}
+
+.badge-grid .reward-box img {
+    width: 80px;
+    height: 80px;
+}
+
+.badge-grid .reward-details {
+    align-items: center;
+}
+
 .badge-item {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- shrink badges on the badges page
- gray out entire badge boxes when not earned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870b678e16083318457af0933010db3