### PR TITLE
Afficher les prochains événements Google Agenda (préfixe 5E1) sur la page d'accueil

### DIFF
--- a/calendar-events.js
+++ b/calendar-events.js
@@ -1,0 +1,103 @@
+(function () {
+    const CALENDAR_CONFIG = {
+        apiKey: '',
+        calendarId: '',
+        maxResults: 8,
+        eventPrefix: '5E1'
+    };
+
+    const listElement = document.getElementById('calendar-events-list');
+    const statusElement = document.getElementById('calendar-status');
+
+    if (!listElement || !statusElement) {
+        return;
+    }
+
+    function setStatus(message, isError) {
+        statusElement.textContent = message;
+        statusElement.classList.toggle('calendar-error', Boolean(isError));
+    }
+
+    function formatDate(isoDate, timeZone) {
+        const date = new Date(isoDate);
+        const options = {
+            weekday: 'short',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            timeZone: timeZone || 'Europe/Paris'
+        };
+
+        return new Intl.DateTimeFormat('fr-FR', options).format(date);
+    }
+
+    function renderEvents(events, timeZone) {
+        listElement.innerHTML = '';
+
+        if (!events.length) {
+            const item = document.createElement('li');
+            item.textContent = 'Aucun événement à venir commençant par « 5E1 ».';
+            listElement.appendChild(item);
+            setStatus('Mise à jour effectuée.');
+            return;
+        }
+
+        events.forEach((eventItem) => {
+            const item = document.createElement('li');
+            const startValue = eventItem.start.dateTime || eventItem.start.date;
+
+            const title = document.createElement('strong');
+            title.textContent = eventItem.summary;
+
+            const start = document.createElement('div');
+            start.textContent = `Début : ${formatDate(startValue, timeZone)}`;
+
+            item.appendChild(title);
+            item.appendChild(start);
+            listElement.appendChild(item);
+        });
+
+        setStatus('Mise à jour effectuée.');
+    }
+
+    async function loadCalendarEvents() {
+        if (!CALENDAR_CONFIG.apiKey || !CALENDAR_CONFIG.calendarId) {
+            setStatus('Renseignez apiKey et calendarId dans calendar-events.js pour activer cette section.', true);
+            return;
+        }
+
+        const params = new URLSearchParams({
+            key: CALENDAR_CONFIG.apiKey,
+            singleEvents: 'true',
+            orderBy: 'startTime',
+            timeMin: new Date().toISOString(),
+            maxResults: String(CALENDAR_CONFIG.maxResults)
+        });
+
+        const endpoint = `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(CALENDAR_CONFIG.calendarId)}/events?${params.toString()}`;
+
+        try {
+            setStatus('Chargement des événements Google Agenda...');
+            const response = await fetch(endpoint);
+
+            if (!response.ok) {
+                throw new Error(`Erreur API Google Calendar (${response.status}).`);
+            }
+
+            const payload = await response.json();
+            const items = Array.isArray(payload.items) ? payload.items : [];
+            const filtered = items.filter((eventItem) => {
+                const summary = eventItem.summary || '';
+                return summary.toUpperCase().startsWith(CALENDAR_CONFIG.eventPrefix.toUpperCase());
+            });
+
+            renderEvents(filtered, payload.timeZone);
+        } catch (error) {
+            setStatus(`Impossible de charger l'agenda : ${error.message}`, true);
+        }
+    }
+
+    loadCalendarEvents();
+})();

--- a/index.html
+++ b/index.html
@@ -56,6 +56,17 @@
                 </div>
             </article>
         </section>
+        <section class="description-ateliers">
+            <article class="atelier agenda-card">
+                <div class="atelier-content">
+                    <h2>Prochains événements Google Agenda</h2>
+                    <p>Affiche uniquement les événements dont le titre commence par <strong>5E1</strong>.</p>
+                    <p id="calendar-status" class="calendar-status" aria-live="polite">Initialisation...</p>
+                    <ul id="calendar-events-list" class="calendar-events-list"></ul>
+                </div>
+            </article>
+        </section>
+
     </main>
 
     <footer>
@@ -63,6 +74,7 @@
     </footer>
 
     <script src="sonometre.js"></script>
+    <script src="calendar-events.js"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1029,3 +1029,34 @@ svg.axe { display: block; margin: 0.5em 0; }
     opacity: 0.6;
     cursor: not-allowed;
 }
+
+.agenda-card {
+    align-items: flex-start;
+}
+
+.calendar-status {
+    font-style: italic;
+    margin-bottom: 12px;
+}
+
+.calendar-error {
+    color: #ffb3b3;
+}
+
+.calendar-events-list {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.calendar-events-list li {
+    margin-bottom: 10px;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 6px;
+    padding: 10px;
+}
+
+.calendar-events-list strong {
+    display: block;
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
### Motivation
- Afficher sur la page d'accueil les prochains événements pertinents issus de Google Agenda en filtrant les titres commençant par `5E1` pour rendre l'information facilement accessible.
- Permettre d'indiquer clairement l'état du chargement et les erreurs côté client lorsque la configuration (clé API / identifiant de calendrier) manque ou que l'API renvoie une erreur.

### Description
- Ajout d'une nouvelle section dans `index.html` qui contient la carte « Prochains événements Google Agenda » et le point d'insertion pour la liste et le statut de chargement, plus l'inclusion du script `calendar-events.js`.
- Nouveau fichier `calendar-events.js` qui appelle l'API Google Calendar v3 (paramètres `singleEvents=true`, `orderBy=startTime`, `timeMin=now`), filtre les événements dont le `summary` commence par le préfixe configurable `eventPrefix` (`5E1` par défaut), formate la date en `fr-FR` (timezone `Europe/Paris`) et rend titre + date de début, avec messages de statut et gestion d'erreur.
- Mise à jour de `styles.css` pour ajouter le style de la carte agenda, du statut (`.calendar-status`, `.calendar-error`) et de la liste d'événements (`.calendar-events-list`) pour un rendu cohérent.
- Remarque de configuration : renseigner `CALENDAR_CONFIG.apiKey` et `CALENDAR_CONFIG.calendarId` dans `calendar-events.js` pour activer le chargement réel des événements.

### Testing
- Exécution de la vérification de syntaxe JavaScript `node --check calendar-events.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5b5f1324833196d25033b07bc36a)