### PR TITLE
Add MathJax LaTeX support for 6E QCM

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
+    <script>
+        window.MathJax = {
+            tex: { packages: { '[+]': ['tikz'] } },
+            loader: { load: ['[tex]/tikz'] }
+        };
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
## Summary
- load MathJax on revision6E page with TikZ support
- interpret new `<latex>` tags when parsing QCM data
- typeset questions, answers, corrections and course content with MathJax
- avoid double-wrapping LaTeX expressions so formulas render correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c3034216c833185a42d052a99443d