### PR TITLE
Handle question IDs in QCM CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ supplémentaire intitulée **Statut** qui indique pour chaque tâche si elle est
 désormais présentés sous forme de cases à cocher, comme celui du statut.
 
 La page `sentrainer.html` permet de lancer des QCM issus d'une feuille Google Sheets. Si la récupération échoue, le script se rabat sur `sentrainer_data.json`. Avant de démarrer, les thèmes et les niveaux sont présentés dans deux boîtes distinctes munies d'un onglet "Thème" ou "Niveau", chacune contenant des cases à cocher pour filtrer le quiz. Un curseur permet en outre de choisir le nombre de questions (de 5 à 20) avant de commencer.
-Les questions peuvent désormais comporter une colonne **Image** indiquant le nom d'un fichier PNG à afficher entre l'énoncé et les propositions.
-Le fichier CSV utilisé pour le QCM suit l'ordre suivant : **Thème**, **Niveau**, **Question**, **Image**, **Réponse correcte**, **Réponse fausse A**, **Réponse fausse B**, **Correction**.
+Les questions peuvent désormais comporter une colonne **Image** indiquant le nom d'un fichier PNG à afficher entre l'énoncé et les propositions. Des colonnes **Cours** et **Carte mentale** peuvent également fournir des ressources supplémentaires.
+Le fichier CSV utilisé pour le QCM suit désormais l'ordre suivant : **Numéro**, **Thème**, **Niveau**, **Question**, **Image**, **Réponse correcte**, **Réponse fausse A**, **Réponse fausse B**, **Correction**, **Cours**, **Carte mentale**.
 Si la colonne **Réponse fausse B** est vide pour une question, seuls deux boutons de réponse seront affichés lors du quiz.
 Une fois le test terminé, un bilan par thème affiche des barres de progression colorées :
 plus le pourcentage de bonnes réponses est élevé, plus la barre tend vers le vert, alors qu'elle reste rouge si le score est faible.

--- a/revision6E.js
+++ b/revision6E.js
@@ -11,20 +11,22 @@ async function fetchQCM() {
         rows.shift();
         return rows
             .map(r => ({
-                theme: r[0] || 'Autre',
-                niveau: r[1] || 'Indefini',
-                question: wrapLatex(r[2] || ''),
-                image: r[3] || '',
-                choices: [r[4], r[5], r[6]].filter(Boolean).map(wrapLatex),
-                answer: wrapLatex(r[4] || ''),
-                correction: wrapLatex(r[7] || ''),
-                cours: wrapLatex(r[8] || ''),
-                carte: r[9] || ''
+                numero: r[0] || '',
+                theme: r[1] || 'Autre',
+                niveau: r[2] || 'Indefini',
+                question: wrapLatex(r[3] || ''),
+                image: r[4] || '',
+                choices: [r[5], r[6], r[7]].filter(Boolean).map(wrapLatex),
+                answer: wrapLatex(r[5] || ''),
+                correction: wrapLatex(r[8] || ''),
+                cours: wrapLatex(r[9] || ''),
+                carte: r[10] || ''
             }))
             .filter(q => q.question);
     } catch (e) {
         const res = await fetch('sentrainer_data.json');
         return (await res.json()).map(q => ({
+            numero: q.numero || '',
             niveau: q.niveau || 'Indefini',
             theme: q.theme || 'Autre',
             question: wrapLatex(q.question),
@@ -278,6 +280,7 @@ function showRandomQuestion() {
                 if (Math.random() < 0.9) explodeOtherChoices(btn);
             }
             history.push({
+                numero: current.numero || '',
                 question: current.question,
                 selected: choice,
                 correct: current.answer,

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -11,20 +11,22 @@ async function fetchQCM() {
         rows.shift();
         return rows
             .map(r => ({
-                theme: r[0] || 'Autre',
-                niveau: r[1] || 'Indefini',
-                question: r[2] || '',
-                image: r[3] || '',
-                choices: [r[4], r[5], r[6]].filter(Boolean),
-                answer: r[4] || '',
-                correction: r[7] || '',
-                cours: r[8] || '',
-                carte: r[9] || ''
+                numero: r[0] || '',
+                theme: r[1] || 'Autre',
+                niveau: r[2] || 'Indefini',
+                question: r[3] || '',
+                image: r[4] || '',
+                choices: [r[5], r[6], r[7]].filter(Boolean),
+                answer: r[5] || '',
+                correction: r[8] || '',
+                cours: r[9] || '',
+                carte: r[10] || ''
             }))
             .filter(q => q.question);
     } catch (e) {
         const res = await fetch('sentrainer_data.json');
         return (await res.json()).map(q => ({
+            numero: q.numero || '',
             niveau: q.niveau || 'Indefini',
             theme: q.theme || 'Autre',
             question: q.question,
@@ -224,6 +226,7 @@ function showRandomQuestion() {
                 score++;
             }
             history.push({
+                numero: current.numero || '',
                 question: current.question,
                 selected: choice,
                 correct: current.answer,

--- a/sentrainer_data.json
+++ b/sentrainer_data.json
@@ -1,29 +1,38 @@
 [
   {
+    "numero": "1",
     "niveau": "Facile",
     "theme": "Géographie",
     "question": "Quelle est la capitale de la France ?",
     "choices": ["Paris", "Lyon", "Marseille"],
     "answer": "Paris",
     "correction": "Paris est la capitale de la France.",
-    "image": ""
+    "image": "",
+    "cours": "",
+    "carte": ""
   },
   {
+    "numero": "2",
     "niveau": "Facile",
     "theme": "Maths",
     "question": "Combien font 2 + 2 ?",
     "choices": ["3", "4", "5"],
     "answer": "4",
     "correction": "2 + 2 = 4",
-    "image": ""
+    "image": "",
+    "cours": "",
+    "carte": ""
   },
   {
+    "numero": "3",
     "niveau": "Facile",
     "theme": "Web",
     "question": "Quel est le langage utilisé pour structurer les pages web ?",
     "choices": ["HTML", "Python", "CSS"],
     "answer": "HTML",
     "correction": "On emploie le langage HTML pour structurer une page.",
-    "image": ""
+    "image": "",
+    "cours": "",
+    "carte": ""
   }
 ]


### PR DESCRIPTION
## Summary
- Update QCM loaders to handle new CSV layout including question IDs, course links and mind maps
- Document new CSV format in README and add sample IDs in fallback data

## Testing
- `node --check sentrainer.js revision6E.js`
- `python -m json.tool sentrainer_data.json >/tmp/check && tail -n 5 /tmp/check`


------
https://chatgpt.com/codex/tasks/task_e_688de8df0d248331830181fc12529a55