### PR TITLE
Mise à jour écran d'accueil : 'Contenu de séance', centrage date/heure et alerte DST

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -15,6 +15,7 @@
     let projectIdx = -1;
     let dateIdx = -1;
     let stepIdx = -1;
+    let descriptionIdx = -1;
     let selectedEntryKey = '';
 
     function normalize(value) {
@@ -98,21 +99,17 @@
 
         if (!entry) {
             taskDetailElement.className = 'task-detail-empty';
-            taskDetailElement.textContent = 'Cliquez sur une tâche du planning pour afficher ses détails ici.';
+            taskDetailElement.textContent = 'Cliquez sur une tâche du planning pour afficher son contenu ici.';
             return;
         }
 
-        const safeClass = entry.classText || 'Classe non renseignée';
-        const safeProject = entry.projectText || 'Projet non renseigné';
-        const safeDate = entry.dateText || 'Date non renseignée';
         const safeStep = entry.stepText || 'Tâche non renseignée';
+        const safeDescription = entry.descriptionText || 'Description non renseignée.';
 
         taskDetailElement.className = '';
         taskDetailElement.innerHTML = `
-            <p class="task-detail-meta"><strong>Classe :</strong> ${safeClass}</p>
-            <p class="task-detail-meta"><strong>Projet :</strong> ${safeProject}</p>
-            <p class="task-detail-meta"><strong>Date :</strong> ${safeDate}</p>
             <p class="task-detail-step"><strong>Tâche :</strong> ${safeStep}</p>
+            <p class="task-detail-description">${safeDescription}</p>
         `;
     }
 
@@ -151,7 +148,8 @@
                 projectText: (row[projectIdx] || '').trim(),
                 dateText: row[dateIdx] || '',
                 dateValue: parseDate(row[dateIdx]),
-                stepText: row[stepIdx] || 'Étape non renseignée'
+                stepText: row[stepIdx] || 'Étape non renseignée',
+                descriptionText: descriptionIdx >= 0 ? (row[descriptionIdx] || '').trim() : ''
             }))
             .sort((a, b) => {
                 if (!a.dateValue && !b.dateValue) return 0;
@@ -174,6 +172,9 @@
             const taskButton = document.createElement('button');
             taskButton.type = 'button';
             taskButton.className = 'calendar-task-button';
+            if ((entry.stepText || '').toUpperCase().includes('DST')) {
+                taskButton.classList.add('calendar-task-button-dst');
+            }
             if (entryKey === selectedEntryKey) {
                 taskButton.classList.add('active');
             }
@@ -232,6 +233,7 @@
         projectIdx = header.findIndex((col) => normalize(col) === 'projet');
         dateIdx = header.findIndex((col) => normalize(col) === 'date');
         stepIdx = header.findIndex((col) => ['tache', 'etape'].includes(normalize(col)));
+        descriptionIdx = header.findIndex((col) => normalize(col) === 'description');
 
         if (classIdx === -1 || projectIdx === -1 || dateIdx === -1 || stepIdx === -1) {
             throw new Error('Colonnes attendues introuvables (classe/projet/date/tache-etape).');

--- a/index.html
+++ b/index.html
@@ -57,16 +57,15 @@
             </article>
             <article class="atelier datetime-card home-card-datetime">
                 <div class="atelier-content">
-                    <h2>Date & heure</h2>
                     <p id="live-time" class="datetime-value">--:--:--</p>
                     <p id="live-date" class="datetime-label">--</p>
                 </div>
             </article>
             <article class="atelier task-detail-card home-card-detail">
                 <div class="atelier-content">
-                    <h2>Détail de la tâche</h2>
+                    <h2>Contenu de séance</h2>
                     <p id="progression-task-detail" class="task-detail-empty">
-                        Cliquez sur une tâche du planning pour afficher ses détails ici.
+                        Cliquez sur une tâche du planning pour afficher son contenu ici.
                     </p>
                 </div>
             </article>

--- a/styles.css
+++ b/styles.css
@@ -980,8 +980,9 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .datetime-card {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     justify-content: center;
+    text-align: center;
 }
 
 .datetime-value {
@@ -1083,7 +1084,8 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .task-detail-card {
-    align-items: flex-start;
+    align-items: center;
+    text-align: center;
 }
 
 .task-detail-empty {
@@ -1096,8 +1098,13 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .task-detail-card .task-detail-step {
-    margin: 0;
+    margin: 0 0 10px;
     font-size: 1.05rem;
+    line-height: 1.5;
+}
+
+.task-detail-card .task-detail-description {
+    margin: 0;
     line-height: 1.5;
 }
 
@@ -1177,4 +1184,15 @@ svg.axe { display: block; margin: 0.5em 0; }
 .calendar-task-button.active {
     border-color: rgba(30, 144, 255, 0.9);
     background: rgba(30, 144, 255, 0.45);
+}
+
+.calendar-task-button.calendar-task-button-dst {
+    background: rgba(220, 20, 60, 0.6);
+    border-color: rgba(255, 120, 120, 0.9);
+}
+
+.calendar-task-button.calendar-task-button-dst:hover,
+.calendar-task-button.calendar-task-button-dst:focus-visible,
+.calendar-task-button.calendar-task-button-dst.active {
+    background: rgba(255, 0, 0, 0.75);
 }


### PR DESCRIPTION
### Motivation
- Renommer et simplifier le bloc de détail pour afficher le nom de la tâche et la description issue de la feuille Google Sheets (colonne `Description`).
- Rendre le bloc date/heure visuellement centré et épuré en supprimant son titre redondant.
- Mettre en avant (fond rouge) les tâches du planning dont le libellé contient `DST` pour attirer l'attention.

### Description
- `index.html` : suppression du titre `Date & heure`, renommage du bloc `Détail de la tâche` en `Contenu de séance` et mise à jour du texte d'aide affiché dans le bloc.  
- `home-progressions.js` : ajout de la détection de la colonne `Description` (`descriptionIdx`) et inclusion de `descriptionText` dans le modèle d'entrée; modification de `renderTaskDetail` pour n'afficher que la `Tâche` et la `Description` (avec fallback si absent); ajout d'une classe CSS `calendar-task-button-dst` lorsque `stepText` contient `DST` (vérification insensible à la casse via `toUpperCase().includes('DST')`).
- `styles.css` : centrage visuel du bloc date/heure (`.datetime-card`) et du bloc contenu de séance (`.task-detail-card`), ajout de règles pour `.task-detail-description`, et styles de mise en évidence rouge pour `.calendar-task-button.calendar-task-button-dst` (état normal et hover/actif).

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check home-progressions.js` qui a réussi.  
- Exécution de la vérification de syntaxe JavaScript avec `node --check home-datetime.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdcf9fde08331b1e2b131f601ea59)