### PR TITLE
Traite les dates JJ/MM/AAAA dans les statistiques

### DIFF
--- a/revision6E.js
+++ b/revision6E.js
@@ -128,14 +128,14 @@ function parseCSV(text) {
 }
 
 function parseDate(str) {
-    const d = new Date(str);
-    if (!isNaN(d)) return d;
+    if (!str) return null;
     const m = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2}))?)?$/);
     if (m) {
         const [, day, month, year, hh = '0', mm = '0', ss = '0'] = m;
         return new Date(+year, +month - 1, +day, +hh, +mm, +ss);
     }
-    return null;
+    const d = new Date(str);
+    return isNaN(d) ? null : d;
 }
 
 function shuffle(arr) {

--- a/statistiques.js
+++ b/statistiques.js
@@ -28,14 +28,14 @@ function parseCSV(text) {
 }
 
 function parseDate(str) {
-    const d = new Date(str);
-    if (!isNaN(d)) return d;
+    if (!str) return null;
     const m = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:[ T](\d{1,2}):(\d{2})(?::(\d{2}))?)?$/);
     if (m) {
         const [, day, month, year, hh = '0', mm = '0', ss = '0'] = m;
         return new Date(+year, +month - 1, +day, +hh, +mm, +ss);
     }
-    return null;
+    const d = new Date(str);
+    return isNaN(d) ? null : d;
 }
 
 async function loadStats() {


### PR DESCRIPTION
## Résumé
- Corrige le parseur de dates pour accepter le format JJ/MM/AAAA en priorité
- Évite les mauvaises interprétations des dates dans les historiques de questions

## Test
- `npm test` *(échoue : package.json absent)*

------
https://chatgpt.com/codex/tasks/task_e_689ec417a0c8833180e4d9170da072a8