### PR TITLE
Griser les tâches annulées dans le planning d'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -173,6 +173,9 @@
             if ((entry.stepText || '').toUpperCase().includes('DST')) {
                 taskButton.classList.add('calendar-task-button-dst');
             }
+            if ((entry.stepText || '').toLowerCase().includes('annul')) {
+                taskButton.classList.add('calendar-task-button-cancelled');
+            }
             if (entryKey === selectedEntryKey) {
                 taskButton.classList.add('active');
             }

--- a/styles.css
+++ b/styles.css
@@ -1196,3 +1196,16 @@ svg.axe { display: block; margin: 0.5em 0; }
 .calendar-task-button.calendar-task-button-dst.active {
     background: rgba(255, 0, 0, 0.75);
 }
+
+.calendar-task-button.calendar-task-button-cancelled {
+    background: rgba(128, 128, 128, 0.45);
+    border-color: rgba(200, 200, 200, 0.75);
+    color: rgba(255, 255, 255, 0.78);
+}
+
+.calendar-task-button.calendar-task-button-cancelled:hover,
+.calendar-task-button.calendar-task-button-cancelled:focus-visible,
+.calendar-task-button.calendar-task-button-cancelled.active {
+    background: rgba(110, 110, 110, 0.6);
+    border-color: rgba(220, 220, 220, 0.85);
+}


### PR DESCRIPTION
### Motivation
- Dans l'accueil / Planning, les tâches marquées comme annulées doivent être visuellement désactivées en étant affichées en grisé pour éviter la confusion.

### Description
- Ajout d'une détection insensible à la casse de la sous-chaîne `annul` dans `entry.stepText` pour appliquer la classe `calendar-task-button-cancelled`, et ajout des règles CSS correspondantes dans `styles.css` pour rendre ces boutons grisés (état normal, hover/focus et actif).

### Testing
- Exécution de `node --check home-progressions.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc79e2f5a48331bb9e3449be003ac1)