### PR TITLE
Ajout de mini histogrammes par thème pour les 6E

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -464,6 +464,12 @@ details[open] summary::before {
     margin-bottom: 5px;
 }
 
+.mini-histogram {
+    width: 100%;
+    height: 80px;
+    margin-top: 10px;
+}
+
 .filter-tab {
     position: absolute;
     top: -10px;


### PR DESCRIPTION
## Summary
- Affichage d'un mini histogramme dans chaque thème des statistiques des 6E
- Ajout d'un style dédié pour ces mini histogrammes

## Testing
- `node --check statistiques.js`


------
https://chatgpt.com/codex/tasks/task_e_689a5d5eae9883319836b3e2d93e2704