### PR TITLE
Refondre l'accueil et ajouter un sonomètre de classe

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,148 +4,64 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ateliers Informatique et Création Numérique du Lycée</title>
+    <title>Accueil - Technologie</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 
 <body>
     <header>
-        <h1>Ateliers Informatique et Création Numérique</h1>
+        <h1>Accueil</h1>
         <nav>
             <ul>
                 <li><a href="techno.html">Technologie</a></li>
-                <li><a href="suivi_projet.html">Suivi Projet</a></li>
-                <li><a href="jeux.html">Jeux</a></li>
-                <li><a href="videos.html">Vidéos</a></li>
             </ul>
         </nav>
-        <button id="login-btn">Se connecter</button>
     </header>
 
     <main>
-	<section class="description-ateliers">
-            <h2>Description des Ateliers - Niveau Collége</h2>
-
-            <!-- Bloc pour l'atelier 1 -->
-            <article class="atelier">
-                <img src="photos/jv.jpg" alt="Atelier jeux vidéo" loading="lazy">
-		<div class="atelier-content">
-			<h3>Ateliers Scratch </h3>
-			<p>
-				Découvrez les racines du gaming dans notre série de projets Scratch dédiée aux jeux rétro emblématiques. Vous allez programmer des classiques indémodables comme Space Invaders et Pac-Man, tout en maîtrisant les techniques de base de la création de jeux vidéo en 8 bits. À chaque étape, vous recréerez l'essence de ces légendes, apprendrez leur histoire et rendrez hommage à l'âge d'or de l'arcade. Embarquez pour un voyage nostalgique et éducatif au cœur de l'ère fondatrice du jeu vidéo !
-			</p>
-			<a href="jv.html">En savoir plus</a>
-		</div>
-            </article>
-            <article class="atelier">
-                <img src="photos/arduino00.jpg" alt="Atelier Arduino collège" loading="lazy">
-		<div class="atelier-content">
-			<h3>Ateliers Arduino : Premiers pas vers la robotique (niveau Collège)</h3>
-			<p>
-				Cette suite de projets centrée sur l'Arduino vous invite à explorer cette carte électronique à travers des exercices pratiques, allant de simples montages à des dispositifs plus élaborés tels qu'un compteur binaire ou un radar, utilisant des LEDs, des moteurs, des capteurs à ultrasons, des interrupteurs, et plus encore.
-			</p>
-			<a href="arduinoCollege.html">En savoir plus</a>
-		</div>
-            </article>
-       
-        </section>
-	<section class="description-ateliers">
-            <h2>Description des Ateliers - Niveau intermédiaire Collége/Lycée</h2>
-
-            <!-- Bloc pour l'atelier 1 -->
-	   <article class="atelier">
-                <img src="photos/PYT.PNG" alt="Atelier Python" loading="lazy">
-		<div class="atelier-content">
-			<h3>Ateliers Python : De l'initiation à Python à la création d'un RPG</h3>
-			<p>
-				Dans cette série d'ateliers, Python devient la langue de la création d'univers. Vous apprendrez non seulement à coder, mais aussi à construire des mondes, à designer des personnages et à orchestrer des aventures captivantes. Votre chemin à travers le codage vous mènera à la réalisation d'un RPG dynamique et interactif.
-			</p>
-			<a href="pyt.html">En savoir plus</a>
-		</div>
-            </article>
-            <article class="atelier">
-                <img src="photos/arduino00.jpg" alt="Atelier Arduino" loading="lazy">
-		<div class="atelier-content">
-			<h3>Ateliers Arduino : Premiers pas vers la robotique</h3>
-			<p>
-				Cette suite de projets centrée sur l'Arduino vous invite à explorer cette carte électronique à travers des exercices pratiques, allant de simples montages à des dispositifs plus élaborés tels qu'un compteur binaire ou un radar, utilisant des LEDs, des moteurs, des capteurs à ultrasons, des interrupteurs, et plus encore.
-			</p>
-			<a href="arduino.html">En savoir plus</a>
-		</div>
-            </article>
-        </section>
         <section class="description-ateliers">
