### PR TITLE
Sanitize and render session content as HTML in planning panel

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -98,6 +98,33 @@
         return (value || '').replace(/\s+/g, ' ').trim();
     }
 
+    function sanitizeSessionHtml(html) {
+        const template = document.createElement('template');
+        template.innerHTML = html || '';
+
+        template.content.querySelectorAll('script, style, iframe, object, embed').forEach((node) => {
+            node.remove();
+        });
+
+        template.content.querySelectorAll('*').forEach((element) => {
+            Array.from(element.attributes).forEach((attribute) => {
+                const attributeName = attribute.name.toLowerCase();
+                const attributeValue = (attribute.value || '').trim().toLowerCase();
+
+                if (attributeName.startsWith('on')) {
+                    element.removeAttribute(attribute.name);
+                    return;
+                }
+
+                if ((attributeName === 'href' || attributeName === 'src') && attributeValue.startsWith('javascript:')) {
+                    element.removeAttribute(attribute.name);
+                }
+            });
+        });
+
+        return template.innerHTML.trim();
+    }
+
     function parseBracketContent(text, startIndex = 0) {
         let plainText = '';
         const tasks = [];
@@ -189,7 +216,7 @@
         const details = parseSessionDetails(entry.detailsText || '');
 
         taskContentElement.className = 'task-detail-description';
-        taskContentElement.textContent = details.content || 'Contenu non renseigné.';
+        taskContentElement.innerHTML = sanitizeSessionHtml(details.content) || 'Contenu non renseigné.';
 
         taskListElement.innerHTML = '';
         if (!details.tasks.length) {


### PR DESCRIPTION
### Motivation
- Le contenu de séance s’affichait avec les balises HTML visibles parce qu’il était inséré via `textContent` au lieu d’être rendu comme HTML interprété.
- Il fallait permettre un rendu HTML limité tout en bloquant les vecteurs d’injection (scripts, attributs dangereux).

### Description
- Remplacement de `taskContentElement.textContent = ...` par `taskContentElement.innerHTML = sanitizeSessionHtml(...)` dans `home-progressions.js` pour afficher le contenu formaté.
- Ajout de la fonction `sanitizeSessionHtml(html)` qui supprime les éléments `script`, `style`, `iframe`, `object` et `embed`.
- La fonction retire également les attributs commençant par `on` et les URLs `javascript:` dans les attributs `href` et `src`.

### Testing
- Vérification de la syntaxe JavaScript avec `node --check home-progressions.js` : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de198f242c8331a48e0bff03b4fdd4)