### PR TITLE
Change quiz button fall to explode animation

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -243,7 +243,7 @@ function showRandomQuestion() {
             const correct = choice === current.answer;
             if (correct) {
                 score++;
-                if (Math.random() < 0.9) dropOtherChoices(btn);
+                if (Math.random() < 0.9) explodeOtherChoices(btn);
             }
             history.push({
                 question: current.question,
@@ -523,49 +523,12 @@ function flyStar(fromElem) {
     });
 }
 
-function dropOtherChoices(clicked) {
-    const box = clicked.parentElement;
-    box.style.position = 'relative';
-    const rect = box.getBoundingClientRect();
-    const others = Array.from(box.querySelectorAll('button')).filter(b => b !== clicked);
-    const items = others.map(btn => {
-        const r = btn.getBoundingClientRect();
-        const state = {
-            el: btn,
-            x: r.left - rect.left,
-            y: r.top - rect.top,
-            vx: (Math.random() - 0.5) * 2,
-            vy: 0,
-            bounce: 0.4 + Math.random() * 0.4
-        };
-        btn.style.position = 'absolute';
-        btn.style.left = state.x + 'px';
-        btn.style.top = state.y + 'px';
-        return state;
+function explodeOtherChoices(clicked) {
+    const others = Array.from(clicked.parentElement.querySelectorAll('button')).filter(b => b !== clicked);
+    others.forEach(btn => {
+        btn.classList.add('explode');
+        btn.addEventListener('animationend', () => btn.remove(), { once: true });
     });
-
-    function animate() {
-        items.forEach(s => {
-            s.vy += 0.6;
-            s.x += s.vx;
-            s.y += s.vy;
-            const w = s.el.offsetWidth;
-            const h = s.el.offsetHeight;
-            if (s.x <= 0) { s.x = 0; s.vx *= -s.bounce; }
-            if (s.x + w >= rect.width) { s.x = rect.width - w; s.vx *= -s.bounce; }
-            if (s.y + h >= rect.height) { s.y = rect.height - h; s.vy *= -s.bounce; }
-        });
-
-        items.forEach(s => {
-            s.el.style.left = s.x + 'px';
-            s.el.style.top = s.y + 'px';
-        });
-
-        if (items.some(s => Math.abs(s.vy) > 0.5 || s.y + s.el.offsetHeight < rect.height)) {
-            requestAnimationFrame(animate);
-        }
-    }
-    if (items.length) requestAnimationFrame(animate);
 }
 
 function showTextPopup(text) {

--- a/styles.css
+++ b/styles.css
@@ -848,5 +848,15 @@ header {
     to { opacity: 1; transform: scale(1); }
 }
 
+/* Explosion animation for quiz buttons */
+.answer-box .quiz-btn.explode {
+    animation: explode 0.4s forwards;
+}
+
+@keyframes explode {
+    from { transform: scale(1); opacity: 1; }
+    to { transform: scale(1.5) rotate(45deg); opacity: 0; }
+}
+
 
 


### PR DESCRIPTION
## Summary
- trigger explosion animation for wrong answers instead of falling animation
- add CSS for new explosion effect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687118ea49a483319508a882aadd0961