### PR TITLE
Passe l'objectif à 100 questions sur la journée

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -128,8 +128,7 @@ function getProgressKey() {
     if (!pseudo) return null;
     const now = new Date();
     const date = now.toISOString().slice(0, 10);
-    const slot = now.getHours() < 12 ? 'AM' : 'PM';
-    return `${GOAL_KEY}_${pseudo}_${date}_${slot}`;
+    return `${GOAL_KEY}_${pseudo}_${date}`;
 }
 
 function getGoalProgress() {
@@ -147,10 +146,10 @@ function setGoalProgress(count) {
 function updateGoalDisplay(count) {
     const goalSection = document.getElementById('goal-container');
     if (!goalSection) return;
-    const ratio = Math.min(count / 50, 1);
+    const ratio = Math.min(count / 100, 1);
     goalSection.innerHTML = '';
     const box = ce('div', 'filter-box');
-    box.appendChild(ce('span', 'filter-tab', 'Objectif demi-journée'));
+    box.appendChild(ce('span', 'filter-tab', 'Objectif journée'));
     const line = ce('div', 'progress-container');
     const bar = ce('div', 'progress-bar');
     const prog = ce('div', 'progress-bar-inner');
@@ -160,7 +159,7 @@ function updateGoalDisplay(count) {
     prog.style.backgroundColor = `rgb(${r}, ${g}, 0)`;
     bar.appendChild(prog);
     line.appendChild(bar);
-    line.appendChild(ce('p', '', `${count}/50 questions réussies`));
+    line.appendChild(ce('p', '', `${count}/100 questions réussies`));
     box.appendChild(line);
     goalSection.appendChild(box);
 }

--- a/statistiques.js
+++ b/statistiques.js
@@ -168,20 +168,20 @@ document.addEventListener('DOMContentLoaded', async () => {
     const goalSection = document.getElementById('goal-container');
     const now = new Date();
     const start = new Date(now);
-    start.setHours(now.getHours() < 12 ? 0 : 12, 0, 0, 0);
+    start.setHours(0, 0, 0, 0);
     const end = new Date(start);
-    end.setHours(start.getHours() + 12);
+    end.setDate(end.getDate() + 1);
     let successCount = 0;
     rows.forEach(r => {
         const d = parseDate(r[tIdx]);
         if (d && d >= start && d < end && parseFloat(r[sIdx] || '0') > 0) successCount++;
     });
-    const ratio = Math.min(successCount / 50, 1);
+    const ratio = Math.min(successCount / 100, 1);
     const goalBox = document.createElement('div');
     goalBox.className = 'filter-box';
     const goalTab = document.createElement('span');
     goalTab.className = 'filter-tab';
-    goalTab.textContent = 'Objectif demi-journée';
+    goalTab.textContent = 'Objectif journée';
     goalBox.appendChild(goalTab);
     const progContainer = document.createElement('div');
     progContainer.className = 'progress-container';
@@ -196,7 +196,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     progBar.appendChild(progInner);
     progContainer.appendChild(progBar);
     const progInfo = document.createElement('p');
-    progInfo.textContent = `${successCount}/50 questions réussies`;
+    progInfo.textContent = `${successCount}/100 questions réussies`;
     progContainer.appendChild(progInfo);
     goalBox.appendChild(progContainer);
     goalSection.appendChild(goalBox);


### PR DESCRIPTION
## Summary
- Remplace la progression demi-journée par un suivi quotidien du nombre de questions réussies dans le QCM de révision.
- Met à jour les statistiques 6E pour suivre un objectif journalier de 100 questions.

## Testing
- `node --check revision6E.js`
- `node --check statistiques.js`


------
https://chatgpt.com/codex/tasks/task_e_68990afb51608331b474e4ccc69f8b58