-            <h2>Description des Ateliers - Niveau Lycée</h2>
-
-
-
-            <!-- Bloc pour l'atelier 2 -->
-			 <article class="atelier">
-                                <img src="photos/elec00.jpg" alt="Atelier électricité" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers d'Électricité : Fondements et Applications</h3>
-					<p>Explorez le vaste domaine de l'électricité à travers ces ateliers structurés et méthodiques. Dès le début, vous serez initiés aux principes fondamentaux, en commençant par la loi d'Ohm et en évoluant vers des notions plus avancées telles que le traitement du signal. Le point d'orgue de cet apprentissage sera la découverte des portes logiques et des signaux, piliers essentiels du fonctionnement des ordinateurs. Chaque séance conjugue théorie rigoureuse et pratique concrète, vous permettant ainsi de mettre en application vos connaissances à travers des montages électriques. Abordez l'électricité avec curiosité et rigueur, et éclairez votre chemin vers la maîtrise de cette science fondamentale.</p>
-					<a href="elec.html">En savoir plus</a>
-				</div>
-            </article>
-            <!-- Vous pouvez copier et coller le bloc ci-dessus et le modifier pour chaque atelier supplémentaire. -->
-			<article class="atelier">
-                                <img src="photos/i3D00.jfif" alt="Atelier impression 3D" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers de Modélisation et Impression 3D : De la Conception à la Réalisation</h3>
-					<p>Découvrez le monde fascinant de la modélisation et de l'impression 3D à travers nos ateliers structurés. Commencez par revisiter les bases, avant de progresser vers des projets plus complexes, tels que la conception d'objets techniques ou la reproduction de monuments historiques en détail. Poussez vos compétences encore plus loin en combinant l'impression 3D avec d'autres arts, comme la peinture et le modélisme, et intégrez des éléments électroniques pour créer des dioramas animés et illuminés. Élargissez vos horizons, innovez et donnez vie à vos idées tridimensionnelles.</p>
-					<a href="i3d.html">En savoir plus</a>
-				</div>
-            </article>
-			<article class="atelier">
-                                <img src="photos/crypt00.jfif" alt="Atelier cryptographie" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers Python : Cryptographie et Chiffrement à Travers les Âges</h3>
-					<p>Décryptez les mystères de la cryptographie grâce à nos ateliers Python dédiés au chiffrement. Naviguez à travers l'histoire, depuis les méthodes antiques comme le code de César jusqu'aux techniques modernes comme la stéganographie. Enrichissez vos compétences en Python en relevant des défis stimulants, tels que la création d'un programme capable de briser le code de César. Approfondissez vos connaissances, développez votre esprit critique et devenez un véritable expert en sécurité des informations.</p>
-					<a href="crypt.html">En savoir plus</a>
-				</div>
-            </article>
-			<article class="atelier">
-                                <img src="photos/pyg00.png" alt="Atelier Pygame" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers Pygame : Création d'un RPG Pixel Art avec Python</h3>
-					<p>Lancez-vous dans une aventure captivante avec les ateliers Pygame dédiés à la création de jeux. Découvrez comment le langage Python peut être utilisé pour donner vie à vos visions ludiques, en élaborant un jeu de rôle (RPG) aux graphismes pixel art soignés. Explorez les mécanismes du développement de jeux, de la conception de scénarios à la réalisation d'interactions en passant par le design graphique. Finalisez votre voyage en créant un véritable RPG, tout en maîtrisant les subtilités du Python et du développement de jeux.</p>
-					<a href="pyg.html">En savoir plus</a>
-				</div>
-            </article>
-			<article class="atelier">
-                                <img src="photos/cod00.jfif" alt="Atelier CodinGame" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers CodinGame : Maîtrise du Python à Travers des Défis d'IA et de Bot</h3>
-					<p>Élevez votre compréhension du Python à un niveau supérieur grâce à aux ateliers CodinGame axés sur des défis exigeants. Plongez dans le monde fascinant de l'intelligence artificielle et développez des bots sophistiqués, programmés pour triompher dans les challenges CodinGame. Bien que ces ateliers adoptent une approche ludique, ils représentent l'un des plus grands challenges proposés en ICN, mettant à l'épreuve même les esprits les plus aguerris. Affrontez ces défis, démontrez vos compétences en Python et surpassez-vous dans l'art de la programmation compétitive.</p>
-					<a href="cod.html">En savoir plus</a>
-				</div>
-            </article>
-			
-			<article class="atelier">
-                                <img src="photos/VR00.png" alt="Atelier réalité virtuelle" loading="lazy">
-				<div class="atelier-content">
-					<h3>Ateliers Réalité Virtuelle : Recréation Historique avec Unity</h3>
-					<p>Plongez au cœur de l'histoire grâce à ces ateliers de réalité virtuelle. Utilisez le puissant moteur Unity pour reconstruire méticuleusement des bâtiments historiques emblématiques, offrant une immersion profonde dans le passé. Apprenez les subtilités de la modélisation 3D, du rendu et de la programmation spécifique à la réalité virtuelle pour transposer ces édifices dans un univers interactif. Ces ateliers, alliant patrimoine culturel et technologie de pointe, vous guideront à travers un voyage temporel, où l'histoire prend vie à travers le prisme de la réalité virtuelle. Développez vos compétences, réinventez le passé et expérimentez le futur de la narration interactive.</p>
-					<a href="vr.html">En savoir plus</a>
-				</div>
-            </article>
-		<article class="atelier">
-                                <img src="photos/R2D201.png" alt="Projets étudiants" loading="lazy">
-				<div class="atelier-content">
-					<h3>Quelques projets réalisés par les élèves</h3>
-					<p>Découvrez quelques projets effectués par les élèves dans le cadre des ateliers d'ICN</p>
-					<a href="projets.html">En savoir plus</a>
-				</div>
+            <article class="atelier">
+                <div class="atelier-content">
+                    <h2>Accès rapide</h2>
+                    <p>Accéder aux contenus de Technologie Cycle 4.</p>
+                    <a href="techno.html">Aller à la page Technologie</a>
+                </div>
             </article>
         </section>
 
