### PR TITLE
Improve double-or-nothing challenge handling

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -340,7 +340,7 @@ function showRandomQuestion() {
 
     const qLine = ce('div', 'question-line');
     qLine.appendChild(ceHtml('p', '', current.question));
-    if (current.cours) {
+    if (current.cours && !doubleOrNothingActive) {
         const cIcon = ce('span', 'question-icon lightbulb-icon', '💡');
         cIcon.title = 'Voir le cours';
         cIcon.addEventListener('click', () => showTextPopup(current.cours));
@@ -739,9 +739,9 @@ function showImagePopup(src) {
 
 function offerChallenge(themes) {
     const chance = Math.random();
-    if (chance < 0.01) {
+    if (chance < 0.10) {
         offerDoubleOrNothing();
-    } else if (chance < 0.16 && themes.length) {
+    } else if (chance < 0.25 && themes.length) {
         pauseProgram();
         const theme = themes[Math.floor(Math.random() * themes.length)];
         const overlay = ce('div');


### PR DESCRIPTION
## Summary
- Hide the lightbulb course hint during double-or-nothing challenges
- Raise double-or-nothing challenge chance from 1% to 10%

## Testing
- `node --check revision6E.js`


------
https://chatgpt.com/codex/tasks/task_e_6891a1ded97483318b509dead12b7cea