### PR TITLE
Compacte l'accueil, ajoute sections repliables et dégradé couleur pour minuteurs

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -7,6 +7,7 @@
     const showPastElement = document.getElementById('progression-show-past');
     const taskContentElement = document.getElementById('progression-task-content');
     const taskListElement = document.getElementById('progression-task-list');
+    const taskToggleButtons = Array.from(document.querySelectorAll('.task-toggle-button'));
 
     if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
@@ -170,7 +171,12 @@
         function updateDisplay() {
             timer.textContent = formatRemaining(remainingSeconds);
             const isDone = remainingSeconds <= 0;
+            const progressRatio = totalSeconds > 0 ? Math.min(1, Math.max(0, 1 - (remainingSeconds / totalSeconds))) : 0;
+
+            card.style.setProperty('--timer-progress', String(progressRatio));
             card.classList.toggle('task-subtask-card-complete', isDone);
+            card.classList.toggle('task-subtask-card-running', Boolean(intervalId) && !isDone);
+
             startButton.disabled = isDone;
             pauseButton.disabled = !intervalId;
         }
@@ -516,8 +522,29 @@
         renderSteps();
     }
 
+
+    function setupTaskSectionToggles() {
+        taskToggleButtons.forEach((button) => {
+            const targetId = button.dataset.toggleTarget;
+            const section = button.closest('[data-collapsible-section]');
+            const target = targetId ? document.getElementById(targetId) : null;
+
+            if (!section || !target) {
+                return;
+            }
+
+            button.addEventListener('click', () => {
+                const isCollapsed = section.classList.toggle('is-collapsed');
+                button.textContent = isCollapsed ? 'Afficher' : 'Masquer';
+                button.setAttribute('aria-expanded', String(!isCollapsed));
+            });
+        });
+    }
+
     classFilterElement.addEventListener('change', renderSteps);
     showPastElement.addEventListener('change', renderSteps);
+
+    setupTaskSectionToggles();
 
     setStatus('Chargement du planning...');
     loadRows().catch((error) => {

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <header>
+    <header class="home-header">
         <h1>Accueil</h1>
         <nav>
             <ul>
@@ -64,14 +64,20 @@
             <article class="atelier task-detail-card home-card-detail">
                 <div class="atelier-content">
                     <h2>Contenu de séance</h2>
-                    <section class="task-detail-section">
-                        <h3>Contenu</h3>
+                    <section class="task-detail-section" data-collapsible-section>
+                        <div class="task-detail-section-header">
+                            <h3>Contenu</h3>
+                            <button type="button" class="task-toggle-button" data-toggle-target="progression-task-content" aria-expanded="true">Masquer</button>
+                        </div>
                         <p id="progression-task-content" class="task-detail-empty">
                             Cliquez sur une tâche du planning pour afficher son contenu ici.
                         </p>
                     </section>
-                    <section class="task-detail-section">
-                        <h3>Tâches</h3>
+                    <section class="task-detail-section" data-collapsible-section>
+                        <div class="task-detail-section-header">
+                            <h3>Tâches</h3>
+                            <button type="button" class="task-toggle-button" data-toggle-target="progression-task-list" aria-expanded="true">Masquer</button>
+                        </div>
                         <div id="progression-task-list" class="task-detail-empty">
                             Aucune tâche à afficher.
                         </div>

--- a/styles.css
+++ b/styles.css
@@ -1328,3 +1328,97 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(110, 110, 110, 0.6);
     border-color: rgba(220, 220, 220, 0.85);
 }
+
+.home-header {
+    padding: 10px 16px;
+    margin: 8px 10px;
+}
+
+.home-header h1 {
+    margin: 0;
+    font-size: 1.4rem;
+    line-height: 1.2;
+}
+
+.home-header nav ul {
+    margin: 6px 0 0;
+}
+
+.home-header nav li {
+    margin: 0 10px 0 0;
+}
+
+.home-header nav a {
+    font-size: 0.95rem;
+}
+
+.home-dashboard-grid .atelier {
+    padding: 14px;
+}
+
+.sonometre-card .atelier-content h2,
+.datetime-card .atelier-content h2,
+.task-detail-card .atelier-content h2,
+.agenda-card .atelier-content h2 {
+    margin: 0 0 10px;
+    font-size: 1.2rem;
+}
+
+.sonometre-card .atelier-content > p {
+    margin: 6px 0;
+}
+
+.sonometre-controls {
+    margin: 6px 0;
+}
+
+.datetime-card {
+    min-height: 0;
+    padding-block: 10px;
+}
+
+.datetime-value {
+    font-size: clamp(1.5rem, 4vw, 2.4rem);
+    margin: 2px 0;
+}
+
+.datetime-label {
+    font-size: 1rem;
+}
+
+.task-detail-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.task-toggle-button {
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    padding: 4px 10px;
+    font-size: 0.82rem;
+    cursor: pointer;
+}
+
+.task-toggle-button:hover {
+    background: rgba(255, 255, 255, 0.24);
+}
+
+.task-detail-section.is-collapsed > #progression-task-content,
+.task-detail-section.is-collapsed > #progression-task-list {
+    display: none;
+}
+
+.task-subtask-card {
+    --timer-progress: 0;
+}
+
+.task-subtask-card-running {
+    background: linear-gradient(120deg,
+            rgb(calc(30 + (225 * var(--timer-progress))), 110, calc(255 - (210 * var(--timer-progress)))) 0%,
+            rgb(calc(5 + (250 * var(--timer-progress))), 20, calc(70 - (55 * var(--timer-progress)))) 100%);
+    transition: background 0.35s linear;
+}


### PR DESCRIPTION
### Motivation
- Rendre la page d'accueil plus compacte pour que tout tienne mieux à l'écran en réduisant l'encombrement de l'entête et la hauteur des blocs (sonomètre / date-heure). 
- Permettre de masquer/afficher rapidement le contenu de séance et la liste des tâches pour alléger l'affichage. 
- Améliorer le retour visuel des minuteurs en faisant évoluer le fond d'une carte du bleu au rouge pendant l'exécution d'une tâche.

### Description
- Mise à jour du DOM dans `index.html` : ajout de la classe `home-header` et insertion de boutons `button.task-toggle-button` dans les sections `Contenu` et `Tâches` (attribut `data-collapsible-section` et `data-toggle-target`).
- Styles ajoutés dans `styles.css` : règles compactes pour `home-header`, réduction des paddings/tailles des cartes, styles pour les boutons de bascule (`.task-toggle-button`) et règle `.task-detail-section.is-collapsed` pour cacher le contenu; ajout de la variable CSS `--timer-progress` et du style dynamique `.task-subtask-card-running` qui applique un dégradé dépendant de `--timer-progress`.
- JS modifié dans `home-progressions.js` : sélection des boutons de bascule (`taskToggleButtons`) et fonction `setupTaskSectionToggles()` qui gère l'état replié et met à jour `aria-expanded`, et mise à jour de `createSubtaskTimerCard()` pour calculer le ratio d'avancement (`progressRatio`), écrire la variable CSS `--timer-progress` sur la carte et basculer la classe `task-subtask-card-running` pendant l'exécution du minuteur.

### Testing
- Exécution de `git diff --check` qui n'a retourné aucune erreur et a validé le diff. (réussi)
- Vérification syntaxique du script avec `node --check home-progressions.js` (réussi)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2042cc508331b194b9e8b2ee9a42)