### PR TITLE
Refonte de l'histogramme des statistiques 6E

### DIFF
--- a/statistiques.html
+++ b/statistiques.html
@@ -22,16 +22,16 @@
             <span class="filter-tab">Questions par période</span>
             <div id="period-selector">
                 <label><input type="radio" name="period" value="day" checked> Par jour</label>
-                <label><input type="radio" name="period" value="hour"> Par heure</label>
                 <label><input type="radio" name="period" value="week"> Par semaine</label>
             </div>
-            <div id="histogram"></div>
+            <canvas id="histogram"></canvas>
         </section>
         <section id="goal-container"></section>
         <section id="stats-container">
             <p>Chargement des statistiques...</p>
         </section>
     </main>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="auth.js"></script>
     <script src="statistiques.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -530,41 +530,8 @@ details[open] summary::before {
 }
 
 #histogram {
-    display: flex;
-    align-items: flex-end;
-    gap: 4px;
-    height: 200px;
-}
-
-.bar-wrapper {
-    width: 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    height: 100%;
-}
-
-.bar {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    flex-grow: 1;
-}
-
-.bar-success {
-    background: #0a0;
-}
-
-.bar-fail {
-    background: #d00;
-}
-
-.bar-label {
-    margin-top: 4px;
-    font-size: 0.7em;
-    text-align: center;
-    word-break: break-all;
+    max-width: 100%;
+    height: 300px;
 }
 
 


### PR DESCRIPTION
## Summary
- Remplace l'ancien histogramme par un graphique Chart.js avec grille sur les axes
- Formate les étiquettes des jours en `DD/MM` et des semaines en `S1`
- Supprime l'affichage par heure et les styles obsolètes

## Testing
- `node --check statistiques.js`


------
https://chatgpt.com/codex/tasks/task_e_689838d65bf48331b669f32eb8beb0a8