### PR TITLE
Mettre à jour le bloc d'accueil "Planning" avec filtre de classe

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -3,8 +3,9 @@
 
     const statusElement = document.getElementById('progression-status');
     const listElement = document.getElementById('progression-steps-list');
+    const classFilterElement = document.getElementById('progression-class-filter');
 
-    if (!statusElement || !listElement) {
+    if (!statusElement || !listElement || !classFilterElement) {
         return;
     }
 
@@ -80,11 +81,48 @@
         statusElement.classList.toggle('calendar-error', Boolean(isError));
     }
 
+    function formatDetails(entry) {
+        const parts = [entry.classText];
+        if (entry.projectText) {
+            parts.push(entry.projectText);
+        }
+        parts.push(`Étape : ${entry.stepText}`);
+        return parts.join(' — ');
+    }
+
+    function populateClassFilter() {
+        const classes = Array.from(
+            new Set(
+                allRows
+                    .map((row) => (row[classIdx] || '').trim())
+                    .filter(Boolean)
+            )
+        ).sort((a, b) => a.localeCompare(b));
+
+        classFilterElement.innerHTML = '';
+        const allOption = document.createElement('option');
+        allOption.value = '';
+        allOption.textContent = 'Toutes les classes';
+        classFilterElement.appendChild(allOption);
+
+        classes.forEach((className) => {
+            const option = document.createElement('option');
+            option.value = className;
+            option.textContent = className;
+            classFilterElement.appendChild(option);
+        });
+    }
+
     function renderSteps() {
+        const selectedClass = classFilterElement.value;
         const entries = allRows
+            .filter((row) => {
+                if (!selectedClass) return true;
+                return (row[classIdx] || '').trim() === selectedClass;
+            })
             .map((row) => ({
                 classText: row[classIdx] || 'Classe non renseignée',
-                projectText: row[projectIdx] || 'Projet non renseigné',
+                projectText: (row[projectIdx] || '').trim(),
                 dateText: row[dateIdx] || '',
                 dateValue: parseDate(row[dateIdx]),
                 stepText: row[stepIdx] || 'Étape non renseignée'
@@ -109,7 +147,7 @@
             strong.textContent = entry.dateText || 'Date non renseignée';
 
             const details = document.createElement('div');
-            details.textContent = `${entry.classText} — ${entry.projectText} — Étape : ${entry.stepText}`;
+            details.textContent = formatDetails(entry);
 
             item.appendChild(strong);
             item.appendChild(details);
@@ -158,10 +196,13 @@
             setStatus('Aucune donnée trouvée dans le suivi.', true);
             return;
         }
+        populateClassFilter();
         renderSteps();
     }
 
-    setStatus('Chargement du suivi des progressions...');
+    classFilterElement.addEventListener('change', renderSteps);
+
+    setStatus('Chargement du planning...');
     loadRows().catch((error) => {
         listElement.innerHTML = '';
         setStatus(`Impossible de charger le suivi : ${error.message}`, true);

--- a/index.html
+++ b/index.html
@@ -59,8 +59,14 @@
         <section class="description-ateliers">
             <article class="atelier agenda-card">
                 <div class="atelier-content">
-                    <h2>Suivi des progressions (Google Sheets)</h2>
-                    <p>Toutes les dates et étapes disponibles dans le Google Sheets sont affichées ci-dessous.</p>
+                    <h2>Planning</h2>
+
+                    <div class="progression-controls">
+                        <label for="progression-class-filter">Classe :</label>
+                        <select id="progression-class-filter">
+                            <option value="">Toutes les classes</option>
+                        </select>
+                    </div>
 
                     <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
                     <ul id="progression-steps-list" class="calendar-events-list"></ul>


### PR DESCRIPTION
### Motivation
- Clarifier le bloc d'accueil en remplaçant le titre "Suivi des progressions (Google Sheets)" par "Planning" pour une meilleure lisibilité.
- Remplacer la phrase descriptive par un filtre par classe pour permettre aux utilisateurs de restreindre l'affichage directement depuis l'accueil.
- Éviter d'afficher un nom de projet vide dans la description d'une tâche pour un rendu plus propre.

### Description
- `index.html` : remplacement du titre par `Planning`, suppression de la phrase descriptive et ajout d'un conteneur `.progression-controls` contenant le `select` `#progression-class-filter`.
- `home-progressions.js` : ajout de la récupération DOM de `#progression-class-filter`, implémentation de `populateClassFilter()` qui extrait et ordonne les classes depuis les données, et ajout d'un `change` listener qui réaffiche la liste filtrée.
- `home-progressions.js` : ajout de `formatDetails()` et modification de `renderSteps()` pour omettre le nom du projet lorsque la cellule est vide et pour filtrer les entrées selon la classe sélectionnée.
- Ajustement du message de chargement à `Chargement du planning...` et maintien du fallback sur `suivi_projet_data.json` si Google Sheets est indisponible.

### Testing
- Validation syntaxique JavaScript via `node -e "new Function(require('fs').readFileSync('home-progressions.js','utf8'))"` a réussi.
- Vérification automatique `git diff --check` n'a signalé aucune erreur d'espaces ou trailing blanks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbc7d94b08331a5e04b8872bf72c8)