### PR TITLE
Accueil: afficher toutes les dates du suivi sans filtres classe/projet

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -1,12 +1,10 @@
 (function () {
     const SHEET_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRVQMq6u1Wl-Tzjl27ir1iMcj1hTdSIsoJrVQAtW31i1AhvBoPGLT3rZoc6wfuizX7f1KWuaBphf2IX/pub?output=csv';
 
-    const classSelect = document.getElementById('progression-classe');
-    const projectSelect = document.getElementById('progression-projet');
     const statusElement = document.getElementById('progression-status');
     const listElement = document.getElementById('progression-steps-list');
 
-    if (!classSelect || !projectSelect || !statusElement || !listElement) {
+    if (!statusElement || !listElement) {
         return;
     }
 
@@ -82,24 +80,11 @@
         statusElement.classList.toggle('calendar-error', Boolean(isError));
     }
 
-    function fillSelect(select, values) {
-        select.innerHTML = '';
-        values.forEach((value) => {
-            const option = document.createElement('option');
-            option.value = value;
-            option.textContent = value;
-            select.appendChild(option);
-        });
-        select.disabled = values.length === 0;
-    }
-
     function renderSteps() {
-        const selectedClass = classSelect.value;
-        const selectedProject = projectSelect.value;
-
-        const filtered = allRows
-            .filter((row) => row[classIdx] === selectedClass && row[projectIdx] === selectedProject)
+        const entries = allRows
             .map((row) => ({
+                classText: row[classIdx] || 'Classe non renseignée',
+                projectText: row[projectIdx] || 'Projet non renseigné',
                 dateText: row[dateIdx] || '',
                 dateValue: parseDate(row[dateIdx]),
                 stepText: row[stepIdx] || 'Étape non renseignée'
@@ -113,46 +98,25 @@
 
         listElement.innerHTML = '';
 
-        if (!filtered.length) {
-            setStatus('Aucune étape trouvée pour cette sélection.', true);
+        if (!entries.length) {
+            setStatus('Aucune étape trouvée.', true);
             return;
         }
 
-        filtered.forEach((entry) => {
+        entries.forEach((entry) => {
             const item = document.createElement('li');
             const strong = document.createElement('strong');
             strong.textContent = entry.dateText || 'Date non renseignée';
 
             const details = document.createElement('div');
-            details.textContent = `Étape : ${entry.stepText}`;
+            details.textContent = `${entry.classText} — ${entry.projectText} — Étape : ${entry.stepText}`;
 
             item.appendChild(strong);
             item.appendChild(details);
             listElement.appendChild(item);
         });
 
-        setStatus(`${filtered.length} étape(s) affichée(s).`);
-    }
-
-    function updateProjects() {
-        const selectedClass = classSelect.value;
-        const projects = Array.from(
-            new Set(
-                allRows
-                    .filter((row) => row[classIdx] === selectedClass)
-                    .map((row) => row[projectIdx])
-                    .filter(Boolean)
-            )
-        ).sort((a, b) => a.localeCompare(b, 'fr'));
-
-        fillSelect(projectSelect, projects);
-        if (projects.length) {
-            projectSelect.value = projects[0];
-            renderSteps();
-        } else {
-            listElement.innerHTML = '';
-            setStatus('Aucun projet disponible pour cette classe.', true);
-        }
+        setStatus(`${entries.length} étape(s) affichée(s).`);
     }
 
     async function loadRows() {
@@ -188,26 +152,14 @@
             throw new Error('Colonnes attendues introuvables (classe/projet/date/tache-etape).');
         }
 
-        allRows = rows.filter((row) => row[classIdx] && row[projectIdx]);
-
-        const classes = Array.from(new Set(allRows.map((row) => row[classIdx]))).sort((a, b) =>
-            a.localeCompare(b, 'fr')
-        );
-
-        fillSelect(classSelect, classes);
-        if (!classes.length) {
-            setStatus('Aucune classe trouvée dans le suivi.', true);
+        allRows = rows.filter((row) => row[dateIdx] || row[stepIdx] || row[classIdx] || row[projectIdx]);
+        if (!allRows.length) {
+            listElement.innerHTML = '';
+            setStatus('Aucune donnée trouvée dans le suivi.', true);
             return;
         }
-
-        classSelect.value = classes[0];
-        updateProjects();
-
-        setStatus('Sélectionnez une classe et un projet.');
+        renderSteps();
     }
-
-    classSelect.addEventListener('change', updateProjects);
-    projectSelect.addEventListener('change', renderSteps);
 
     setStatus('Chargement du suivi des progressions...');
     loadRows().catch((error) => {

--- a/index.html
+++ b/index.html
@@ -60,15 +60,7 @@
             <article class="atelier agenda-card">
                 <div class="atelier-content">
                     <h2>Suivi des progressions (Google Sheets)</h2>
-                    <p>Sélectionnez une classe et un projet pour afficher les dates et étapes prévues.</p>
-
-                    <div class="progression-controls">
-                        <label for="progression-classe">Classe :</label>
-                        <select id="progression-classe"></select>
-
-                        <label for="progression-projet">Projet :</label>
-                        <select id="progression-projet"></select>
-                    </div>
+                    <p>Toutes les dates et étapes disponibles dans le Google Sheets sont affichées ci-dessous.</p>
 
                     <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
                     <ul id="progression-steps-list" class="calendar-events-list"></ul>


### PR DESCRIPTION
### Motivation
- Simplifier la carte “Suivi des progressions” sur l’accueil pour afficher directement toutes les dates et étapes présentes dans le Google Sheets sans exiger de sélection manuelle de classe ou de projet.

### Description
- Dans `index.html` la zone de sélection `progression-classe` / `progression-projet` a été retirée et le texte explicatif a été mis à jour pour indiquer que toutes les dates sont affichées.
- Dans `home-progressions.js` la logique a été simplifiée pour ne plus dépendre des `<select>`: les lignes du CSV sont maintenant triées par date et affichées telles quelles avec le contexte `classe — projet — étape` pour chaque entrée.
- Le chargement conserve le fallback local (`suivi_projet_data.json`) et les vérifications de colonnes restent en place, mais le filtrage exige désormais seulement la présence d’au moins une valeur utile (`date`, `tache/etape`, `classe` ou `projet`).
- Les sélecteurs, fonctions `fillSelect` et gestion d’événements liés aux filtres ont été supprimés du flux d’affichage.

### Testing
- Exécution de la vérification syntaxique `node --check home-progressions.js` qui a réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb89149d08331a7b1a3b4b5902ad0)