### PR TITLE
Add MathJax LaTeX support for 6E QCM

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
+    <script>
+        window.MathJax = {
+            tex: { packages: { '[+]': ['tikz'] } },
+            loader: { load: ['[tex]/tikz'] }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>
     <header>

--- a/revision6E.js
+++ b/revision6E.js
@@ -14,12 +14,12 @@ async function fetchQCM() {
                 numero: r[0] || '',
                 theme: r[1] || 'Autre',
                 niveau: r[2] || 'Indefini',
-                question: unwrapHtml(r[3] || ''),
+                question: wrapLatex(r[3] || ''),
                 image: r[4] || '',
-                choices: [r[5], r[6], r[7]].filter(Boolean).map(unwrapHtml),
-                answer: unwrapHtml(r[5] || ''),
-                correction: unwrapHtml(r[8] || ''),
-                cours: unwrapHtml(r[9] || ''),
+                choices: [r[5], r[6], r[7]].filter(Boolean).map(wrapLatex),
+                answer: wrapLatex(r[5] || ''),
+                correction: wrapLatex(r[8] || ''),
+                cours: wrapLatex(r[9] || ''),
                 carte: r[10] || ''
             }))
             .filter(q => q.question);
@@ -29,12 +29,12 @@ async function fetchQCM() {
             numero: q.numero || '',
             niveau: q.niveau || 'Indefini',
             theme: q.theme || 'Autre',
-            question: unwrapHtml(q.question),
-            choices: (q.choices || []).map(unwrapHtml),
-            answer: unwrapHtml(q.answer),
-            correction: unwrapHtml(q.correction || ''),
+            question: wrapLatex(q.question),
+            choices: (q.choices || []).map(wrapLatex),
+            answer: wrapLatex(q.answer),
+            correction: wrapLatex(q.correction || ''),
             image: q.image || '',
-            cours: unwrapHtml(q.cours || ''),
+            cours: wrapLatex(q.cours || ''),
             carte: q.carte || ''
         }));
     }
@@ -251,12 +251,37 @@ function renderAxes(root) {
         axe.replaceWith(svg);
     });
 }
-function unwrapHtml(str) {
-    // Replace explicit <html>...</html> segments with raw HTML
+
+function wrapLatex(str) {
     if (str.includes('<html>')) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
+    const tikzBlocks = [];
+    if (str.includes('<tikz>')) {
+        str = str.replace(/<tikz>([\s\S]*?)<\/tikz>/g, (_, tikz) => {
+            const hasEnv = /\\begin{tikzpicture}/.test(tikz);
+            const body = hasEnv ? tikz : `\\begin{tikzpicture}${tikz}\\end{tikzpicture}`;
+            const token = `@@TIKZ${tikzBlocks.length}@@`;
+            tikzBlocks.push(`\\[\\require{tikz}${body}\\]`);
+            return token;
+        });
+    }
+    if (str.includes('<latex>')) {
+        str = str.replace(/<latex>([\s\S]*?)<\/latex>/g, (_, tex) => `\\(${tex}\\)`);
+    }
+    str = str.replace(/\\[a-zA-Z]+(?:\{[^{}]*\})*/g, m => `\\(${m}\\)`);
+    tikzBlocks.forEach((block, i) => {
+        str = str.replace(`@@TIKZ${i}@@`, block);
+    });
     return str;
+}
+
+function typesetMath() {
+    if (window.MathJax && MathJax.typesetPromise) {
+        MathJax.typesetPromise();
+    } else {
+        setTimeout(typesetMath, 100);
+    }
 }
 
 function imgElem(src) {
@@ -501,6 +526,7 @@ function showResults(container) {
     const restart = ce('button', 'quiz-btn', 'Nouveau test');
     restart.addEventListener('click', showFilterSelection);
     container.appendChild(restart);
+    typesetMath();
 }
 
 function showRandomQuestion() {
@@ -603,6 +629,7 @@ function showRandomQuestion() {
     block.appendChild(answerBox);
 
     container.appendChild(block);
+    typesetMath();
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -913,6 +940,7 @@ function showTextPopup(text) {
     box.appendChild(content);
     overlay.appendChild(box);
     document.body.appendChild(overlay);
+    typesetMath();
 }
 
 function showImagePopup(src) {


### PR DESCRIPTION
## Summary
- load MathJax on revision6E page with TikZ support
- interpret new `<latex>` tags when parsing QCM data
- typeset questions, answers, corrections and course content with MathJax

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c3034216c833185a42d052a99443d