### PR TITLE
Ajout pause/reprise et contrôles manuels du compteur du sonomètre

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,9 @@
 
                     <div class="sonometre-actions">
                         <button id="start-sonometre" type="button">Démarrer le sonomètre</button>
+                        <button id="pause-sonometre" type="button" disabled>Mettre en pause</button>
+                        <button id="decrement-compteur" type="button">-1 dépassement</button>
+                        <button id="increment-compteur" type="button">+1 dépassement</button>
                         <button id="reset-compteur" type="button">Réinitialiser le compteur</button>
                     </div>
                 </div>

--- a/sonometre.js
+++ b/sonometre.js
@@ -5,35 +5,48 @@
   const niveauLive = document.getElementById('niveau-live');
   const depassementsEl = document.getElementById('depassements');
   const startBtn = document.getElementById('start-sonometre');
+  const pauseBtn = document.getElementById('pause-sonometre');
+  const decrementBtn = document.getElementById('decrement-compteur');
+  const incrementBtn = document.getElementById('increment-compteur');
   const resetBtn = document.getElementById('reset-compteur');
 
-  if (!seuilInput || !startBtn) return;
+  if (!seuilInput || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn) return;
 
   let audioContext;
   let analyser;
   let dataArray;
   let depassements = 0;
   let lastTriggerAt = 0;
+  let isPaused = false;
   const triggerCooldownMs = 1200;
 
   const playAlertSignal = () => {
     if (!audioContext) return;
 
-    const oscillator = audioContext.createOscillator();
-    const gainNode = audioContext.createGain();
     const now = audioContext.currentTime;
+    const envelope = audioContext.createGain();
+    envelope.gain.setValueAtTime(0.0001, now);
+    envelope.gain.exponentialRampToValueAtTime(0.55, now + 0.02);
+    envelope.gain.exponentialRampToValueAtTime(0.0001, now + 0.5);
+    envelope.connect(audioContext.destination);
 
-    oscillator.type = 'sine';
-    oscillator.frequency.setValueAtTime(880, now);
-    gainNode.gain.setValueAtTime(0.0001, now);
-    gainNode.gain.exponentialRampToValueAtTime(0.2, now + 0.01);
-    gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.25);
+    const freqs = [920, 640, 920];
+    const beepDuration = 0.12;
+    const gap = 0.05;
 
-    oscillator.connect(gainNode);
-    gainNode.connect(audioContext.destination);
+    freqs.forEach((freq, index) => {
+      const oscillator = audioContext.createOscillator();
+      const startAt = now + index * (beepDuration + gap);
+      oscillator.type = 'square';
+      oscillator.frequency.setValueAtTime(freq, startAt);
+      oscillator.connect(envelope);
+      oscillator.start(startAt);
+      oscillator.stop(startAt + beepDuration);
+    });
+  };
 
-    oscillator.start(now);
-    oscillator.stop(now + 0.25);
+  const updateCompteur = () => {
+    depassementsEl.textContent = `Dépassements : ${depassements}`;
   };
 
   const updateSeuilLabel = () => {
@@ -52,6 +65,12 @@
 
   const render = () => {
     if (!analyser) return;
+
+    if (isPaused) {
+      requestAnimationFrame(render);
+      return;
+    }
+
     analyser.getByteTimeDomainData(dataArray);
     const level = normalizeVolume(dataArray);
     const seuil = Number(seuilInput.value);
@@ -64,7 +83,7 @@
     if (level >= seuil && now - lastTriggerAt > triggerCooldownMs) {
       depassements += 1;
       lastTriggerAt = now;
-      depassementsEl.textContent = `Dépassements : ${depassements}`;
+      updateCompteur();
       playAlertSignal();
     }
 
@@ -84,6 +103,8 @@
       analyser.fftSize = 1024;
       dataArray = new Uint8Array(analyser.frequencyBinCount);
       source.connect(analyser);
+      pauseBtn.disabled = false;
+      pauseBtn.textContent = 'Mettre en pause';
 
       render();
     } catch (err) {
@@ -93,11 +114,35 @@
     }
   };
 
+  const togglePause = async () => {
+    if (!audioContext) return;
+
+    if (!isPaused) {
+      isPaused = true;
+      pauseBtn.textContent = 'Reprendre';
+      niveauLive.textContent = 'Niveau actuel : pause';
+      await audioContext.suspend();
+    } else {
+      isPaused = false;
+      pauseBtn.textContent = 'Mettre en pause';
+      await audioContext.resume();
+    }
+  };
+
   seuilInput.addEventListener('input', updateSeuilLabel);
   startBtn.addEventListener('click', start);
+  pauseBtn.addEventListener('click', togglePause);
+  decrementBtn.addEventListener('click', () => {
+    depassements = Math.max(0, depassements - 1);
+    updateCompteur();
+  });
+  incrementBtn.addEventListener('click', () => {
+    depassements += 1;
+    updateCompteur();
+  });
   resetBtn.addEventListener('click', () => {
     depassements = 0;
-    depassementsEl.textContent = 'Dépassements : 0';
+    updateCompteur();
   });
 
   updateSeuilLabel();


### PR DESCRIPTION
### Motivation
- Permettre de mettre le sonomètre en pause/reprise pendant l’utilisation, et d’ajuster manuellement le compteur de dépassements, tout en rendant le signal sonore de dépassement plus audible (alarme). 

### Description
- Ajout de trois boutons dans l’interface (`pause-sonometre`, `decrement-compteur`, `increment-compteur`) et activation du bouton de pause après démarrage (`index.html`).
- Implémentation en JS de l’état pause avec suspension/reprise de l’`AudioContext` via la fonction `togglePause`, et protection de la boucle de rendu quand `isPaused` est vrai (`sonometre.js`).
- Ajout des handlers pour incrémenter/décrémenter et centralisation de l’affichage du compteur dans `updateCompteur`, plus mise à jour des interactions existantes (reset/start).
- Renforcement du signal d’alerte dans `playAlertSignal` en utilisant une enveloppe de gain plus forte et une séquence de bips en onde carrée pour un effet d’alarme plus marqué.

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check sonometre.js` qui a réussi. 
- Aucune autre validation automatisée navigateur n’a été exécutée dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da73ecbe888331ab6a376772603948)