+        <section class="description-ateliers">
+            <article class="atelier sonometre-card">
+                <div class="atelier-content">
+                    <h2>Sonomètre de classe</h2>
+                    <p>Utilisez ce sonomètre pour réguler le bruit pendant les activités. Le compteur augmente à chaque dépassement du seuil.</p>
 
+                    <div class="sonometre-controls">
+                        <label for="seuil">Seuil de bruit (%) :</label>
+                        <input id="seuil" type="range" min="10" max="90" value="55">
+                        <span id="seuil-valeur">55%</span>
+                    </div>
+
+                    <div class="barre-wrapper" aria-label="Niveau sonore en direct">
+                        <div id="barre-niveau" class="barre-niveau"></div>
+                    </div>
+
+                    <p id="niveau-live">Niveau actuel : 0%</p>
+                    <p id="depassements">Dépassements : 0</p>
+
+                    <div class="sonometre-actions">
+                        <button id="start-sonometre" type="button">Démarrer le sonomètre</button>
+                        <button id="reset-compteur" type="button">Réinitialiser le compteur</button>
+                    </div>
+                </div>
+            </article>
+        </section>
     </main>
+
     <footer>
         <p>© Lycée XXXX - Tous droits réservés.</p>
     </footer>
-    <script src="auth.js"></script>
+
+    <script src="sonometre.js"></script>
 </body>
 
 </html>

