### PR TITLE
Order questions by decreasing success rate

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -359,6 +359,12 @@ details[open] summary::before {
     background: linear-gradient(to bottom, rgba(255, 0, 0, 0.6), rgba(0, 0, 0, 0.8));
 }
 
+.success-rate {
+    font-size: 0.9em;
+    text-align: right;
+    margin-top: 5px;
+}
+
 .question-image {
     display: block;
     margin: 10px auto;


### PR DESCRIPTION
## Summary
- Retrieve per-question success rates from history sheet
- Order quiz questions so each one is harder than the last
- Display each question's success rate

## Testing
- `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_688e4a5d60a483319330cda420e7856d