### PR TITLE
Reduce Quitte ou Double challenge frequency

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -777,9 +777,9 @@ function showImagePopup(src) {
 
 function offerChallenge(themes) {
     const chance = Math.random();
-    if (chance < 0.10) {
+    if (chance < 0.05) {
         offerDoubleOrNothing();
-    } else if (chance < 0.25 && themes.length) {
+    } else if (chance < 0.20 && themes.length) {
         pauseProgram();
         const theme = themes[Math.floor(Math.random() * themes.length)];
         const overlay = ce('div');


### PR DESCRIPTION
## Summary
- Lowered the chance of triggering the Quitte ou Double challenge from 10% to 5% and adjusted the theme challenge interval accordingly.

## Testing
- `node --check revision6E.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c1b6f4bc8331ac99c43d0eb53128