### PR TITLE
feat: isolate latex sections in 6E quiz

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -257,12 +257,16 @@ function wrapLatex(str) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
     if (str.includes('<latex>')) {
-        str = str.replace(/<latex>([\s\S]*?)<\/latex>/g, (_, tex) => `\\(${tex}\\)`);
+        str = str.replace(
+            /<latex>([\s\S]*?)<\/latex>/g,
+            (_, tex) => `<span t="Latex">\\(${tex}\\)</span>`
+        );
     }
+    const hasSpan = /<span t="Latex">/.test(str);
     const hasLatex = /\\[a-zA-Z]+/.test(str);
     const hasDelims = str.includes('\\(') || str.includes('\\[') || str.includes('$$');
-    if (hasLatex && !hasDelims) {
-        str = `\\(${str}\\)`;
+    if (!hasSpan && hasLatex && !hasDelims) {
+        return `<span t="Latex">\\(${str}\\)</span>`;
     }
     return str;
 }


### PR DESCRIPTION
## Summary
- ensure `<latex>` parts of questions render as `t="Latex"` spans
- avoid wrapping non-math text in math delimiters for 6E QCM

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c221ab0508331b6ef9665d917b8a1