### PR TITLE
Remplacer le widget Google Agenda de l'accueil par le suivi Google Sheets

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -1,0 +1,217 @@
+(function () {
+    const SHEET_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pub?output=csv';
+
+    const classSelect = document.getElementById('progression-classe');
+    const projectSelect = document.getElementById('progression-projet');
+    const statusElement = document.getElementById('progression-status');
+    const listElement = document.getElementById('progression-steps-list');
+
+    if (!classSelect || !projectSelect || !statusElement || !listElement) {
+        return;
+    }
+
+    let allRows = [];
+    let classIdx = -1;
+    let projectIdx = -1;
+    let dateIdx = -1;
+    let stepIdx = -1;
+
+    function normalize(value) {
+        return (value || '')
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .trim();
+    }
+
+    function parseCSV(text) {
+        const rows = [];
+        let current = '';
+        let row = [];
+        let inQuotes = false;
+
+        for (let i = 0; i < text.length; i++) {
+            const char = text[i];
+            if (inQuotes) {
+                if (char === '"') {
+                    if (text[i + 1] === '"') {
+                        current += '"';
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    current += char;
+                }
+            } else if (char === '"') {
+                inQuotes = true;
+            } else if (char === ',') {
+                row.push(current);
+                current = '';
+            } else if (char === '\n') {
+                row.push(current);
+                rows.push(row);
+                row = [];
+                current = '';
+            } else if (char !== '\r') {
+                current += char;
+            }
+        }
+
+        if (current || row.length) {
+            row.push(current);
+        }
+        if (row.length) {
+            rows.push(row);
+        }
+
+        return rows;
+    }
+
+    function parseDate(value) {
+        const [d, m, y] = (value || '').split('/');
+        if (!d || !m || !y) {
+            return null;
+        }
+        const date = new Date(`${y}-${m}-${d}`);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    function setStatus(message, isError) {
+        statusElement.textContent = message;
+        statusElement.classList.toggle('calendar-error', Boolean(isError));
+    }
+
+    function fillSelect(select, values) {
+        select.innerHTML = '';
+        values.forEach((value) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = value;
+            select.appendChild(option);
+        });
+        select.disabled = values.length === 0;
+    }
+
+    function renderSteps() {
+        const selectedClass = classSelect.value;
+        const selectedProject = projectSelect.value;
+
+        const filtered = allRows
+            .filter((row) => row[classIdx] === selectedClass && row[projectIdx] === selectedProject)
+            .map((row) => ({
+                dateText: row[dateIdx] || '',
+                dateValue: parseDate(row[dateIdx]),
+                stepText: row[stepIdx] || 'Étape non renseignée'
+            }))
+            .sort((a, b) => {
+                if (!a.dateValue && !b.dateValue) return 0;
+                if (!a.dateValue) return 1;
+                if (!b.dateValue) return -1;
+                return a.dateValue - b.dateValue;
+            });
+
+        listElement.innerHTML = '';
+
+        if (!filtered.length) {
+            setStatus('Aucune étape trouvée pour cette sélection.', true);
+            return;
+        }
+
+        filtered.forEach((entry) => {
+            const item = document.createElement('li');
+            const strong = document.createElement('strong');
+            strong.textContent = entry.dateText || 'Date non renseignée';
+
+            const details = document.createElement('div');
+            details.textContent = `Étape : ${entry.stepText}`;
+
+            item.appendChild(strong);
+            item.appendChild(details);
+            listElement.appendChild(item);
+        });
+
+        setStatus(`${filtered.length} étape(s) affichée(s).`);
+    }
+
+    function updateProjects() {
+        const selectedClass = classSelect.value;
+        const projects = Array.from(
+            new Set(
+                allRows
+                    .filter((row) => row[classIdx] === selectedClass)
+                    .map((row) => row[projectIdx])
+                    .filter(Boolean)
+            )
+        ).sort((a, b) => a.localeCompare(b, 'fr'));
+
+        fillSelect(projectSelect, projects);
+        if (projects.length) {
+            projectSelect.value = projects[0];
+            renderSteps();
+        } else {
+            listElement.innerHTML = '';
+            setStatus('Aucun projet disponible pour cette classe.', true);
+        }
+    }
+
+    async function loadRows() {
+        let header = [];
+        let rows = [];
+
+        try {
+            const response = await fetch(`${SHEET_CSV_URL}&ts=${Date.now()}`);
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const csvText = await response.text();
+            const parsed = parseCSV(csvText);
+            if (!parsed.length) {
+                throw new Error('Données vides');
+            }
+            header = parsed.shift() || [];
+            rows = parsed;
+        } catch (error) {
+            const localResponse = await fetch('suivi_projet_data.json');
+            const localData = await localResponse.json();
+            header = localData.cols || [];
+            rows = localData.rows || [];
+            setStatus('Google Sheets indisponible : affichage des données locales.', true);
+        }
+
+        classIdx = header.findIndex((col) => normalize(col) === 'classe');
+        projectIdx = header.findIndex((col) => normalize(col) === 'projet');
+        dateIdx = header.findIndex((col) => normalize(col) === 'date');
+        stepIdx = header.findIndex((col) => ['tache', 'etape'].includes(normalize(col)));
+
+        if (classIdx === -1 || projectIdx === -1 || dateIdx === -1 || stepIdx === -1) {
+            throw new Error('Colonnes attendues introuvables (classe/projet/date/tache-etape).');
+        }
+
+        allRows = rows.filter((row) => row[classIdx] && row[projectIdx]);
+
+        const classes = Array.from(new Set(allRows.map((row) => row[classIdx]))).sort((a, b) =>
+            a.localeCompare(b, 'fr')
+        );
+
+        fillSelect(classSelect, classes);
+        if (!classes.length) {
+            setStatus('Aucune classe trouvée dans le suivi.', true);
+            return;
+        }
+
+        classSelect.value = classes[0];
+        updateProjects();
+
+        setStatus('Sélectionnez une classe et un projet.');
+    }
+
+    classSelect.addEventListener('change', updateProjects);
+    projectSelect.addEventListener('change', renderSteps);
+
+    setStatus('Chargement du suivi des progressions...');
+    loadRows().catch((error) => {
+        listElement.innerHTML = '';
+        setStatus(`Impossible de charger le suivi : ${error.message}`, true);
+    });
+})();

--- a/index.html
+++ b/index.html
@@ -59,10 +59,19 @@
         <section class="description-ateliers">
             <article class="atelier agenda-card">
                 <div class="atelier-content">
-                    <h2>Prochains événements Google Agenda</h2>
-                    <p>Affiche uniquement les événements dont le titre commence par <strong>5E1</strong>.</p>
-                    <p id="calendar-status" class="calendar-status" aria-live="polite">Initialisation...</p>
-                    <ul id="calendar-events-list" class="calendar-events-list"></ul>
+                    <h2>Suivi des progressions (Google Sheets)</h2>
+                    <p>Sélectionnez une classe et un projet pour afficher les dates et étapes prévues.</p>
+
+                    <div class="progression-controls">
+                        <label for="progression-classe">Classe :</label>
+                        <select id="progression-classe"></select>
+
+                        <label for="progression-projet">Projet :</label>
+                        <select id="progression-projet"></select>
+                    </div>
+
+                    <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
+                    <ul id="progression-steps-list" class="calendar-events-list"></ul>
                 </div>
             </article>
         </section>
@@ -74,7 +83,7 @@
     </footer>
 
     <script src="sonometre.js"></script>
-    <script src="calendar-events.js"></script>
+    <script src="home-progressions.js"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1034,6 +1034,24 @@ svg.axe { display: block; margin: 0.5em 0; }
     align-items: flex-start;
 }
 
