### PR TITLE
Fix histogram size on statistics page

### DIFF
--- a/statistiques.html
+++ b/statistiques.html
@@ -24,7 +24,7 @@
                 <label><input type="radio" name="period" value="day" checked> Par jour</label>
                 <label><input type="radio" name="period" value="week"> Par semaine</label>
             </div>
-            <canvas id="histogram"></canvas>
+            <canvas id="histogram" width="400" height="300"></canvas>
         </section>
         <section id="stats-container">
             <p>Chargement des statistiques...</p>

--- a/statistiques.js
+++ b/statistiques.js
@@ -101,6 +101,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     const histCanvas = document.getElementById('histogram');
+    histCanvas.width = 400;
+    histCanvas.height = 300;
     let chart;
 
     function getWeekNumber(d) {
@@ -148,7 +150,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             ]
         };
         const options = {
-            responsive: true,
+            responsive: false,
+            maintainAspectRatio: false,
             scales: {
                 x: { stacked: true, grid: { color: 'rgba(0,0,0,0.1)' } },
                 y: { beginAtZero: true, stacked: true, grid: { color: 'rgba(0,0,0,0.1)' }, ticks: { stepSize: 1 } }
@@ -197,6 +200,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const miniCanvas = document.createElement('canvas');
         miniCanvas.className = 'mini-histogram';
+        miniCanvas.width = 400;
+        miniCanvas.height = 300;
         box.appendChild(miniCanvas);
         const themeData = groupRows('day', obj.rows);
         const miniLabels = themeData.map(d => formatDate(d.key));
@@ -212,7 +217,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 ]
             },
             options: {
-                responsive: true,
+                responsive: false,
                 maintainAspectRatio: false,
                 plugins: { legend: { display: false } },
                 scales: {

--- a/styles.css
+++ b/styles.css
@@ -465,9 +465,8 @@ details[open] summary::before {
 }
 
 .mini-histogram {
-    width: 100%;
-    max-width: 400px;
-    height: 80px;
+    width: 400px;
+    height: 300px;
     margin-top: 10px;
 }
 
@@ -537,10 +536,8 @@ details[open] summary::before {
 }
 
 #histogram {
-    width: 100%;
-    max-width: 400px;
-    height: 200px;
-    max-height: 300px;
+    width: 400px;
+    height: 300px;
 }
 
 


### PR DESCRIPTION
## Summary
- Limit histogram canvas to 400x300
- Disable Chart.js responsive sizing for fixed dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6568839c8331990c686412df35fe