### PR TITLE
Affiche les axes des histogrammes des thèmes

### DIFF
--- a/statistiques.js
+++ b/statistiques.js
@@ -221,8 +221,13 @@ document.addEventListener('DOMContentLoaded', async () => {
                 maintainAspectRatio: false,
                 plugins: { legend: { display: false } },
                 scales: {
-                    x: { display: false, stacked: true },
-                    y: { display: false, stacked: true }
+                    x: { stacked: true, grid: { color: 'rgba(0,0,0,0.1)' } },
+                    y: {
+                        beginAtZero: true,
+                        stacked: true,
+                        grid: { color: 'rgba(0,0,0,0.1)' },
+                        ticks: { stepSize: 1 }
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Summary
- Affiche les axes X et Y sur les mini-histogrammes des thèmes pour refléter l'histogramme global.

## Testing
- `node --check statistiques.js`


------
https://chatgpt.com/codex/tasks/task_e_689ac582a4c08331941ca23bacf3ad44