### PR TITLE
feat(stats): show half-day goal progress

### DIFF
--- a/statistiques.html
+++ b/statistiques.html
@@ -26,6 +26,7 @@
             </div>
             <div id="histogram"></div>
         </section>
+        <section id="goal-container"></section>
         <section id="stats-container">
             <p>Chargement des statistiques...</p>
         </section>

--- a/statistiques.js
+++ b/statistiques.js
@@ -142,6 +142,42 @@ document.addEventListener('DOMContentLoaded', async () => {
     periodInputs.forEach(i => i.addEventListener('change', updateHistogram));
     updateHistogram();
 
+    const goalSection = document.getElementById('goal-container');
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(now.getHours() < 12 ? 0 : 12, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(start.getHours() + 12);
+    let successCount = 0;
+    rows.forEach(r => {
+        const d = new Date(r[tIdx]);
+        if (d >= start && d < end && parseFloat(r[sIdx] || '0') > 0) successCount++;
+    });
+    const ratio = Math.min(successCount / 50, 1);
+    const goalBox = document.createElement('div');
+    goalBox.className = 'filter-box';
+    const goalTab = document.createElement('span');
+    goalTab.className = 'filter-tab';
+    goalTab.textContent = 'Objectif demi-journée';
+    goalBox.appendChild(goalTab);
+    const progContainer = document.createElement('div');
+    progContainer.className = 'progress-container';
+    const progBar = document.createElement('div');
+    progBar.className = 'progress-bar';
+    const progInner = document.createElement('div');
+    progInner.className = 'progress-bar-inner';
+    progInner.style.width = (ratio * 100) + '%';
+    const rCol = Math.round(255 * (1 - ratio));
+    const gCol = Math.round(255 * ratio);
+    progInner.style.backgroundColor = `rgb(${rCol}, ${gCol}, 0)`;
+    progBar.appendChild(progInner);
+    progContainer.appendChild(progBar);
+    const progInfo = document.createElement('p');
+    progInfo.textContent = `${successCount}/50 questions réussies`;
+    progContainer.appendChild(progInfo);
+    goalBox.appendChild(progContainer);
+    goalSection.appendChild(goalBox);
+
     const stats = {};
     rows.forEach(r => {
         const num = (r[qIdx] || '').trim();


### PR DESCRIPTION
## Summary
- add half-day goal section to statistics page
- display progress toward 50 successful questions with progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -c statistiques.js`


------
https://chatgpt.com/codex/tasks/task_e_689830f6fda483319eaf7502915a4be1