### PR TITLE
Remove obsolete progress bar from 6E quiz and stats

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -19,7 +19,6 @@
         </nav>
     </header>
     <main>
-        <section id="goal-container"></section>
         <section id="quiz-container">
             <p>Chargement du QCM...</p>
         </section>

--- a/revision6E.js
+++ b/revision6E.js
@@ -122,58 +122,6 @@ function parseCSV(text) {
     return rows;
 }
 
-const GOAL_KEY = 'goalProgress';
-
-function getProgressKey() {
-    if (!pseudo) return null;
-    const now = new Date();
-    const date = now.toISOString().slice(0, 10);
-    return `${GOAL_KEY}_${pseudo}_${date}`;
-}
-
-function getGoalProgress() {
-    const key = getProgressKey();
-    if (!key) return 0;
-    return parseInt(localStorage.getItem(key) || '0', 10);
-}
-
-function setGoalProgress(count) {
-    const key = getProgressKey();
-    if (!key) return;
-    localStorage.setItem(key, count);
-}
-
-function updateGoalDisplay(count) {
-    const goalSection = document.getElementById('goal-container');
-    if (!goalSection) return;
-    const ratio = Math.min(count / 100, 1);
-    goalSection.innerHTML = '';
-    const box = ce('div', 'filter-box');
-    box.appendChild(ce('span', 'filter-tab', 'Objectif journée'));
-    const line = ce('div', 'progress-container');
-    const bar = ce('div', 'progress-bar');
-    const prog = ce('div', 'progress-bar-inner');
-    prog.style.width = ratio * 100 + '%';
-    const r = Math.round(255 * (1 - ratio));
-    const g = Math.round(255 * ratio);
-    prog.style.backgroundColor = `rgb(${r}, ${g}, 0)`;
-    bar.appendChild(prog);
-    line.appendChild(bar);
-    line.appendChild(ce('p', '', `${count}/100 questions réussies`));
-    box.appendChild(line);
-    goalSection.appendChild(box);
-}
-
-function showGoalProgress() {
-    const count = getGoalProgress();
-    updateGoalDisplay(count);
-}
-
-function incrementGoalProgress() {
-    const newCount = getGoalProgress() + 1;
-    setGoalProgress(newCount);
-    updateGoalDisplay(newCount);
-}
 
 function shuffle(arr) {
     for (let i = arr.length - 1; i > 0; i--) {
@@ -576,7 +524,6 @@ function showRandomQuestion() {
 
 document.addEventListener('DOMContentLoaded', async () => {
     pseudo = localStorage.getItem('pseudo') || '';
-    showGoalProgress();
     const [qcm, rates, stats] = await Promise.all([
         fetchQCM(),
         fetchQuestionRates(),
@@ -727,7 +674,6 @@ function showLogin() {
             pseudo = val;
             localStorage.setItem('pseudo', pseudo);
             userQuestionStats = await fetchUserQuestionStats(pseudo);
-            showGoalProgress();
             showFilterSelection();
         }
     });
@@ -755,7 +701,6 @@ function sendCompetence(idQuestion, resultat) {
             body: JSON.stringify(["competence", { pseudo: pseudo, idQuestion: idQuestion, resultat: resultat }])
         }).catch(() => {});
     }
-    if (resultat > 0) incrementGoalProgress();
 }
 
 function showStarAnimation(points, bonus = false) {

--- a/statistiques.html
+++ b/statistiques.html
@@ -26,7 +26,6 @@
             </div>
             <canvas id="histogram"></canvas>
         </section>
-        <section id="goal-container"></section>
         <section id="stats-container">
             <p>Chargement des statistiques...</p>
         </section>

--- a/statistiques.js
+++ b/statistiques.js
@@ -165,42 +165,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     periodInputs.forEach(i => i.addEventListener('change', updateHistogram));
     updateHistogram();
 
-    const goalSection = document.getElementById('goal-container');
-    const now = new Date();
-    const start = new Date(now);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    let successCount = 0;
-    rows.forEach(r => {
-        const d = parseDate(r[tIdx]);
-        if (d && d >= start && d < end && parseFloat(r[sIdx] || '0') > 0) successCount++;
-    });
-    const ratio = Math.min(successCount / 100, 1);
-    const goalBox = document.createElement('div');
-    goalBox.className = 'filter-box';
-    const goalTab = document.createElement('span');
-    goalTab.className = 'filter-tab';
-    goalTab.textContent = 'Objectif journée';
-    goalBox.appendChild(goalTab);
-    const progContainer = document.createElement('div');
-    progContainer.className = 'progress-container';
-    const progBar = document.createElement('div');
-    progBar.className = 'progress-bar';
-    const progInner = document.createElement('div');
-    progInner.className = 'progress-bar-inner';
-    progInner.style.width = (ratio * 100) + '%';
-    const rCol = Math.round(255 * (1 - ratio));
-    const gCol = Math.round(255 * ratio);
-    progInner.style.backgroundColor = `rgb(${rCol}, ${gCol}, 0)`;
-    progBar.appendChild(progInner);
-    progContainer.appendChild(progBar);
-    const progInfo = document.createElement('p');
-    progInfo.textContent = `${successCount}/100 questions réussies`;
-    progContainer.appendChild(progInfo);
-    goalBox.appendChild(progContainer);
-    goalSection.appendChild(goalBox);
-
     const stats = {};
     rows.forEach(r => {
         const num = (r[qIdx] || '').trim();


### PR DESCRIPTION
## Summary
- Drop daily goal progress bar from statistics page.
- Clean 6E quiz by removing goal tracking logic and related HTML.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689961314b9483319ff4b5237b22b228