### PR TITLE
Handle colon syntax for axes points

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -181,11 +181,19 @@ function ceHtml(tag, cls, html) {
 
 function renderAxes(root) {
     const ns = 'http://www.w3.org/2000/svg';
+
+    function getAttr(el, name) {
+        let val = el.getAttribute(name);
+        if (val !== null) return val;
+        const attr = Array.from(el.attributes).find(a => a.name.startsWith(name + ':'));
+        return attr ? attr.name.split(':')[1] : null;
+    }
+
     root.querySelectorAll('axe').forEach(axe => {
-        const min = parseFloat(axe.getAttribute('min')) || 0;
-        const max = parseFloat(axe.getAttribute('max')) || 10;
-        const step = parseFloat(axe.getAttribute('graduation')) || 1;
-        const color = axe.getAttribute('couleur') || '#fff';
+        const min = parseFloat(getAttr(axe, 'min')) || 0;
+        const max = parseFloat(getAttr(axe, 'max')) || 10;
+        const step = parseFloat(getAttr(axe, 'graduation')) || 1;
+        const color = getAttr(axe, 'couleur') || '#fff';
         const width = 300;
         const height = 40;
         const padding = 10;
@@ -221,11 +229,11 @@ function renderAxes(root) {
             svg.appendChild(label);
         }
         axe.querySelectorAll('point').forEach(pt => {
-            const xVal = parseFloat(pt.getAttribute('x'));
+            const xVal = parseFloat(getAttr(pt, 'x'));
             if (isNaN(xVal)) return;
             const lbl = pt.textContent.trim();
             const x = padding + ((xVal - min) / range) * (width - 2 * padding);
-            const pColor = pt.getAttribute('couleur') || color;
+            const pColor = getAttr(pt, 'couleur') || color;
             if (lbl) {
                 const txt = document.createElementNS(ns, 'text');
                 txt.setAttribute('x', x);

--- a/revision6E.js
+++ b/revision6E.js
@@ -237,10 +237,9 @@ function renderAxes(root) {
             if (lbl) {
                 const txt = document.createElementNS(ns, 'text');
                 txt.setAttribute('x', x);
-                txt.setAttribute('y', height / 2);
+                txt.setAttribute('y', height / 2 - 8);
                 txt.setAttribute('font-size', '10');
                 txt.setAttribute('text-anchor', 'middle');
-                txt.setAttribute('dominant-baseline', 'middle');
                 txt.setAttribute('fill', pColor);
                 txt.textContent = lbl;
                 svg.appendChild(txt);

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -105,11 +105,19 @@ function ceHtml(tag, cls, html) {
 
 function renderAxes(root) {
     const ns = 'http://www.w3.org/2000/svg';
+
+    function getAttr(el, name) {
+        let val = el.getAttribute(name);
+        if (val !== null) return val;
+        const attr = Array.from(el.attributes).find(a => a.name.startsWith(name + ':'));
+        return attr ? attr.name.split(':')[1] : null;
+    }
+
     root.querySelectorAll('axe').forEach(axe => {
-        const min = parseFloat(axe.getAttribute('min')) || 0;
-        const max = parseFloat(axe.getAttribute('max')) || 10;
-        const step = parseFloat(axe.getAttribute('graduation')) || 1;
-        const color = axe.getAttribute('couleur') || '#000';
+        const min = parseFloat(getAttr(axe, 'min')) || 0;
+        const max = parseFloat(getAttr(axe, 'max')) || 10;
+        const step = parseFloat(getAttr(axe, 'graduation')) || 1;
+        const color = getAttr(axe, 'couleur') || '#000';
         const width = 300;
         const height = 40;
         const padding = 10;
@@ -144,12 +152,12 @@ function renderAxes(root) {
             svg.appendChild(label);
         }
         axe.querySelectorAll('point').forEach(pt => {
-            const xVal = parseFloat(pt.getAttribute('x'));
+            const xVal = parseFloat(getAttr(pt, 'x'));
             if (isNaN(xVal)) return;
             const lbl = pt.textContent.trim();
             const x = padding + ((xVal - min) / range) * (width - 2 * padding);
             const circle = document.createElementNS(ns, 'circle');
-            const pColor = pt.getAttribute('couleur') || 'red';
+            const pColor = getAttr(pt, 'couleur') || 'red';
             circle.setAttribute('cx', x);
             circle.setAttribute('cy', height / 2);
             circle.setAttribute('r', 3);

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -169,6 +169,7 @@ function renderAxes(root) {
                 txt.setAttribute('y', height / 2 - 8);
                 txt.setAttribute('font-size', '10');
                 txt.setAttribute('text-anchor', 'middle');
+                txt.setAttribute('fill', pColor);
                 txt.textContent = lbl;
                 svg.appendChild(txt);
             }


### PR DESCRIPTION
## Summary
- parse `min:max`/`x:3` style attributes in custom `<axe>` elements
- render point labels and colors even when attributes use colon syntax

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ae9ca61508331b2e219c1f74cb141