### PR TITLE
Allow equal success rate for follow-up questions in QCM 6E

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -166,7 +166,7 @@ function selectQuestions(candidates, count) {
     const result = [first];
     let prevRate = questionRates[first.numero] || 0;
     while (result.length < count) {
-        const lower = pool.filter(q => (questionRates[q.numero] || 0) < prevRate);
+        const lower = pool.filter(q => (questionRates[q.numero] || 0) <= prevRate);
         if (!lower.length) break;
         lower.sort((a, b) => (questionRates[b.numero] || 0) - (questionRates[a.numero] || 0));
         const bestRate = questionRates[lower[0].numero] || 0;


### PR DESCRIPTION
## Summary
- Permettre la sélection de questions dont le taux de réussite est inférieur **ou égal** à la question précédente dans le QCM 6E

## Testing
- `node --check revision6E.js`


------
https://chatgpt.com/codex/tasks/task_e_688e575200688331a7cb8decf44294b0