### PR TITLE
Add scrollbar to course popup in 6E quiz

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -570,7 +570,7 @@ function showTextPopup(text) {
         overlay.addEventListener('animationend', () => overlay.remove(), {once: true});
     });
     box.appendChild(close);
-    const content = ce('div');
+    const content = ce('div', 'popup-content');
     content.innerHTML = text;
     box.appendChild(content);
     overlay.appendChild(box);

--- a/styles.css
+++ b/styles.css
@@ -729,6 +729,11 @@ header {
     font-size: 1.5em;
 }
 
+#info-popup .popup-box .popup-content {
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
 #challenge-popup {
     display: flex;
     position: fixed;


### PR DESCRIPTION
## Summary
- allow scrolling inside course popup for overly long content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c49ca372483318284f1c643e8ac03