### PR TITLE
Update score tracking URL

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,6 +1,6 @@
 (function(){
     const SHEET_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQCSH8hh-ykxl1L9joc4opVRARLGfcqi6uTW1bRXyyzsu99zo1OXuOYFwCBzxISzEjt2q3Abd9yU-NJ/pub?gid=1003065620&single=true&output=csv';
-    const SCORE_HISTORY_URL = 'https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec';
+    const SCORE_HISTORY_URL = 'https://script.google.com/macros/s/AKfycbwrGEvUtBgPPGg1UoYWccMsAST3SujPnSBgpcyFhsGSQq4vxLRVyFjfFnoY1baHvgqobQ/exec';
     let users = null;
     let originalNav = null;
 

--- a/revision6E.js
+++ b/revision6E.js
@@ -475,7 +475,7 @@ function showLogin() {
 
 function sendScore() {
     if (!pseudo) return;
-    fetch('https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec', {
+    fetch('https://script.google.com/macros/s/AKfycbwrGEvUtBgPPGg1UoYWccMsAST3SujPnSBgpcyFhsGSQq4vxLRVyFjfFnoY1baHvgqobQ/exec', {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },
@@ -485,7 +485,7 @@ function sendScore() {
 
 function sendCompetence(idQuestion, resultat) {
     if (!pseudo) return;
-    fetch('https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec', {
+    fetch('https://script.google.com/macros/s/AKfycbwrGEvUtBgPPGg1UoYWccMsAST3SujPnSBgpcyFhsGSQq4vxLRVyFjfFnoY1baHvgqobQ/exec', {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -386,7 +386,7 @@ function showLogin() {
 
 function sendScore() {
     if (!pseudo) return;
-    fetch('https://script.google.com/macros/s/AKfycbzHfWfQzgWHNx7iE2aeCcgC27Y-1lvr2SVnZQDoNOeLwgsebjQyGw8zWTavJ175GSmg/exec', {
+    fetch('https://script.google.com/macros/s/AKfycbwrGEvUtBgPPGg1UoYWccMsAST3SujPnSBgpcyFhsGSQq4vxLRVyFjfFnoY1baHvgqobQ/exec', {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- point score tracking to new Google Apps Script endpoint
- update score submissions in revision6E and sentrainer

## Testing
- `node --check auth.js revision6E.js sentrainer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0a7941048331bc5a05b940f7e8fb