### PR TITLE
Fix reward tab text

### DIFF
--- a/depenser.js
+++ b/depenser.js
@@ -102,7 +102,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         section.querySelectorAll('.reward-box').forEach(b => b.remove());
         rewards.forEach(r => {
             const box = ce('div', 'filter-box reward-box');
-            box.appendChild(ce('span', 'filter-tab', `${r.cost} ⭐ → ${r.cost} ${r.label}`));
+            // display cost in stars followed by an arrow and the reward name
+            box.appendChild(ce('span', 'filter-tab', `${r.cost} ⭐ → ${r.label}`));
 
             const imgBox = ce('div', 'image-box');
             imgBox.appendChild(imgElem(r.image));


### PR DESCRIPTION
## Summary
- show only one star count before reward name

## Testing
- `node --check depenser.js`


------
https://chatgpt.com/codex/tasks/task_e_6889b9d8c1dc83319df1cc4db5ef29b9