### PR TITLE
Séparer le contenu de séance et afficher les tâches imbriquées sur l'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -5,7 +5,8 @@
     const listElement = document.getElementById('progression-steps-list');
     const classFilterElement = document.getElementById('progression-class-filter');
     const showPastElement = document.getElementById('progression-show-past');
-    const taskDetailElement = document.getElementById('progression-task-detail');
+    const taskContentElement = document.getElementById('progression-task-content');
+    const taskListElement = document.getElementById('progression-task-list');
 
     if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
@@ -93,23 +94,112 @@
         return `${entry.classText}|${entry.projectText}|${entry.dateText}|${entry.stepText}`;
     }
 
+    function cleanText(value) {
+        return (value || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function parseBracketContent(text, startIndex = 0) {
+        let plainText = '';
+        const tasks = [];
+        let cursor = startIndex;
+
+        while (cursor < text.length) {
+            const char = text[cursor];
+            if (char === '[') {
+                const nested = parseBracketContent(text, cursor + 1);
+                tasks.push({
+                    label: cleanText(nested.plainText),
+                    subtasks: nested.tasks
+                });
+                cursor = nested.nextIndex;
+                continue;
+            }
+
+            if (char === ']') {
+                return {
+                    plainText,
+                    tasks,
+                    nextIndex: cursor + 1
+                };
+            }
+
+            plainText += char;
+            cursor += 1;
+        }
+
+        return {
+            plainText,
+            tasks,
+            nextIndex: cursor
+        };
+    }
+
+    function parseSessionDetails(detailsText) {
+        const parsed = parseBracketContent(detailsText || '', 0);
+        const content = cleanText(parsed.plainText);
+
+        function normalizeTasks(tasks) {
+            return tasks
+                .map((task) => ({
+                    label: cleanText(task.label),
+                    subtasks: normalizeTasks(task.subtasks || [])
+                }))
+                .filter((task) => task.label || task.subtasks.length > 0);
+        }
+
+        return {
+            content,
+            tasks: normalizeTasks(parsed.tasks || [])
+        };
+    }
+
+    function buildTasksList(tasks) {
+        const list = document.createElement('ol');
+        list.className = 'task-detail-tasks';
+
+        tasks.forEach((task) => {
+            const item = document.createElement('li');
+            const label = document.createElement('span');
+            label.textContent = task.label || 'Tâche sans titre';
+            item.appendChild(label);
+
+            if (task.subtasks && task.subtasks.length) {
+                item.appendChild(buildTasksList(task.subtasks));
+            }
+
+            list.appendChild(item);
+        });
+
+        return list;
+    }
+
     function renderTaskDetail(entry) {
-        if (!taskDetailElement) {
+        if (!taskContentElement || !taskListElement) {
             return;
         }
 
         if (!entry) {
-            taskDetailElement.className = 'task-detail-empty';
-            taskDetailElement.textContent = 'Cliquez sur une tâche du planning pour afficher son contenu ici.';
+            taskContentElement.className = 'task-detail-empty';
+            taskContentElement.textContent = 'Cliquez sur une tâche du planning pour afficher son contenu ici.';
+            taskListElement.className = 'task-detail-empty';
+            taskListElement.textContent = 'Aucune tâche à afficher.';
             return;
         }
 
-        const safeDetails = entry.detailsText || 'Détails non renseignés.';
+        const details = parseSessionDetails(entry.detailsText || '');
 
-        taskDetailElement.className = '';
-        taskDetailElement.innerHTML = `
-            <p class="task-detail-description">${safeDetails}</p>
-        `;
+        taskContentElement.className = 'task-detail-description';
+        taskContentElement.textContent = details.content || 'Contenu non renseigné.';
+
+        taskListElement.innerHTML = '';
+        if (!details.tasks.length) {
+            taskListElement.className = 'task-detail-empty';
+            taskListElement.textContent = 'Aucune tâche définie.';
+            return;
+        }
+
+        taskListElement.className = 'task-detail-list-container';
+        taskListElement.appendChild(buildTasksList(details.tasks));
     }
 
     function populateClassFilter() {

--- a/index.html
+++ b/index.html
@@ -64,9 +64,18 @@
             <article class="atelier task-detail-card home-card-detail">
                 <div class="atelier-content">
                     <h2>Contenu de séance</h2>
-                    <p id="progression-task-detail" class="task-detail-empty">
-                        Cliquez sur une tâche du planning pour afficher son contenu ici.
-                    </p>
+                    <section class="task-detail-section">
+                        <h3>Contenu</h3>
+                        <p id="progression-task-content" class="task-detail-empty">
+                            Cliquez sur une tâche du planning pour afficher son contenu ici.
+                        </p>
+                    </section>
+                    <section class="task-detail-section">
+                        <h3>Tâches</h3>
+                        <div id="progression-task-list" class="task-detail-empty">
+                            Aucune tâche à afficher.
+                        </div>
+                    </section>
                 </div>
             </article>
             <article class="atelier agenda-card home-card-agenda">

--- a/styles.css
+++ b/styles.css
@@ -1108,6 +1108,30 @@ svg.axe { display: block; margin: 0.5em 0; }
     line-height: 1.5;
 }
 
+.task-detail-card .task-detail-section + .task-detail-section {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.task-detail-card .task-detail-section h3 {
+    margin: 0 0 8px;
+    font-size: 1rem;
+}
+
+.task-detail-list-container {
+    line-height: 1.5;
+}
+
+.task-detail-tasks {
+    margin: 0;
+    padding-left: 20px;
+}
+
+.task-detail-tasks .task-detail-tasks {
+    margin-top: 6px;
+}
+
 @media (max-width: 900px) {
     .home-dashboard-grid {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Rendre la zone "Contenu de séance" plus lisible en séparant le texte principal des tâches explicites encadrées par des crochets (`[ ... ]`).
- Supporter plusieurs tâches et sous-tâches imbriquées pour faciliter la lecture et l’édition côté affichage.

### Description
- Remplace la zone unique de détail dans `index.html` par deux sections distinctes identifiées par `progression-task-content` et `progression-task-list` pour afficher respectivement le contenu hors crochets et la liste des tâches.
- Ajoute dans `home-progressions.js` un parseur récursif (`parseBracketContent`, `parseSessionDetails`) et une fonction `buildTasksList` pour extraire des segments `[ ... ]`, normaliser le texte et construire une liste ordonnée imbriquée de tâches/sous-tâches, puis met à jour `renderTaskDetail` pour utiliser ces éléments DOM au lieu d’un simple `innerHTML`.
- Ajoute une fonction utilitaire `cleanText` pour nettoyer les espaces et normaliser le contenu extrait.
- Met à jour `styles.css` pour séparer visuellement les sections (`.task-detail-section`) et styler les listes imbriquées (`.task-detail-tasks`, `.task-detail-list-container`).

### Testing
- `node --check home-progressions.js` a été exécuté et a réussi.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de15e2144483319223ef0e83af73db)