### PR TITLE
Remove TikZ support from 6E quiz and simplify LaTeX handling

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,12 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
-    <script>
-        window.MathJax = {
-            tex: { packages: { '[+]': ['tikz'] } },
-            loader: { load: ['[tex]/tikz'] }
-        };
-    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>

--- a/revision6E.js
+++ b/revision6E.js
@@ -256,25 +256,14 @@ function wrapLatex(str) {
     if (str.includes('<html>')) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
-    const tikzBlocks = [];
-    if (str.includes('<tikz>')) {
-        str = str.replace(/<tikz>([\s\S]*?)<\/tikz>/g, (_, tikz) => {
-            const hasEnv = /\\begin{tikzpicture}/.test(tikz);
-            const body = hasEnv ? tikz : `\\begin{tikzpicture}${tikz}\\end{tikzpicture}`;
-            const token = `@@TIKZ${tikzBlocks.length}@@`;
-            tikzBlocks.push(`\\[\\require{tikz}${body}\\]`);
-            return token;
-        });
-    }
-    // Replace explicit <latex>...</latex> segments with MathJax inline syntax
     if (str.includes('<latex>')) {
         str = str.replace(/<latex>([\s\S]*?)<\/latex>/g, (_, tex) => `\\(${tex}\\)`);
     }
-    // Fallback: wrap any LaTeX style commands starting with a backslash
-    str = str.replace(/\\[a-zA-Z]+(?:\{[^{}]*\})*/g, m => `\\(${m}\\)`);
-    tikzBlocks.forEach((block, i) => {
-        str = str.replace(`@@TIKZ${i}@@`, block);
-    });
+    const hasLatex = /\\[a-zA-Z]+/.test(str);
+    const hasDelims = str.includes('\\(') || str.includes('\\[') || str.includes('$$');
+    if (hasLatex && !hasDelims) {
+        str = `\\(${str}\\)`;
+    }
     return str;
 }
 


### PR DESCRIPTION
## Summary
- Drop TikZ package configuration from the 6ème quiz page
- Streamline LaTeX wrapper to remove TikZ processing and avoid double wrapping

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c1d5441108331924b2e970ee36bea