### PR TITLE
Supprime les liens de navigation vers ICN (index.html) et SNT (SNT.html)

### DIFF
--- a/SNT.html
+++ b/SNT.html
@@ -13,9 +13,7 @@
         <h1>SNT - Niveau 2nde</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P1A.html
+++ b/SNT_P1A.html
@@ -11,7 +11,6 @@
         <h1>Projet 1A - La collecte des données personnelles : Le crédit social en Chine</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P2A.html
+++ b/SNT_P2A.html
@@ -13,7 +13,6 @@
         <h1>Projet 2A - Internet: Le VPN</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P2B.html
+++ b/SNT_P2B.html
@@ -13,7 +13,6 @@
         <h1>Projet 2A - Internet: La cybercriminalité</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P2C.html
+++ b/SNT_P2C.html
@@ -13,7 +13,6 @@
         <h1>Projet 2A - Internet: La neutralité du Net</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P3A.html
+++ b/SNT_P3A.html
@@ -13,7 +13,6 @@
         <h1>Projet 3A - Le web: La désinformation sur internet</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P4A.html
+++ b/SNT_P4A.html
@@ -13,7 +13,6 @@
         <h1>Projet 4A - La géolocalisation: Vidéo promotionnelle d’un circuit touristique</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/SNT_P5A.html
+++ b/SNT_P5A.html
@@ -13,7 +13,6 @@
         <h1>Projet 5A - La photographie numérique: Les extraterrestres débarquent au lycée !</h1>
         <nav>
             <ul>
-                <li><a href="SNT.html">Retour à la page d'accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/arduino.html
+++ b/arduino.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Arduino : Premiers pas vers la robotique </h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/arduinoCollege.html
+++ b/arduinoCollege.html
@@ -14,7 +14,6 @@
         <nav>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
         </nav>

--- a/badges.html
+++ b/badges.html
@@ -11,9 +11,7 @@
         <h1>Mes badges</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
                 <li><a href="videos.html">Vidéos</a></li>

--- a/cod.html
+++ b/cod.html
@@ -13,7 +13,6 @@
         <h1>Ateliers CodinGame : Maîtrise du Python à Travers des Défis d'IA et de Bot</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/crypt.html
+++ b/crypt.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Python : Cryptographie et Chiffrement à Travers les Âges</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/elec.html
+++ b/elec.html
@@ -13,7 +13,6 @@
         <h1>Ateliers d'Électricité : Fondements et Applications</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/eleves.html
+++ b/eleves.html
@@ -13,7 +13,6 @@
 			<h1>Élèves des Ateliers Informatique et Création Numérique</h1>
 			<nav>
 				<ul>
-					<li><a href="index.html">Accueil</a></li>
 					<li><a href="eleves.html" class="active">Élèves</a></li>
 					<li><a href="travaux.html">Travaux</a></li>
 					<li><a href="contact.html">Contact</a></li>

--- a/i3d.html
+++ b/i3d.html
@@ -14,7 +14,6 @@
         <nav>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
         </nav>

--- a/index.html
+++ b/index.html
@@ -13,9 +13,7 @@
         <h1>Ateliers Informatique et Création Numérique</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
                 <li><a href="videos.html">Vidéos</a></li>

--- a/jeux.html
+++ b/jeux.html
@@ -29,9 +29,7 @@
         <h1>Jeux</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
                 <li><a href="videos.html">Vidéos</a></li>

--- a/jv.html
+++ b/jv.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Jeux Vidéos sur scratch : Revivre l'histoire du jeux vidéo</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/nsm.html
+++ b/nsm.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Aventure Spatiale : Exploration Intergalactique et Apprentissage Multidisciplinaire</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Accueil</a></li>
                 <li><a href="eleves.html">Élèves</a></li>
                 <li><a href="travaux.html">Travaux</a></li>
                 <li><a href="contact.html">Contact</a></li>

--- a/projets.html
+++ b/projets.html
@@ -14,7 +14,6 @@
         <nav>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
         </nav>

--- a/pyg.html
+++ b/pyg.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Pygame : Création d'un RPG Pixel Art avec Python</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/pyt.html
+++ b/pyt.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Python : De l'initiation à Python à la création d'un RPG</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>

--- a/sentrainer.html
+++ b/sentrainer.html
@@ -12,9 +12,7 @@
         <h1>S'entrainer</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
             </ul>
         </nav>

--- a/suivi_projet.html
+++ b/suivi_projet.html
@@ -16,9 +16,7 @@
         <h1>Suivi Projet</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html" class="active">Suivi Projet</a></li>
             </ul>
         </nav>

--- a/techno.html
+++ b/techno.html
@@ -13,9 +13,7 @@
         <h1>Technologie - Cycle 4</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
             </ul>
         </nav>
     </header>

--- a/videos.html
+++ b/videos.html
@@ -11,9 +11,7 @@
         <h1>Vidéos</h1>
         <nav>
             <ul>
-                <li><a href="index.html">ICN</a></li>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="SNT.html">SNT</a></li>
                 <li><a href="suivi_projet.html">Suivi Projet</a></li>
                 <li><a href="jeux.html">Jeux</a></li>
                 <li><a href="videos.html">Vidéos</a></li>

--- a/vr.html
+++ b/vr.html
@@ -13,7 +13,6 @@
         <h1>Ateliers Réalité Virtuelle : Recréation Historique avec Unity</h1>
         <nav>
             <ul>
-                <li><a href="index.html">Retour à l'Accueil</a></li>
             </ul>
         </nav>
     </header>


### PR DESCRIPTION
### Motivation
- Les sections ICN (`index.html`) et SNT (`SNT.html`) ne doivent plus être exposées dans les menus du site, il faut donc retirer les liens de navigation et les liens de retour qui y faisaient référence.
- Nettoyer les en-têtes/navigation empêche la navigation vers des pages obsolètes et évite les liens morts dans les sous-pages de projet.

### Description
- Suppression des entrées de navigation pointant vers `index.html` et `SNT.html` dans les menus de l’ensemble des pages HTML du site (menus principaux et sous-pages de contenu). 
- Retrait des liens de retour vers `SNT.html` présents dans les pages de projets `SNT_P*` et retrait des liens similaires dans de nombreuses pages d’activité (`arduino.html`, `cod.html`, `crypt.html`, etc.).
- Les menus conservent désormais uniquement les liens pertinents (ex. `techno.html`, `suivi_projet.html`, `jeux.html`, `videos.html`).
- Modifications appliquées sur l’ensemble des fichiers HTML concernés (modifications répercutées dans une vingtaine de fichiers). 

### Testing
- Exécution d’une recherche globale avec `rg -n "href=\"(index|SNT)\.html\"" *.html` qui a retourné aucune occurrence restante, confirmant la suppression des liens. 
- Inspection de quelques en-têtes de pages (ex. `index.html`, `SNT.html`, `badges.html`, `arduino.html`) pour vérifier que la structure HTML des menus reste valide après les suppressions. 
- Aucune erreur automatique supplémentaire détectée par les vérifications effectuées après les changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6900f3348331adc623b540730753)