### PR TITLE
Accueil: afficher la colonne Détails dans le bloc Contenu de séance

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -15,7 +15,7 @@
     let projectIdx = -1;
     let dateIdx = -1;
     let stepIdx = -1;
-    let descriptionIdx = -1;
+    let detailsIdx = -1;
     let selectedEntryKey = '';
 
     function normalize(value) {
@@ -103,13 +103,11 @@
             return;
         }
 
-        const safeStep = entry.stepText || 'Tâche non renseignée';
-        const safeDescription = entry.descriptionText || 'Description non renseignée.';
+        const safeDetails = entry.detailsText || 'Détails non renseignés.';
 
         taskDetailElement.className = '';
         taskDetailElement.innerHTML = `
-            <p class="task-detail-step"><strong>Tâche :</strong> ${safeStep}</p>
-            <p class="task-detail-description">${safeDescription}</p>
+            <p class="task-detail-description">${safeDetails}</p>
         `;
     }
 
@@ -149,7 +147,7 @@
                 dateText: row[dateIdx] || '',
                 dateValue: parseDate(row[dateIdx]),
                 stepText: row[stepIdx] || 'Étape non renseignée',
-                descriptionText: descriptionIdx >= 0 ? (row[descriptionIdx] || '').trim() : ''
+                detailsText: detailsIdx >= 0 ? (row[detailsIdx] || '').trim() : ''
             }))
             .sort((a, b) => {
                 if (!a.dateValue && !b.dateValue) return 0;
@@ -233,7 +231,7 @@
         projectIdx = header.findIndex((col) => normalize(col) === 'projet');
         dateIdx = header.findIndex((col) => normalize(col) === 'date');
         stepIdx = header.findIndex((col) => ['tache', 'etape'].includes(normalize(col)));
-        descriptionIdx = header.findIndex((col) => normalize(col) === 'description');
+        detailsIdx = header.findIndex((col) => ['details', 'detail', 'description'].includes(normalize(col)));
 
         if (classIdx === -1 || projectIdx === -1 || dateIdx === -1 || stepIdx === -1) {
             throw new Error('Colonnes attendues introuvables (classe/projet/date/tache-etape).');

--- a/styles.css
+++ b/styles.css
@@ -1084,8 +1084,8 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .task-detail-card {
-    align-items: center;
-    text-align: center;
+    align-items: flex-start;
+    text-align: left;
 }
 
 .task-detail-empty {


### PR DESCRIPTION
### Motivation
- Le bloc « Contenu de séance » doit afficher le texte provenant de la colonne `Détails` du Google Sheet (flux attendu : `Date	Classe	Projet	Rôle	Tâche	Détails`).
- Le texte de ce bloc ne doit plus être centré mais aligné normalement à gauche pour une lecture plus standard.

### Description
- Parseur CSV et mapping de colonnes mis à jour pour détecter la colonne `Détails` (compatibilité avec `details` / `detail` / `description`) et stocker sa valeur dans `detailsText` dans `home-progressions.js`.
- Le rendu du bloc de détail (`renderTaskDetail`) affiche désormais uniquement le contenu de `detailsText` et retire le préfixe tâche/étape précédemment affiché.
- Styles CSS ajustés dans `styles.css` pour que `.task-detail-card` utilise `align-items: flex-start` et `text-align: left` afin d’empêcher le centrage du texte.
- Le comportement de repli local (fallback vers `suivi_projet_data.json` si Sheets indisponible) est conservé.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check home-progressions.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf5f09cb883319b23a65a7e14e47e)