### PR TITLE
Render QCM axis markup in questions and solutions

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -940,3 +940,5 @@ header {
 
 
 
+
+svg.axe { display: block; margin: 0.5em 0; }


### PR DESCRIPTION
## Summary
- render custom `<axe>` tags as SVG axes with optional points
- parse axes in questions, answers, and popups for both training and revision QCM pages
- style generated SVG axes

## Testing
- `node --check sentrainer.js`
- `node --check revision6E.js`


------
https://chatgpt.com/codex/tasks/task_e_689ad840f400833187a8fa6cd17d26c6