### PR TITLE
Add boxed histogram for statistics

### DIFF
--- a/statistiques.html
+++ b/statistiques.html
@@ -18,7 +18,8 @@
         </nav>
     </header>
     <main>
-        <section id="histogram-section">
+        <section id="histogram-section" class="filter-box">
+            <span class="filter-tab">Questions par période</span>
             <div id="period-selector">
                 <label><input type="radio" name="period" value="day" checked> Par jour</label>
                 <label><input type="radio" name="period" value="hour"> Par heure</label>

--- a/styles.css
+++ b/styles.css
@@ -541,6 +541,7 @@ details[open] summary::before {
     display: flex;
     flex-direction: column;
     align-items: center;
+    height: 100%;
 }
 
 .bar {


### PR DESCRIPTION
## Summary
- Wrap histogram section in a styled box with a descriptive tab
- Ensure histogram bars span container height for proper rendering

## Testing
- `node --check site/statistiques.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689836439d008331b50ff525fac21617