### PR TITLE
Reduce double-or-nothing challenge probability to 1%

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -734,8 +734,10 @@ function showImagePopup(src) {
 }
 
 function offerChallenge(themes) {
-    if (Math.random() >= 0.3) return;
-    if (Math.random() < 0.5 && themes.length) {
+    const chance = Math.random();
+    if (chance < 0.01) {
+        offerDoubleOrNothing();
+    } else if (chance < 0.16 && themes.length) {
         pauseProgram();
         const theme = themes[Math.floor(Math.random() * themes.length)];
         const overlay = ce('div');
@@ -780,8 +782,6 @@ function offerChallenge(themes) {
         box.appendChild(refuse);
         overlay.appendChild(box);
         document.body.appendChild(overlay);
-    } else {
-        offerDoubleOrNothing();
     }
 }
 


### PR DESCRIPTION
## Summary
- Lower double-or-nothing challenge trigger rate to 1% in the 6E quiz.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ee58901d8833188cc1bea622c1aa9