+
+.progression-controls {
+    display: grid;
+    grid-template-columns: auto minmax(160px, 1fr);
+    gap: 8px 12px;
+    align-items: center;
+    max-width: 420px;
+    margin-bottom: 12px;
+}
+
+.progression-controls select {
+    padding: 6px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: rgba(0, 0, 0, 0.4);
+    color: #fff;
+}
+
 .calendar-status {
     font-style: italic;
     margin-bottom: 12px;


### PR DESCRIPTION
### Motivation
- Permettre depuis l'accueil la consultation des dates et étapes de suivi projet en lisant la feuille Google Sheets de suivi au lieu d'afficher le widget Google Agenda.
- Offrir un filtre simple par `Classe` et `Projet` directement sur la page d'accueil pour accéder rapidement aux étapes d'un groupe.

### Description
- Remplacement de la carte « Prochains événements Google Agenda » dans `index.html` par une carte « Suivi des progressions (Google Sheets) » contenant deux sélecteurs (`#progression-classe`, `#progression-projet`) et une liste `#progression-steps-list`.
- Ajout du script client `home-progressions.js` qui charge le CSV publié de la feuille Google Sheets (avec cache-buster), fait du parsing CSV côté client, détecte les colonnes `classe`, `projet`, `date` et `tache`/`etape`, filtre par classe/projet, trie chronologiquement et affiche les dates + étapes; il bascule sur `suivi_projet_data.json` en fallback si la feuille est inaccessible.
- Remplacement de la référence `calendar-events.js` par `home-progressions.js` dans `index.html`.
- Ajout du style pour les nouveaux contrôles (`.progression-controls` et règles pour `select`) dans `styles.css` pour intégrer l'interface visuelle.

### Testing
- Vérification syntaxique du nouveau script avec `node --check home-progressions.js`, résultat : succès.
- Vérification automatisée des références présentes dans les fichiers avec la recherche `rg` (nouveaux IDs et inclusion de `home-progressions.js`), résultat : succès.
- Le script gère un fallback local sur `suivi_projet_data.json` lorsque le fetch du CSV échoue (testé par simulation côté code via le chemin de secours).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbae6945dc8331815f3f18a1fabe09)