### PR TITLE
Add historique marker when posting scores

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -251,7 +251,7 @@
                 method: 'POST',
                 mode: 'no-cors',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ pseudo: user.pseudo, score: points })
+                body: JSON.stringify(["historique", { pseudo: user.pseudo, score: points }])
             });
         } catch(e) {}
         await refreshUserScore(user.pseudo);

--- a/revision6E.js
+++ b/revision6E.js
@@ -475,7 +475,7 @@ function sendScore() {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pseudo: pseudo, score: score })
+        body: JSON.stringify(["historique", { pseudo: pseudo, score: score }])
     }).catch(() => {});
 }
 

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -387,7 +387,7 @@ function sendScore() {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pseudo: pseudo, score: score })
+        body: JSON.stringify(["historique", { pseudo: pseudo, score: score }])
     }).catch(() => {});
 }
 


### PR DESCRIPTION
## Summary
- Prefix score submissions with `historique` to align with updated server-side doPost handler.

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688de67d45788331810de2bb66d3a94f