### PR TITLE
Limit histogram dimensions on statistics page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -466,6 +466,7 @@ details[open] summary::before {
 
 .mini-histogram {
     width: 100%;
+    max-width: 400px;
     height: 80px;
     margin-top: 10px;
 }
@@ -536,8 +537,10 @@ details[open] summary::before {
 }
 
 #histogram {
-    max-width: 100%;
+    width: 100%;
+    max-width: 400px;
     height: 200px;
+    max-height: 300px;
 }
 
 


### PR DESCRIPTION
## Summary
- Constrain main histogram canvas to a maximum of 400x300px
- Restrict mini histogram canvases to 400px wide to prevent oversized charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a630415008331953840a0bcfab8da