### PR TITLE
Remove unused TikZ handling

### DIFF
--- a/revision6E.html
+++ b/revision6E.html
@@ -5,12 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gagner des étoiles</title>
     <link rel="stylesheet" href="styles.css">
-    <script>
-        window.MathJax = {
-            tex: { packages: { '[+]': ['tikz'] } },
-            loader: { load: ['[tex]/tikz'] }
-        };
-    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>

--- a/revision6E.js
+++ b/revision6E.js
@@ -256,25 +256,9 @@ function wrapLatex(str) {
     if (str.includes('<html>')) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
-    const tikzBlocks = [];
-    if (str.includes('<tikz>')) {
-        str = str.replace(/<tikz>([\s\S]*?)<\/tikz>/g, (_, tikz) => {
-            const hasEnv = /\\begin{tikzpicture}/.test(tikz);
-            const body = hasEnv ? tikz : `\\begin{tikzpicture}${tikz}\\end{tikzpicture}`;
-            const token = `@@TIKZ${tikzBlocks.length}@@`;
-            tikzBlocks.push(`\\[\\require{tikz}${body}\\]`);
-            return token;
-        });
-    }
     if (str.includes('<latex>')) {
         str = str.replace(/<latex>([\s\S]*?)<\/latex>/g, (_, tex) => `\\(${tex}\\)`);
     }
-
-    
-
-    tikzBlocks.forEach((block, i) => {
-        str = str.replace(`@@TIKZ${i}@@`, block);
-    });
     return str;
 }
 

--- a/sentrainer.html
+++ b/sentrainer.html
@@ -5,12 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>S'entrainer</title>
     <link rel="stylesheet" href="styles.css">
-    <script>
-        window.MathJax = {
-            tex: { packages: { '[+]': ['tikz'] } },
-            loader: { load: ['[tex]/tikz'] }
-        };
-    </script>
     <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-svg.js" defer></script>
 </head>
 <body>

--- a/sentrainer.js
+++ b/sentrainer.js
@@ -183,23 +183,10 @@ function wrapLatex(str) {
     if (str.includes('<html>')) {
         str = str.replace(/<html>([\s\S]*?)<\/html>/g, (_, html) => html);
     }
-    const tikzBlocks = [];
-    if (str.includes('<tikz>')) {
-        str = str.replace(/<tikz>([\s\S]*?)<\/tikz>/g, (_, tikz) => {
-            const hasEnv = /\\begin{tikzpicture}/.test(tikz);
-            const body = hasEnv ? tikz : `\\begin{tikzpicture}${tikz}\\end{tikzpicture}`;
-            const token = `@@TIKZ${tikzBlocks.length}@@`;
-            tikzBlocks.push(`\\[\\require{tikz}${body}\\]`);
-            return token;
-        });
-    }
     if (str.includes('<latex>')) {
         str = str.replace(/<latex>([\s\S]*?)<\/latex>/g, (_, tex) => `\\(${tex}\\)`);
     }
     str = str.replace(/\\[a-zA-Z]+(?:\{[^{}]*\})*/g, m => `\\(${m}\\)`);
-    tikzBlocks.forEach((block, i) => {
-        str = str.replace(`@@TIKZ${i}@@`, block);
-    });
     return str;
 }
 


### PR DESCRIPTION
## Summary
- drop MathJax TikZ configuration from training and revision pages
- simplify wrapLatex helpers by removing TikZ tag processing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d6610d6d08331b8d4671c55a3f6c7