### PR TITLE
Fix badge progress parsing

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -68,7 +68,8 @@
                 const progress = {};
                 badgeIdx.forEach((i, bIdx) => {
                     if(i === -1) return;
-                    const num = parseFloat((r[i] || '').replace(/[^0-9.-]/g,'')) || 0;
+                    let num = parseFloat((r[i] || '').replace(/[^0-9.,-]/g,'').replace(',', '.')) || 0;
+                    if(num <= 1) num *= 100; // already provided as percentage
                     progress[badgeNames[bIdx]] = num;
                     if(num >= 100) badges.push(badgeNames[bIdx]);
                 });

--- a/badges.html
+++ b/badges.html
@@ -111,7 +111,8 @@
                     const progress = {};
                     badgeIdx.forEach((i, bIdx) => {
                         if(i === -1) return;
-                        const num = parseFloat((row[i] || '').replace(/[^0-9.-]/g,'')) || 0;
+                        let num = parseFloat((row[i] || '').replace(/[^0-9.,-]/g,'').replace(',', '.')) || 0;
+                        if(num <= 1) num *= 100; // convert from decimal if needed
                         progress[badgeNames[bIdx]] = num;
                         if(num >= 100) bnames.push(badgeNames[bIdx]);
                     });


### PR DESCRIPTION
## Summary
- handle decimal progress values in badge CSV
- avoid double-multiplying badge progress percentages

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6870c9e003108331b3739a4f7781d979