### PR TITLE
Mettre en rouge les évaluations du planning et intensifier le bloc sonomètre

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -173,6 +173,9 @@
             if ((entry.stepText || '').toUpperCase().includes('DST')) {
                 taskButton.classList.add('calendar-task-button-dst');
             }
+            if (normalize(entry.stepText).includes('evaluation')) {
+                taskButton.classList.add('calendar-task-button-evaluation');
+            }
             if ((entry.stepText || '').toLowerCase().includes('annul')) {
                 taskButton.classList.add('calendar-task-button-cancelled');
             }

--- a/sonometre.js
+++ b/sonometre.js
@@ -8,6 +8,7 @@
   const seuilMarkerLabel = document.getElementById('seuil-marker-label');
   const niveauLive = document.getElementById('niveau-live');
   const depassementsEl = document.getElementById('depassements');
+  const sonometreCard = document.querySelector('.sonometre-card');
   const startBtn = document.getElementById('start-sonometre');
   const pauseBtn = document.getElementById('pause-sonometre');
   const decrementBtn = document.getElementById('decrement-compteur');
@@ -51,6 +52,17 @@
 
   const updateCompteur = () => {
     depassementsEl.textContent = `Dépassements : ${depassements}`;
+    updateSonometreColor();
+  };
+
+  const updateSonometreColor = () => {
+    if (!sonometreCard) return;
+    const ratio = Math.min(depassements, 20) / 20;
+    const red = Math.round(30 + (255 - 30) * ratio);
+    const green = Math.round(144 * (1 - ratio));
+    const blue = Math.round(255 * (1 - ratio));
+    const alpha = 0.2 + ratio * 0.35;
+    sonometreCard.style.backgroundColor = `rgba(${red}, ${green}, ${blue}, ${alpha.toFixed(2)})`;
   };
 
   const updateSeuilLabel = () => {
@@ -170,4 +182,5 @@
   pauseBtn.removeAttribute('disabled');
   updateSeuilLabel();
   updateSensibiliteLabel();
+  updateCompteur();
 })();

--- a/styles.css
+++ b/styles.css
@@ -1197,6 +1197,17 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(255, 0, 0, 0.75);
 }
 
+.calendar-task-button.calendar-task-button-evaluation {
+    background: rgba(220, 20, 60, 0.6);
+    border-color: rgba(255, 120, 120, 0.9);
+}
+
+.calendar-task-button.calendar-task-button-evaluation:hover,
+.calendar-task-button.calendar-task-button-evaluation:focus-visible,
+.calendar-task-button.calendar-task-button-evaluation.active {
+    background: rgba(255, 0, 0, 0.75);
+}
+
 .calendar-task-button.calendar-task-button-cancelled {
     background: rgba(128, 128, 128, 0.45);
     border-color: rgba(200, 200, 200, 0.75);


### PR DESCRIPTION
### Motivation
- Mettre en évidence dans le planning les tâches de type « évaluation » (insensible à la casse et aux accents) pour faciliter le repérage visuel.
- Rendre le bloc du sonomètre progressivement plus rouge en fonction du nombre de dépassements, avec rouge maximal à partir de 20 dépassements.

### Description
- Dans `home-progressions.js` la fonction de rendu des tâches utilise la fonction `normalize` existante pour détecter (sans accents ni casse) la présence du mot `evaluation` et ajoute la classe `calendar-task-button-evaluation` aux boutons concernés.
- Dans `styles.css` ajout d’un style `calendar-task-button-evaluation` pour afficher ces tâches en rouge (états normal, hover/focus et actif).
- Dans `sonometre.js` ajout de la sélection de l’élément `.sonometre-card`, d’une fonction `updateSonometreColor` qui calcule un ratio `Math.min(depassements, 20) / 20` et ajuste la couleur de fond en rgba pour devenir de plus en plus rouge, et appel de cette fonction depuis `updateCompteur` et à l’initialisation.
- Les modifications visent à être non intrusives et réutilisent des utilitaires existants (`normalize`) sans modifier les structures de données principales.

### Testing
- Exécution de `node --check home-progressions.js` qui a réussi.
- Exécution de `node --check sonometre.js` qui a réussi.
- Exécution de `git diff --check` qui a renvoyé aucun problème.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca623ff6483318dfa8eee9c7a1457)