### PR TITLE
Accueil: simplifier l'affichage du planning et ajouter un bloc Date & heure

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -1,0 +1,22 @@
+(function () {
+    const timeElement = document.getElementById('live-time');
+    const dateElement = document.getElementById('live-date');
+
+    if (!timeElement || !dateElement) {
+        return;
+    }
+
+    function updateDateTime() {
+        const now = new Date();
+        timeElement.textContent = now.toLocaleTimeString('fr-FR');
+        dateElement.textContent = now.toLocaleDateString('fr-FR', {
+            weekday: 'long',
+            day: 'numeric',
+            month: 'long',
+            year: 'numeric'
+        });
+    }
+
+    updateDateTime();
+    setInterval(updateDateTime, 1000);
+})();

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -82,12 +82,7 @@
     }
 
     function formatDetails(entry) {
-        const parts = [entry.classText];
-        if (entry.projectText) {
-            parts.push(entry.projectText);
-        }
-        parts.push(`Étape : ${entry.stepText}`);
-        return parts.join(' — ');
+        return `${entry.classText} - ${entry.stepText}`;
     }
 
     function populateClassFilter() {
@@ -137,7 +132,7 @@
         listElement.innerHTML = '';
 
         if (!entries.length) {
-            setStatus('Aucune étape trouvée.', true);
+            setStatus('Aucune tâche trouvée.', true);
             return;
         }
 
@@ -154,7 +149,7 @@
             listElement.appendChild(item);
         });
 
-        setStatus(`${entries.length} étape(s) affichée(s).`);
+        setStatus('Planning mis à jour.');
     }
 
     async function loadRows() {

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     </header>
 
     <main>
-        <section class="description-ateliers">
+        <section class="description-ateliers home-top-grid">
             <article class="atelier sonometre-card">
                 <div class="atelier-content">
                     <h2>Régulation du bruit</h2>
@@ -55,6 +55,13 @@
                     </div>
                 </div>
             </article>
+            <article class="atelier datetime-card">
+                <div class="atelier-content">
+                    <h2>Date & heure</h2>
+                    <p id="live-time" class="datetime-value">--:--:--</p>
+                    <p id="live-date" class="datetime-label">--</p>
+                </div>
+            </article>
         </section>
         <section class="description-ateliers">
             <article class="atelier agenda-card">
@@ -82,6 +89,7 @@
 
     <script src="sonometre.js"></script>
     <script src="home-progressions.js"></script>
+    <script src="home-datetime.js"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -948,6 +948,35 @@ svg.axe { display: block; margin: 0.5em 0; }
     align-items: stretch;
 }
 
+.home-top-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 20px;
+    align-items: stretch;
+}
+
+.home-top-grid .atelier {
+    margin: 0;
+}
+
+.datetime-card {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.datetime-value {
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    font-weight: 700;
+    margin: 8px 0;
+}
+
+.datetime-label {
+    margin: 0;
+    text-transform: capitalize;
+    font-size: 1.1rem;
+}
+
 .sonometre-controls {
     display: flex;
     align-items: center;
@@ -1032,6 +1061,12 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .agenda-card {
     align-items: flex-start;
+}
+
+@media (max-width: 900px) {
+    .home-top-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 


### PR DESCRIPTION
### Motivation
- Simplifier l'affichage du planning en supprimant le préfixe répétitif et le compteur de lignes pour rendre la lecture plus claire dans la page d'accueil. 
- Ajouter un bloc indépendant affichant l'heure et la date à droite du sonomètre, dans le même style visuel que les autres cartes, pour fournir une référence temporelle en temps réel. 

### Description
- Remplace le rendu des détails du planning par le format `Classe - tâche` en supprimant le libellé `Étape :` dans `home-progressions.js`. 
- Remplace l'affichage du nombre de tâches par un statut neutre (`Planning mis à jour.`) dans `home-progressions.js`. 
- Ajoute un nouveau bloc HTML `Date & heure` dans `index.html` et inclut le script `home-datetime.js` qui met à jour l'heure et la date toutes les secondes. 
- Ajoute le CSS de mise en page et de style (`.home-top-grid`, `.datetime-card`, `.datetime-value`, `.datetime-label`) dans `styles.css` pour aligner le sonomètre et le bloc date/heure en grille responsive (2 colonnes desktop, 1 colonne mobile). 

### Testing
- Exécuté `node --check home-progressions.js` et la vérification a réussi. 
- Exécuté `node --check home-datetime.js` et la vérification a réussi. 
- Exécuté `node --check sonometre.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbfbd56f083319b00fb4882dae9f4)