### PR TITLE
Handle badge columns in CSV

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -28,13 +28,26 @@
             const text = await res.text();
             const lines = text.trim().split(/\n+/).slice(1);
             users = lines.map(l => {
-                const [classe, pseudo, pass, score, badges] = l.split(',');
+                const parts = l.split(',');
+                const [classe, pseudo, pass, score] = parts;
+                const badgeVals = parts.slice(4);
+                const badgeNames = [
+                    'BadgeScore10.png',
+                    'BadgeScore100.png',
+                    'BadgeScore500.png',
+                    'BadgeScore1000.png'
+                ];
+                const badges = [];
+                badgeVals.forEach((v, idx) => {
+                    const num = parseFloat((v || '').replace(/[^0-9.-]/g, '')) || 0;
+                    if (num >= 100) badges.push(badgeNames[idx]);
+                });
                 return {
-                    classe: (classe||'').trim(),
-                    pseudo: pseudo.trim(),
-                    pass: (pass||'').trim(),
-                    score: parseInt(score,10)||0,
-                    badges: (badges||'').trim()
+                    classe: (classe || '').trim(),
+                    pseudo: (pseudo || '').trim(),
+                    pass: (pass || '').trim(),
+                    score: parseInt(score, 10) || 0,
+                    badges: badges.join(' ')
                 };
             });
         } catch(e) {

--- a/badges.html
+++ b/badges.html
@@ -96,9 +96,21 @@
             const lines = text.trim().split(/\n+/).slice(1);
             badgeCounts = {};
             lines.forEach(line => {
-                const [classe, pseudo, pass, score, badges] = line.split(',');
-                const bnames = (badges || '').trim().split(/\s+/).filter(Boolean);
-                if(pseudo.trim() === user.pseudo){
+                const parts = line.split(',');
+                const [classe, pseudo, pass, score] = parts;
+                const badgeVals = parts.slice(4);
+                const badgeNames = [
+                    'BadgeScore10.png',
+                    'BadgeScore100.png',
+                    'BadgeScore500.png',
+                    'BadgeScore1000.png'
+                ];
+                const bnames = [];
+                badgeVals.forEach((v, idx) => {
+                    const num = parseFloat((v || '').replace(/[^0-9.-]/g, '')) || 0;
+                    if (num >= 100) bnames.push(badgeNames[idx]);
+                });
+                if ((pseudo || '').trim() === user.pseudo) {
                     userBadges = bnames.join(' ');
                     localStorage.setItem('userBadges', userBadges);
                 }


### PR DESCRIPTION
## Summary
- support new per-badge columns in auth.js
- update badges page to compute badges from new CSV layout

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870bca3be3c8331894d54fbc29db504