### PR TITLE
Add LEGO CITY reward for 6E

### DIFF
--- a/depenser.js
+++ b/depenser.js
@@ -16,7 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const rewards = [
         { cost: 1000, label: 'Vbucks', image: 'vbucks.png' },
-        { cost: 800, label: 'Robux', image: 'robux.png' }
+        { cost: 800, label: 'Robux', image: 'robux.png' },
+        {
+            cost: 2000,
+            label: 'LEGO CITY - le commissariat',
+            image:
+                'https://m.media-amazon.com/images/I/61efxiYfMQL._AC_SL1250_.jpg'
+        }
     ];
 
     const section = document.getElementById('spend-section');


### PR DESCRIPTION
## Summary
- extend the rewards list for 6E star exchange
- include LEGO CITY police station reward

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889aaf4c94c833191ba74d4fe299c66