### PR TITLE
Correct histogram daily success/failure counts

### DIFF
--- a/statistiques.js
+++ b/statistiques.js
@@ -94,6 +94,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         return;
     }
 
+    let globalMinDate = null;
+    rows.forEach(r => {
+        const d = parseDate(r[tIdx]);
+        if (d && (!globalMinDate || d < globalMinDate)) globalMinDate = d;
+    });
+    if (globalMinDate) globalMinDate.setHours(0, 0, 0, 0);
+
     rows = rows.filter(r => (r[pIdx] || '').trim().toLowerCase() === user.pseudo.toLowerCase());
     if (!rows.length) {
         container.innerHTML = '<p>Aucune donnée disponible.</p>';
@@ -113,7 +120,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         return Math.ceil(((date - yearStart) / 86400000 + 1) / 7);
     }
 
-    function groupRows(period, srcRows = rows) {
+    function groupRows(period, srcRows = rows, startDate = globalMinDate) {
         const map = new Map();
         srcRows.forEach(r => {
             const d = parseDate(r[tIdx]);
@@ -123,12 +130,37 @@ document.addEventListener('DOMContentLoaded', async () => {
             else {
                 key = `${d.getFullYear()}-W${String(getWeekNumber(d)).padStart(2, '0')}`;
             }
-            const entry = map.get(key) || { total: 0, success: 0 };
-            entry.total++;
+            const entry = map.get(key) || { success: 0, fail: 0 };
             if (parseFloat(r[sIdx] || '0') === 1) entry.success++;
+            else entry.fail++;
             map.set(key, entry);
         });
-        return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0])).map(([key, v]) => ({ key, total: v.total, success: v.success }));
+        if (!startDate) return [];
+
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const result = [];
+        if (period === 'day') {
+            for (let d = new Date(startDate); d <= today; d.setDate(d.getDate() + 1)) {
+                const key = d.toISOString().slice(0, 10);
+                const v = map.get(key) || { success: 0, fail: 0 };
+                result.push({ key, success: v.success, fail: v.fail });
+            }
+        } else {
+            let year = startDate.getFullYear();
+            let week = getWeekNumber(startDate);
+            const endYear = today.getFullYear();
+            const endWeek = getWeekNumber(today);
+            while (year < endYear || (year === endYear && week <= endWeek)) {
+                const key = `${year}-W${String(week).padStart(2, '0')}`;
+                const v = map.get(key) || { success: 0, fail: 0 };
+                result.push({ key, success: v.success, fail: v.fail });
+                week++;
+                const weeksInYear = getWeekNumber(new Date(year, 11, 31));
+                if (week > weeksInYear) { week = 1; year++; }
+            }
+        }
+        return result;
     }
     function formatDate(key) {
         const [year, month, day] = key.split('-');
@@ -141,7 +173,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const data = groupRows(period);
         const labels = data.map(d => period === 'week' ? `S${d.key.slice(-2)}` : formatDate(d.key));
         const success = data.map(d => d.success);
-        const fail = data.map(d => d.total - d.success);
+        const fail = data.map(d => d.fail);
         const chartData = {
             labels,
             datasets: [
@@ -206,7 +238,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const themeData = groupRows('day', obj.rows);
         const miniLabels = themeData.map(d => formatDate(d.key));
         const miniSuccess = themeData.map(d => d.success);
-        const miniFail = themeData.map(d => d.total - d.success);
+        const miniFail = themeData.map(d => d.fail);
         new Chart(miniCanvas, {
             type: 'bar',
             data: {


### PR DESCRIPTION
## Summary
- Track earliest history date and fill missing days through today
- Count successes and failures separately for daily/weekly histograms

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dabb6be2c8331b8de474b324d4657