### PR TITLE
Retire le bloc « Accès rapide » et ajoute une alerte sonore au sonomètre

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,19 +20,9 @@
 
     <main>
         <section class="description-ateliers">
-            <article class="atelier">
-                <div class="atelier-content">
-                    <h2>Accès rapide</h2>
-                    <p>Accéder aux contenus de Technologie Cycle 4.</p>
-                    <a href="techno.html">Aller à la page Technologie</a>
-                </div>
-            </article>
-        </section>
-
-        <section class="description-ateliers">
             <article class="atelier sonometre-card">
                 <div class="atelier-content">
-                    <h2>Sonomètre de classe</h2>
+                    <h2>Régulation du bruit</h2>
                     <p>Utilisez ce sonomètre pour réguler le bruit pendant les activités. Le compteur augmente à chaque dépassement du seuil.</p>
 
                     <div class="sonometre-controls">

--- a/sonometre.js
+++ b/sonometre.js
@@ -16,6 +16,26 @@
   let lastTriggerAt = 0;
   const triggerCooldownMs = 1200;
 
+  const playAlertSignal = () => {
+    if (!audioContext) return;
+
+    const oscillator = audioContext.createOscillator();
+    const gainNode = audioContext.createGain();
+    const now = audioContext.currentTime;
+
+    oscillator.type = 'sine';
+    oscillator.frequency.setValueAtTime(880, now);
+    gainNode.gain.setValueAtTime(0.0001, now);
+    gainNode.gain.exponentialRampToValueAtTime(0.2, now + 0.01);
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.25);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(audioContext.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + 0.25);
+  };
+
   const updateSeuilLabel = () => {
     seuilValeur.textContent = `${seuilInput.value}%`;
   };
@@ -45,6 +65,7 @@
       depassements += 1;
       lastTriggerAt = now;
       depassementsEl.textContent = `Dépassements : ${depassements}`;
+      playAlertSignal();
     }
 
     requestAnimationFrame(render);


### PR DESCRIPTION
### Motivation
- Simplifier la page d'accueil en supprimant le bloc « Accès rapide » et recentrer l'interface sur l'outil de régulation du bruit.
- Rendre le sonomètre plus utile en alertant auditivement lorsqu'un seuil de bruit est dépassé.

### Description
- `index.html` : suppression de la section « Accès rapide » et renommage du titre de la carte sonomètre en `Régulation du bruit`.
- `sonometre.js` : ajout de la fonction `playAlertSignal()` utilisant l'API Web Audio (oscillateur + gain) pour émettre un court bip.
- `sonometre.js` : appel de `playAlertSignal()` lors d'un dépassement du seuil existant, en respectant le cooldown déjà présent.

### Testing
- Aucun test automatisé n'est configuré pour ce projet, les modifications ont été vérifiées en inspectant les fichiers modifiés et le diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da712063c0833181b385f529caf887)