### PR TITLE
Remove daily success counter for 6E students

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -19,10 +19,6 @@
         </nav>
     </header>
     <main>
-        <section id="success-box" class="filter-box">
-            <span class="filter-tab">Nombre de questions réussies</span>
-            <p id="success-count">0</p>
-        </section>
         <section id="quiz-container">
             <p>Chargement du QCM...</p>
         </section>

--- a/revision6E.js
+++ b/revision6E.js
@@ -232,7 +232,6 @@ let maxQuestions = 5;
 let history = [];
 let pseudo = '';
 let userQuestionStats = {};
-let todaySuccess = 0;
 const HIGHLIGHT_DELAY = 1000; // temps avant la question suivante
 let pointsAwarded = false; // évite un ajout multiple de points
 let allThemesSelectedAtStart = false; // indique si tous les thèmes étaient cochés
@@ -247,13 +246,10 @@ let actionTimeout = null;
 let challengeGuard = null;
 let challengeGuardWarned = false;
 
-async function updateTodaySuccess() {
+async function updateUserStats() {
     if (!pseudo) return;
     const data = await fetchUserQuestionStats(pseudo);
     userQuestionStats = data.stats;
-    todaySuccess = data.todaySuccess;
-    const successElem = document.getElementById('success-count');
-    if (successElem) successElem.textContent = todaySuccess;
 }
 
 function activateChallengeGuard() {
@@ -495,7 +491,7 @@ function showRandomQuestion() {
             const correct = choice === current.answer;
             if (correct) {
                 score++;
-                await updateTodaySuccess();
+                await updateUserStats();
                 if (Math.random() < 0.9) explodeOtherChoices(btn);
             }
             history.push({
@@ -557,7 +553,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     allQuestions = qcm;
     questionRates = rates;
     if (pseudo) {
-        await updateTodaySuccess();
+        await updateUserStats();
         showFilterSelection();
     } else {
         showLogin();
@@ -698,7 +694,7 @@ function showLogin() {
         if (val) {
             pseudo = val;
             localStorage.setItem('pseudo', pseudo);
-            await updateTodaySuccess();
+            await updateUserStats();
             showFilterSelection();
         }
     });

--- a/statistiques.html
+++ b/statistiques.html
@@ -18,10 +18,6 @@
         </nav>
     </header>
     <main>
-        <section id="success-box" class="filter-box">
-            <span class="filter-tab">Nombre de questions réussies</span>
-            <p id="success-count">0</p>
-        </section>
         <section id="histogram-section" class="filter-box">
             <span class="filter-tab">Questions par période</span>
             <div id="period-selector">

--- a/statistiques.js
+++ b/statistiques.js
@@ -95,13 +95,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     rows = rows.filter(r => (r[pIdx] || '').trim().toLowerCase() === user.pseudo.toLowerCase());
-    const todayStr = new Date().toISOString().slice(0, 10);
-    const todaySuccess = rows.reduce((acc, r) => {
-        const d = parseDate(r[tIdx]);
-        return acc + (d && d.toISOString().slice(0, 10) === todayStr && parseFloat(r[sIdx] || '0') === 1 ? 1 : 0);
-    }, 0);
-    const successElem = document.getElementById('success-count');
-    if (successElem) successElem.textContent = todaySuccess;
     if (!rows.length) {
         container.innerHTML = '<p>Aucune donnée disponible.</p>';
         return;


### PR DESCRIPTION
## Summary
- Hide daily success counter on training and statistics pages for 6E.
- Simplify scripts to fetch user stats without tracking today's successes.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f252ca848331a0547e90aa743e46