### PR TITLE
feat: warn and remove fullscreen in challenge mode

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -232,6 +232,7 @@ let challengeGuardWarned = false;
 let offZoneTimeout = null;
 
 function activateChallengeGuard() {
+    showWarningPopup("Challenge : l'utilisation d'internet est interdite");
     const warn = () => {
         if (challengeGuardWarned) return;
         challengeGuardWarned = true;
@@ -239,22 +240,13 @@ function activateChallengeGuard() {
         startOffZoneTimer();
         setTimeout(() => (challengeGuardWarned = false), 500);
     };
-    const requestFullScreen = () => {
-        const el = document.documentElement;
-        if (el.requestFullscreen) {
-            el.requestFullscreen().catch(() => {});
-        }
-    };
-    requestFullScreen();
     const handleBlur = () => {
         warn();
-        requestFullScreen();
         window.focus();
     };
     const handleVisibility = () => {
         if (document.hidden) {
             warn();
-            requestFullScreen();
         } else {
             clearOffZoneTimer();
         }
@@ -353,6 +345,7 @@ function resumeProgram() {
 }
 
 function showResults(container) {
+    deactivateChallengeGuard();
     const percent = count ? Math.round((score / count) * 100) : 0;
     const noError = percent === 100;
     let multiplier = 1;


### PR DESCRIPTION
## Summary
- show internet-use warning when challenge begins
- remove fullscreen enforcement in challenge mode
- disable challenge guard after final question so results screen is free

## Testing
- `node --check revision6E.js`


------
https://chatgpt.com/codex/tasks/task_e_68945248b0e48331b1593855e3bef0a4