### PR TITLE
Count daily successes from history CSV

### DIFF
--- a/statistiques.js
+++ b/statistiques.js
@@ -98,7 +98,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const todayStr = new Date().toISOString().slice(0, 10);
     const todaySuccess = rows.reduce((acc, r) => {
         const d = parseDate(r[tIdx]);
-        return acc + (d && d.toISOString().slice(0, 10) === todayStr && parseFloat(r[sIdx] || '0') > 0 ? 1 : 0);
+        return acc + (d && d.toISOString().slice(0, 10) === todayStr && parseFloat(r[sIdx] || '0') === 1 ? 1 : 0);
     }, 0);
     const successElem = document.getElementById('success-count');
     if (successElem) successElem.textContent = todaySuccess;
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
             const entry = map.get(key) || { total: 0, success: 0 };
             entry.total++;
-            if (parseFloat(r[sIdx] || '0') > 0) entry.success++;
+            if (parseFloat(r[sIdx] || '0') === 1) entry.success++;
             map.set(key, entry);
         });
         return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0])).map(([key, v]) => ({ key, total: v.total, success: v.success }));


### PR DESCRIPTION
## Summary
- Fetch and tally only score=1 entries from the history CSV to compute today's successes.
- Introduce `updateTodaySuccess` to refresh the success count on load, login, and after each correct answer.
- Update statistics page to base success and histogram counts on score=1 rows.

## Testing
- `node --check revision6E.js`
- `node --check statistiques.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997e7ff10c83318e186945a6d6b3fe