### PR TITLE
Affiche la progression de l'objectif demi-journée dans le QCM 6E

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -19,6 +19,7 @@
         </nav>
     </header>
     <main>
+        <section id="goal-container"></section>
         <section id="quiz-container">
             <p>Chargement du QCM...</p>
         </section>


### PR DESCRIPTION
## Summary
- Ajout d'une section dédiée pour afficher la progression vers l'objectif de la demi-journée.
- Calcul et mise à jour de la barre de progression à partir de l'historique des réponses.
- Rafraîchissement de la progression après chaque réponse enregistrée.

## Testing
- `node --check revision6E.js`
- `npm test` *(échec attendu : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68983d2c09808331a06890651d131df6