### PR TITLE
Add "show past" toggles for tasks and progressions with UI/styling updates

### DIFF
--- a/family_organiser.html
+++ b/family_organiser.html
@@ -105,6 +105,21 @@
     .task-text { flex: 1; }
     .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 8px; background: #eef2ff; color: var(--primary); font-weight: 600; font-size: 0.8rem; margin-right: 0.35rem; }
     .filters { display: flex; gap: 0.5rem; flex-wrap: wrap; margin: 0.5rem 0; }
+    .filter-checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.9rem;
+      color: var(--text);
+      background: #f8fafc;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 0.4rem 0.55rem;
+    }
+    .filter-checkbox input {
+      width: auto;
+      margin: 0;
+    }
     .link-card { border: 1px solid var(--border); padding: 0.7rem; border-radius: 10px; display: flex; justify-content: space-between; align-items: center; background: #f9fafb; }
     .link-card a { color: var(--primary); text-decoration: none; font-weight: 700; }
     .timetable-grid {
@@ -189,6 +204,10 @@
             <select id="personFilter" aria-label="Filtrer par personne">
               <option value="all">Toutes les personnes</option>
             </select>
+            <label for="showPastTasks" class="filter-checkbox">
+              <input type="checkbox" id="showPastTasks">
+              Voir les tâches passées
+            </label>
           </div>
         </div>
         <form id="taskForm" class="form-grid" autocomplete="off">
@@ -562,6 +581,7 @@
       const tasksList = document.getElementById('tasksList');
       const statusFilter = document.getElementById('statusFilter');
       const personFilter = document.getElementById('personFilter');
+      const showPastTasks = document.getElementById('showPastTasks');
 
       taskForm.addEventListener('submit', (e) => {
         e.preventDefault();
@@ -582,13 +602,16 @@
 
       statusFilter.addEventListener('change', renderTasks);
       personFilter.addEventListener('change', renderTasks);
+      showPastTasks.addEventListener('change', renderTasks);
 
       function renderTasks() {
         tasksList.innerHTML = '';
+        const todayIso = new Date().toISOString().slice(0,10);
         const filtered = state.tasks.filter(task => {
           if (statusFilter.value === 'todo' && task.done) return false;
           if (statusFilter.value === 'done' && !task.done) return false;
           if (personFilter.value !== 'all' && task.person !== personFilter.value) return false;
+          if (!showPastTasks.checked && task.dueDate && task.dueDate < todayIso) return false;
           return true;
         });
         if (!filtered.length) {

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -4,9 +4,10 @@
     const statusElement = document.getElementById('progression-status');
     const listElement = document.getElementById('progression-steps-list');
     const classFilterElement = document.getElementById('progression-class-filter');
+    const showPastElement = document.getElementById('progression-show-past');
     const taskDetailElement = document.getElementById('progression-task-detail');
 
-    if (!statusElement || !listElement || !classFilterElement) {
+    if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
     }
 
@@ -136,6 +137,8 @@
 
     function renderSteps() {
         const selectedClass = classFilterElement.value;
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
         const entries = allRows
             .filter((row) => {
                 if (!selectedClass) return true;
@@ -149,6 +152,11 @@
                 stepText: row[stepIdx] || 'Étape non renseignée',
                 detailsText: detailsIdx >= 0 ? (row[detailsIdx] || '').trim() : ''
             }))
+            .filter((entry) => {
+                if (showPastElement.checked) return true;
+                if (!entry.dateValue) return true;
+                return entry.dateValue >= today;
+            })
             .sort((a, b) => {
                 if (!a.dateValue && !b.dateValue) return 0;
                 if (!a.dateValue) return 1;
@@ -254,6 +262,7 @@
     }
 
     classFilterElement.addEventListener('change', renderSteps);
+    showPastElement.addEventListener('change', renderSteps);
 
     setStatus('Chargement du planning...');
     loadRows().catch((error) => {

--- a/index.html
+++ b/index.html
@@ -79,6 +79,12 @@
                             <option value="">Toutes les classes</option>
                         </select>
                     </div>
+                    <div class="progression-controls progression-controls-checkbox">
+                        <label>
+                            <input type="checkbox" id="progression-show-past">
+                            Voir les anciennes tâches
+                        </label>
+                    </div>
 
                     <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
                     <ul id="progression-steps-list" class="calendar-events-list"></ul>

--- a/styles.css
+++ b/styles.css
@@ -1137,6 +1137,21 @@ svg.axe { display: block; margin: 0.5em 0; }
     color: #fff;
 }
 
+.progression-controls-checkbox {
+    grid-template-columns: 1fr;
+}
+
+.progression-controls-checkbox label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.progression-controls-checkbox input[type="checkbox"] {
+    width: auto;
+    margin: 0;
+}
+
 .calendar-status {
     font-style: italic;
     margin-bottom: 12px;


### PR DESCRIPTION
### Motivation
- Provide a way to hide or show past/expired items in the task list and the progressions feed to reduce clutter. 
- Make the new controls visually consistent with existing filters and the site's design. 
- Ensure progressions and tasks respect user preference when displaying dated entries.

### Description
- Added a checkbox UI to the tasks panel with id `showPastTasks` and a `.filter-checkbox` style in `family_organiser.html` to toggle visibility of past tasks. 
- Implemented filtering in the tasks renderer by comparing `task.dueDate` against `todayIso` and wired `showPastTasks.addEventListener('change', renderTasks)` to update the view. 
- Added a checkbox control with id `progression-show-past` to `index.html`, hooked it into `home-progressions.js` as `showPastElement`, and filtered progression entries by comparing parsed dates to `today`. 
- Added CSS rules for `.filter-checkbox` and `.progression-controls-checkbox` in `styles.css` to align checkbox controls with existing form styles. 

### Testing
- No automated tests were added or executed for this change. 
- Changes were designed to be backwards-compatible and only affect rendering when the new checkboxes are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcaee724908331a11031c04ebd80f0)