### PR TITLE
Améliore l’affichage des sous-tâches sur la page d’accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -98,6 +98,129 @@
         return (value || '').replace(/\s+/g, ' ').trim();
     }
 
+    function parseInlineSubtasks(labelText) {
+        const parts = (labelText || '')
+            .split(';')
+            .map((part) => cleanText(part))
+            .filter(Boolean);
+
+        if (parts.length < 2 || parts.length % 2 !== 0) {
+            return null;
+        }
+
+        const parsed = [];
+        for (let i = 0; i < parts.length; i += 2) {
+            const name = parts[i];
+            const durationRaw = parts[i + 1].replace(',', '.');
+            const durationMinutes = Number.parseFloat(durationRaw);
+            if (!name || !Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+                return null;
+            }
+            parsed.push({
+                name,
+                durationMinutes
+            });
+        }
+
+        return parsed.length ? parsed : null;
+    }
+
+    function formatRemaining(seconds) {
+        const safeSeconds = Math.max(0, Math.floor(seconds));
+        const minutes = String(Math.floor(safeSeconds / 60)).padStart(2, '0');
+        const remainingSeconds = String(safeSeconds % 60).padStart(2, '0');
+        return `${minutes}:${remainingSeconds}`;
+    }
+
+    function createSubtaskTimerCard(subtask) {
+        const totalSeconds = Math.round(subtask.durationMinutes * 60);
+        let remainingSeconds = totalSeconds;
+        let intervalId = null;
+
+        const card = document.createElement('article');
+        card.className = 'task-subtask-card';
+
+        const title = document.createElement('h5');
+        title.className = 'task-subtask-title';
+        title.textContent = subtask.name;
+
+        const plannedDuration = document.createElement('p');
+        plannedDuration.className = 'task-subtask-duration';
+        plannedDuration.textContent = `Durée prévue : ${subtask.durationMinutes} min`;
+
+        const timer = document.createElement('p');
+        timer.className = 'task-subtask-timer';
+        timer.textContent = formatRemaining(remainingSeconds);
+
+        const actions = document.createElement('div');
+        actions.className = 'task-subtask-actions';
+
+        const startButton = document.createElement('button');
+        startButton.type = 'button';
+        startButton.textContent = 'Démarrer';
+
+        const pauseButton = document.createElement('button');
+        pauseButton.type = 'button';
+        pauseButton.textContent = 'Pause';
+
+        const resetButton = document.createElement('button');
+        resetButton.type = 'button';
+        resetButton.textContent = 'Remise à zéro';
+
+        function updateDisplay() {
+            timer.textContent = formatRemaining(remainingSeconds);
+            const isDone = remainingSeconds <= 0;
+            card.classList.toggle('task-subtask-card-complete', isDone);
+            startButton.disabled = isDone;
+            pauseButton.disabled = !intervalId;
+        }
+
+        function stopTimer() {
+            if (intervalId) {
+                clearInterval(intervalId);
+                intervalId = null;
+            }
+            updateDisplay();
+        }
+
+        startButton.addEventListener('click', () => {
+            if (intervalId || remainingSeconds <= 0) {
+                return;
+            }
+
+            intervalId = setInterval(() => {
+                remainingSeconds -= 1;
+                if (remainingSeconds <= 0) {
+                    remainingSeconds = 0;
+                    stopTimer();
+                } else {
+                    updateDisplay();
+                }
+            }, 1000);
+
+            updateDisplay();
+        });
+
+        pauseButton.addEventListener('click', stopTimer);
+        resetButton.addEventListener('click', () => {
+            stopTimer();
+            remainingSeconds = totalSeconds;
+            updateDisplay();
+        });
+
+        actions.appendChild(startButton);
+        actions.appendChild(pauseButton);
+        actions.appendChild(resetButton);
+
+        card.appendChild(title);
+        card.appendChild(plannedDuration);
+        card.appendChild(timer);
+        card.appendChild(actions);
+
+        updateDisplay();
+        return card;
+    }
+
     function sanitizeSessionHtml(html) {
         const template = document.createElement('template');
         template.innerHTML = html || '';
@@ -187,8 +310,23 @@
         tasks.forEach((task) => {
             const item = document.createElement('li');
             const label = document.createElement('span');
-            label.textContent = task.label || 'Tâche sans titre';
-            item.appendChild(label);
+            const inlineSubtasks = parseInlineSubtasks(task.label);
+
+            if (inlineSubtasks) {
+                label.className = 'task-group-title';
+                label.textContent = 'Sous-tâches';
+                item.appendChild(label);
+
+                const subtaskGrid = document.createElement('div');
+                subtaskGrid.className = 'task-subtasks-grid';
+                inlineSubtasks.forEach((subtask) => {
+                    subtaskGrid.appendChild(createSubtaskTimerCard(subtask));
+                });
+                item.appendChild(subtaskGrid);
+            } else {
+                label.textContent = task.label || 'Tâche sans titre';
+                item.appendChild(label);
+            }
 
             if (task.subtasks && task.subtasks.length) {
                 item.appendChild(buildTasksList(task.subtasks));

--- a/styles.css
+++ b/styles.css
@@ -1132,6 +1132,75 @@ svg.axe { display: block; margin: 0.5em 0; }
     margin-top: 6px;
 }
 
+.task-group-title {
+    display: inline-block;
+    margin-bottom: 8px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.task-subtasks-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 10px;
+    margin-bottom: 6px;
+}
+
+.task-subtask-card {
+    background: rgba(7, 16, 39, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 10px;
+    padding: 10px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.task-subtask-card-complete {
+    border-color: #47d16d;
+    box-shadow: 0 0 0 2px rgba(71, 209, 109, 0.25);
+}
+
+.task-subtask-title {
+    margin: 0;
+    font-size: 0.98rem;
+}
+
+.task-subtask-duration {
+    margin: 6px 0 0;
+    opacity: 0.85;
+    font-size: 0.9rem;
+}
+
+.task-subtask-timer {
+    margin: 8px 0;
+    font-size: 1.35rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+.task-subtask-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.task-subtask-actions button {
+    border: none;
+    border-radius: 6px;
+    padding: 6px 8px;
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+    cursor: pointer;
+}
+
+.task-subtask-actions button:hover {
+    background: rgba(255, 255, 255, 0.28);
+}
+
+.task-subtask-actions button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 @media (max-width: 900px) {
     .home-dashboard-grid {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Rendre les listes de sous-tâches (format `nom;durée;nom;durée`) plus lisibles sur la page projetée et permettre de lancer un minuteur indépendant pour chaque sous-tâche afin de mieux gérer le temps en classe.

### Description
- Ajout d'un parseur `parseInlineSubtasks` dans `home-progressions.js` pour reconnaître et valider le format `nom;durée;...` et convertir chaque paire en objet `{name, durationMinutes}`.
- Implémentation d'un minuteur indépendant par sous-tâche via `createSubtaskTimerCard` (affichage `mm:ss`, actions `Démarrer` / `Pause` / `Remise à zéro`, état visuel quand terminé) et intégration dans la liste avec `buildTasksList`.
- Ajout d'aides utilitaires `formatRemaining` et gestion propre des intervalles pour éviter les fuites de timers.
- Ajout des styles dans `styles.css` (`.task-group-title`, `.task-subtasks-grid`, `.task-subtask-card`, etc.) pour une grille de cartes lisible en projection et des boutons contrastés.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check home-progressions.js` qui a réussi.
- Aucun test E2E navigateur automatisé disponible dans cet environnement d'intégration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de1c624e788331be004e23031b49fb)