### PR TITLE
Display badge progress

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -65,12 +65,14 @@
                 const pass = (r[idx('mot de passe')] || '').trim();
                 const score = parseInt(r[idx('score')] || '0', 10) || 0;
                 const badges = [];
+                const progress = {};
                 badgeIdx.forEach((i, bIdx) => {
                     if(i === -1) return;
                     const num = parseFloat((r[i] || '').replace(/[^0-9.-]/g,'')) || 0;
+                    progress[badgeNames[bIdx]] = num;
                     if(num >= 100) badges.push(badgeNames[bIdx]);
                 });
-                return {classe, pseudo, pass, score, badges: badges.join(' ')};
+                return {classe, pseudo, pass, score, badges: badges.join(' '), badgeProgress: progress};
             });
         } catch(e) {
             console.error('Failed to load users', e);
@@ -93,6 +95,7 @@
             localStorage.setItem('userScore', user.score);
             localStorage.setItem('userBadges', user.badges);
             localStorage.setItem('userClasse', user.classe);
+            localStorage.setItem('userBadgeProgress', JSON.stringify(user.badgeProgress || {}));
             updateUserInfo();
             const loginBtn = document.getElementById('login-btn');
             if(loginBtn) loginBtn.style.display = 'none';
@@ -108,6 +111,7 @@
         localStorage.removeItem('userScore');
         localStorage.removeItem('userBadges');
         localStorage.removeItem('userClasse');
+        localStorage.removeItem('userBadgeProgress');
         updateUserInfo();
         const loginBtn = document.getElementById('login-btn');
         if(loginBtn) loginBtn.style.display = '';
@@ -122,7 +126,8 @@
         const score = parseInt(localStorage.getItem('userScore')||'0',10);
         const badges = (localStorage.getItem('userBadges')||'');
         const classe = (localStorage.getItem('userClasse')||'');
-        return {pseudo, score, badges, classe};
+        const badgeProgress = JSON.parse(localStorage.getItem('userBadgeProgress') || '{}');
+        return {pseudo, score, badges, classe, badgeProgress};
     }
 
     function updateNavForClass(user){
@@ -228,6 +233,7 @@
                 localStorage.setItem('userScore', up.score);
                 localStorage.setItem('userBadges', up.badges);
                 localStorage.setItem('userClasse', up.classe);
+                localStorage.setItem('userBadgeProgress', JSON.stringify(up.badgeProgress || {}));
             }
         } catch(e) {}
     }

--- a/badges.html
+++ b/badges.html
@@ -90,6 +90,7 @@
 
         let badgeCounts = null;
         let userBadges = (user.badges || '').trim();
+        let userProgress = Object.assign({}, user.badgeProgress || {});
         try {
             const res = await fetch(USER_SHEET_URL + '&t=' + Date.now());
             const rows = parseCSV(await res.text());
@@ -107,14 +108,18 @@
                 rows.forEach(row => {
                     const pseudo = (row[idx('pseudo')] || '').trim();
                     const bnames = [];
+                    const progress = {};
                     badgeIdx.forEach((i, bIdx) => {
                         if(i === -1) return;
                         const num = parseFloat((row[i] || '').replace(/[^0-9.-]/g,'')) || 0;
+                        progress[badgeNames[bIdx]] = num;
                         if(num >= 100) bnames.push(badgeNames[bIdx]);
                     });
                     if (pseudo === user.pseudo) {
                         userBadges = bnames.join(' ');
                         localStorage.setItem('userBadges', userBadges);
+                        userProgress = progress;
+                        localStorage.setItem('userBadgeProgress', JSON.stringify(userProgress));
                     }
                     bnames.forEach(n => {
                         badgeCounts[n] = (badgeCounts[n] || 0) + 1;
@@ -155,6 +160,10 @@
             details.appendChild(ce('p','badge-desc', def.desc));
             const count = badgeCounts ? (badgeCounts[def.badge] || 0) : '?';
             details.appendChild(ce('p','badge-count', 'Obtenu par ' + count + ' élèves'));
+            const progVal = userProgress[def.badge];
+            if(typeof progVal === 'number') {
+                details.appendChild(ce('p','badge-progress', 'Progression : ' + Math.floor(progVal) + '%'));
+            }
             box.appendChild(details);
 
             list.appendChild(box);

--- a/styles.css
+++ b/styles.css
@@ -654,7 +654,8 @@ header {
 }
 
 .badge-desc,
-.badge-count {
+.badge-count,
+.badge-progress {
     margin-top: 5px;
     color: #fff;
     text-align: center;


### PR DESCRIPTION
## Summary
- track progress for each badge in `auth.js`
- persist badge progress in localStorage
- show badge progression in `badges.html`
- style `.badge-progress`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870c4fef56c83318a66d63d7d346bc8