### PR TITLE
Supprimer le message « Planning mis à jour » sur la page d'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -214,7 +214,7 @@
             renderTaskDetail(null);
         }
 
-        setStatus('Planning mis à jour.');
+        setStatus('');
     }
 
     async function loadRows() {


### PR DESCRIPTION
### Motivation
- Enlever le texte de statut « Planning mis à jour. » affiché dans le bloc Planning de la page d'accueil pour ne pas montrer ce message après le rendu des tâches.

### Description
- Remplacement de l'appel `setStatus('Planning mis à jour.')` par `setStatus('')` dans `home-progressions.js` pour vider le message de statut après le rendu des entrées.

### Testing
- Vérifications automatiques exécutées : recherche avec `rg` pour repérer les occurrences du message et inspection du fichier modifié avec `nl -ba home-progressions.js | sed -n '206,222p'`, et les contrôles ont confirmé que la modification est appliquée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc05f360083318eb06a62a43897ae)