### PR TITLE
Corrige remplissage du sonomètre, active le bouton pause et ajoute un indicateur de seuil

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
 
                     <div class="barre-wrapper" aria-label="Niveau sonore en direct">
                         <div id="barre-niveau" class="barre-niveau"></div>
+                        <div id="seuil-marker" class="seuil-marker" aria-hidden="true">
+                            <span id="seuil-marker-label" class="seuil-marker-label">55%</span>
+                        </div>
                     </div>
 
                     <p id="niveau-live">Niveau actuel : 0%</p>
@@ -40,7 +43,7 @@
 
                     <div class="sonometre-actions">
                         <button id="start-sonometre" type="button">Démarrer le sonomètre</button>
-                        <button id="pause-sonometre" type="button" disabled>Mettre en pause</button>
+                        <button id="pause-sonometre" type="button">Mettre en pause</button>
                         <button id="decrement-compteur" type="button">-1 dépassement</button>
                         <button id="increment-compteur" type="button">+1 dépassement</button>
                         <button id="reset-compteur" type="button">Réinitialiser le compteur</button>

--- a/sonometre.js
+++ b/sonometre.js
@@ -2,6 +2,8 @@
   const seuilInput = document.getElementById('seuil');
   const seuilValeur = document.getElementById('seuil-valeur');
   const barreNiveau = document.getElementById('barre-niveau');
+  const seuilMarker = document.getElementById('seuil-marker');
+  const seuilMarkerLabel = document.getElementById('seuil-marker-label');
   const niveauLive = document.getElementById('niveau-live');
   const depassementsEl = document.getElementById('depassements');
   const startBtn = document.getElementById('start-sonometre');
@@ -10,7 +12,7 @@
   const incrementBtn = document.getElementById('increment-compteur');
   const resetBtn = document.getElementById('reset-compteur');
 
-  if (!seuilInput || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn) return;
+  if (!seuilInput || !barreNiveau || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn) return;
 
   let audioContext;
   let analyser;
@@ -50,7 +52,15 @@
   };
 
   const updateSeuilLabel = () => {
-    seuilValeur.textContent = `${seuilInput.value}%`;
+    const seuil = Number(seuilInput.value);
+    seuilValeur.textContent = `${seuil}%`;
+
+    if (seuilMarker) {
+      seuilMarker.style.left = `${seuil}%`;
+      if (seuilMarkerLabel) {
+        seuilMarkerLabel.textContent = `${seuil}%`;
+      }
+    }
   };
 
   const normalizeVolume = (arr) => {
@@ -104,6 +114,7 @@
       dataArray = new Uint8Array(analyser.frequencyBinCount);
       source.connect(analyser);
       pauseBtn.disabled = false;
+      pauseBtn.removeAttribute('disabled');
       pauseBtn.textContent = 'Mettre en pause';
 
       render();
@@ -145,5 +156,7 @@
     updateCompteur();
   });
 
+  pauseBtn.disabled = false;
+  pauseBtn.removeAttribute('disabled');
   updateSeuilLabel();
 })();

--- a/styles.css
+++ b/styles.css
@@ -961,6 +961,7 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .barre-wrapper {
+    position: relative;
     width: 100%;
     height: 28px;
     border-radius: 14px;
@@ -968,13 +969,37 @@ svg.axe { display: block; margin: 0.5em 0; }
     background-color: rgba(0, 0, 0, 0.45);
     overflow: hidden;
     margin: 12px 0;
+    box-sizing: border-box;
 }
 
 .barre-niveau {
     height: 100%;
-    width: 0;
+    width: 0%;
     background: linear-gradient(90deg, #1e90ff, #4da3ff);
-    transition: width 0.2s ease;
+    transition: none;
+}
+
+
+.seuil-marker {
+    position: absolute;
+    left: 55%;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background-color: #ffffff;
+    transform: translateX(-50%);
+    pointer-events: none;
+}
+
+.seuil-marker-label {
+    position: absolute;
+    top: -22px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #ffffff;
+    white-space: nowrap;
 }
 
 .barre-niveau.warning {


### PR DESCRIPTION
### Motivation
- Le remplissage de la barre de niveau devait refléter proportionnellement le pourcentage mesuré sans décalage visuel causé par la transition CSS. 
- Le bouton « Mettre en pause » était inactif côté HTML/JS et devait être cliquable pour permettre la pause/reprise. 
- Il manquait un repère visuel montrant le seuil sélectionné directement sur la barre de progression pour faciliter la lecture.

### Description
- Ajout d’un marqueur de seuil dans `index.html` avec un label dynamique (`#seuil-marker` et `#seuil-marker-label`) et suppression de l’attribut `disabled` sur le bouton pause. 
- Mise à jour de `sonometre.js` pour référencer le marqueur et son label, positionner le marqueur dans `updateSeuilLabel`, assurer la présence de `barreNiveau` avant d’initier le script, et forcer l’activation du bouton pause (`removeAttribute('disabled')`). 
- Ajustements CSS dans `styles.css` pour rendre `.barre-wrapper` positionnée, définir `.barre-niveau` avec `width: 0%` et sans transition pour éviter les effets de décalage, et ajout des styles `.seuil-marker` et `.seuil-marker-label` pour afficher le trait vertical et son pourcentage. 
- Fichiers modifiés : `index.html`, `sonometre.js`, `styles.css`.

### Testing
- Executed `node --check sonometre.js` and it completed successfully. 
- Ran `git status --short` to validate the working tree state after changes and it reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9dcfbb148331aa60f36c4af5cdab)