### PR TITLE
Enable TikZ support for LaTeX content

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,7 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" defer></script>
+    <script>
+        window.MathJax = {
+            tex: { packages: { '[+]': ['tikz'] } },
+            loader: { load: ['[tex]/tikz'] }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
## Summary
- add TikZ block handling to wrapLatex
- load MathJax TikZ extension and SVG renderer

## Testing
- `node --check revision6E.js`
- `npx -y htmlhint revision6E.html`


------
https://chatgpt.com/codex/tasks/task_e_689acf13abc8833196d03fa9deaa8b2f