--- a/sonometre.js
+++ b/sonometre.js
@@ -1,0 +1,83 @@
+(() => {
+  const seuilInput = document.getElementById('seuil');
+  const seuilValeur = document.getElementById('seuil-valeur');
+  const barreNiveau = document.getElementById('barre-niveau');
+  const niveauLive = document.getElementById('niveau-live');
+  const depassementsEl = document.getElementById('depassements');
+  const startBtn = document.getElementById('start-sonometre');
+  const resetBtn = document.getElementById('reset-compteur');
+
+  if (!seuilInput || !startBtn) return;
+
+  let audioContext;
+  let analyser;
+  let dataArray;
+  let depassements = 0;
+  let lastTriggerAt = 0;
+  const triggerCooldownMs = 1200;
+
+  const updateSeuilLabel = () => {
+    seuilValeur.textContent = `${seuilInput.value}%`;
+  };
+
+  const normalizeVolume = (arr) => {
+    let sum = 0;
+    for (let i = 0; i < arr.length; i += 1) {
+      const centered = arr[i] - 128;
+      sum += centered * centered;
+    }
+    const rms = Math.sqrt(sum / arr.length);
+    return Math.min(100, Math.round((rms / 64) * 100));
+  };
+
+  const render = () => {
+    if (!analyser) return;
+    analyser.getByteTimeDomainData(dataArray);
+    const level = normalizeVolume(dataArray);
+    const seuil = Number(seuilInput.value);
+
+    barreNiveau.style.width = `${level}%`;
+    barreNiveau.classList.toggle('warning', level >= seuil);
+    niveauLive.textContent = `Niveau actuel : ${level}%`;
+
+    const now = Date.now();
+    if (level >= seuil && now - lastTriggerAt > triggerCooldownMs) {
+      depassements += 1;
+      lastTriggerAt = now;
+      depassementsEl.textContent = `Dépassements : ${depassements}`;
+    }
+
+    requestAnimationFrame(render);
+  };
+
+  const start = async () => {
+    startBtn.disabled = true;
+    startBtn.textContent = 'Sonomètre actif';
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      const source = audioContext.createMediaStreamSource(stream);
+
+      analyser = audioContext.createAnalyser();
+      analyser.fftSize = 1024;
+      dataArray = new Uint8Array(analyser.frequencyBinCount);
+      source.connect(analyser);
+
+      render();
+    } catch (err) {
+      startBtn.disabled = false;
+      startBtn.textContent = 'Démarrer le sonomètre';
+      niveauLive.textContent = 'Niveau actuel : accès micro refusé ou indisponible.';
+    }
+  };
+
+  seuilInput.addEventListener('input', updateSeuilLabel);
+  startBtn.addEventListener('click', start);
+  resetBtn.addEventListener('click', () => {
+    depassements = 0;
+    depassementsEl.textContent = 'Dépassements : 0';
+  });
+
+  updateSeuilLabel();
+})();

--- a/styles.css
+++ b/styles.css
@@ -942,3 +942,65 @@ header {
 
 
 svg.axe { display: block; margin: 0.5em 0; }
+
+.sonometre-card {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.sonometre-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin: 10px 0;
+}
+
+#seuil {
+    accent-color: #1e90ff;
+}
+
+.barre-wrapper {
+    width: 100%;
+    height: 28px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background-color: rgba(0, 0, 0, 0.45);
+    overflow: hidden;
+    margin: 12px 0;
+}
+
+.barre-niveau {
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, #1e90ff, #4da3ff);
+    transition: width 0.2s ease;
+}
+
+.barre-niveau.warning {
+    background: linear-gradient(90deg, #ff7a7a, #ff1f1f);
+}
+
+.sonometre-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.sonometre-actions button {
+    border: 1px solid #fff;
+    border-radius: 5px;
+    color: #fff;
+    background-color: #1e90ff;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.sonometre-actions button:hover {
+    background-color: #0000ff;
+}
+
+.sonometre-actions button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/techno.html
+++ b/techno.html
@@ -13,6 +13,7 @@
         <h1>Technologie - Cycle 4</h1>
         <nav>
             <ul>
+                <li><a href="index.html">Accueil</a></li>
                 <li><a href="techno.html">Technologie</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
### Motivation
- Mettre en place une vraie page d'entrée nommée « Accueil » qui dirige vers la section Technologie. 
- Fournir un outil visuel et simple (sonomètre) pour aider à réguler le bruit en classe pendant les activités. 
- Conserver le même style graphique que le site tout en ajoutant des contrôles accessibles et un compteur de dépassements.

### Description
- Remplace le contenu de la page d'accueil par une page `index.html` simplifiée intitulée « Accueil » contenant un lien vers `techno.html` et une carte dédiée au sonomètre. 
- Ajoute `sonometre.js` qui utilise `getUserMedia` pour capturer l'audio, calcule un niveau normalisé, met à jour une barre graphique et incrémente un compteur de dépassements avec anti-rebond. 
- Ajoute les règles CSS dans `styles.css` (`.sonometre-card`, `.barre-wrapper`, `.barre-niveau`, contrôles et boutons) pour intégrer visuellement le sonomètre au thème existant. 
- Met à jour `techno.html` pour inclure un lien de retour vers `index.html` dans la navigation.

### Testing
- Exécution de `git diff --check` pour vérifier les erreurs de diff/espaces, résultat : succès. 
- Vérification de la syntaxe du script avec `node --check sonometre.js`, résultat : succès. 
- Aucune erreur de build ou de lint automatisé détectée dans cet environnement de test (exécution locale limitée au contrôle de syntaxe et diff).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6dc0317c8331b0906cb1b4280a9f)