### PR TITLE
Remove LaTeX handling from 6E quiz

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>
     <header>

--- a/revision6E.js
+++ b/revision6E.js
@@ -14,12 +14,12 @@ async function fetchQCM() {
                 numero: r[0] || '',
                 theme: r[1] || 'Autre',
                 niveau: r[2] || 'Indefini',
-                question: wrapLatex(r[3] || ''),
+                question: unwrapHtml(r[3] || ''),
                 image: r[4] || '',
-                choices: [r[5], r[6], r[7]].filter(Boolean).map(wrapLatex),
-                answer: wrapLatex(r[5] || ''),
-                correction: wrapLatex(r[8] || ''),
-                cours: wrapLatex(r[9] || ''),
+                choices: [r[5], r[6], r[7]].filter(Boolean).map(unwrapHtml),
+                answer: unwrapHtml(r[5] || ''),
+                correction: unwrapHtml(r[8] || ''),
+                cours: unwrapHtml(r[9] || ''),
                 carte: r[10] || ''
             }))
             .filter(q => q.question);
@@ -29,12 +29,12 @@ async function fetchQCM() {
             numero: q.numero || '',
             niveau: q.niveau || 'Indefini',
             theme: q.theme || 'Autre',
-            question: wrapLatex(q.question),
-            choices: (q.choices || []).map(wrapLatex),
-            answer: wrapLatex(q.answer),
-            correction: wrapLatex(q.correction || ''),
+            question: unwrapHtml(q.question),
+            choices: (q.choices || []).map(unwrapHtml),
+            answer: unwrapHtml(q.answer),
+            correction: unwrapHtml(q.correction || ''),
             image: q.image || '',
-            cours: wrapLatex(q.cours || ''),
+            cours: unwrapHtml(q.cours || ''),
             carte: q.carte || ''
         }));
     }
@@ -251,32 +251,12 @@ function renderAxes(root) {
         axe.replaceWith(svg);
     });
 }
-function wrapLatex(str) {
+function unwrapHtml(str) {
     // Replace explicit <html>...</html> segments with raw HTML
     if (str.includes('<html>')) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
-    if (str.includes('<latex>')) {
-        str = str.replace(
-            /<latex>([\s\S]*?)<\/latex>/g,
-            (_, tex) => `<span t="Latex">\\(${tex}\\)</span>`
-        );
-    }
-    const hasSpan = /<span t="Latex">/.test(str);
-    const hasLatex = /\\[a-zA-Z]+/.test(str);
-    const hasDelims = str.includes('\\(') || str.includes('\\[') || str.includes('$$');
-    if (!hasSpan && hasLatex && !hasDelims) {
-        return `<span t="Latex">\\(${str}\\)</span>`;
-    }
     return str;
-}
-
-function typesetMath() {
-    if (window.MathJax && MathJax.typesetPromise) {
-        MathJax.typesetPromise();
-    } else {
-        setTimeout(typesetMath, 100);
-    }
 }
 
 function imgElem(src) {
@@ -521,7 +501,6 @@ function showResults(container) {
     const restart = ce('button', 'quiz-btn', 'Nouveau test');
     restart.addEventListener('click', showFilterSelection);
     container.appendChild(restart);
-    typesetMath();
 }
 
 function showRandomQuestion() {
@@ -624,7 +603,6 @@ function showRandomQuestion() {
     block.appendChild(answerBox);
 
     container.appendChild(block);
-    typesetMath();
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -935,7 +913,6 @@ function showTextPopup(text) {
     box.appendChild(content);
     overlay.appendChild(box);
     document.body.appendChild(overlay);
-    typesetMath();
 }
 
 function showImagePopup(src) {


### PR DESCRIPTION
## Summary
- Strip LaTeX parsing in the 6E quiz and replace it with simple HTML unwrapping
- Drop MathJax dependency

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c2c6d2b7c83319dfc39fdd99512d4