### PR TITLE
Affiche la correction dans une popup pour les QCM 6E

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -282,6 +282,9 @@ function showRandomQuestion() {
                 isCorrect: correct
             });
             btn.style.backgroundColor = correct ? '#00a000' : '#ff0000';
+            if (!correct && current.correction) {
+                showTextPopup(`Correction : ${current.correction}`);
+            }
             setTimeout(showRandomQuestion, HIGHLIGHT_DELAY);
         });
         answerBox.appendChild(btn);


### PR DESCRIPTION
## Summary
- Affiche une fenêtre de correction lorsqu'une réponse erronée possède une correction dans les QCM 6E.

## Testing
- `npm test` *(échoue : Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dad429b088331a0f9ce15fe58992c