### PR TITLE
Fix LaTeX rendering in quizzes

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -281,6 +281,8 @@ function wrapLatex(str) {
 function typesetMath() {
     if (window.MathJax && MathJax.typesetPromise) {
         MathJax.typesetPromise();
+    } else {
+        setTimeout(typesetMath, 100);
     }
 }
 

--- a/sentrainer.html
+++ b/sentrainer.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>S'entrainer</title>
     <link rel="stylesheet" href="styles.css">
+    <script>
+        window.MathJax = {
+            tex: { packages: { '[+]': ['tikz'] } },
+            loader: { load: ['[tex]/tikz'] }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
## Summary
- Retry MathJax typesetting until the library loads so fractions display correctly.
- Add MathJax support and LaTeX wrapping to the training quiz page.

## Testing
- `node --check revision6E.js && node --check sentrainer.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c18ef5fa883319b26e0c0be7dce12