### PR TITLE
Ajout mode compact pour le sonomètre et bouton +/- pour le planning

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -8,6 +8,7 @@
     const taskContentElement = document.getElementById('progression-task-content');
     const taskListElement = document.getElementById('progression-task-list');
     const taskToggleButtons = Array.from(document.querySelectorAll('.task-toggle-button'));
+    const planningToggleCountButton = document.getElementById('progression-toggle-count');
 
     if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
@@ -20,6 +21,7 @@
     let stepIdx = -1;
     let detailsIdx = -1;
     let selectedEntryKey = '';
+    let showAllPlanningDates = false;
 
     function normalize(value) {
         return (value || '')
@@ -145,10 +147,6 @@
         title.className = 'task-subtask-title';
         title.textContent = subtask.name;
 
-        const plannedDuration = document.createElement('p');
-        plannedDuration.className = 'task-subtask-duration';
-        plannedDuration.textContent = `Durée prévue : ${subtask.durationMinutes} min`;
-
         const timer = document.createElement('p');
         timer.className = 'task-subtask-timer';
         timer.textContent = formatRemaining(remainingSeconds);
@@ -219,7 +217,6 @@
         actions.appendChild(resetButton);
 
         card.appendChild(title);
-        card.appendChild(plannedDuration);
         card.appendChild(timer);
         card.appendChild(actions);
 
@@ -425,15 +422,23 @@
                 return a.dateValue - b.dateValue;
             });
 
+        const displayedEntries = showAllPlanningDates ? entries : entries.slice(0, 3);
+
+        if (planningToggleCountButton) {
+            planningToggleCountButton.textContent = showAllPlanningDates ? '-' : '+';
+            planningToggleCountButton.setAttribute('aria-expanded', String(showAllPlanningDates));
+            planningToggleCountButton.title = showAllPlanningDates ? 'Afficher seulement les 3 prochaines dates' : 'Afficher toutes les dates';
+        }
+
         listElement.innerHTML = '';
 
-        if (!entries.length) {
+        if (!displayedEntries.length) {
             renderTaskDetail(null);
             setStatus('Aucune tâche trouvée.', true);
             return;
         }
 
-        entries.forEach((entry) => {
+        displayedEntries.forEach((entry) => {
             const item = document.createElement('li');
             const entryKey = getEntryKey(entry);
             const taskButton = document.createElement('button');
@@ -470,7 +475,7 @@
             listElement.appendChild(item);
         });
 
-        if (!entries.some((entry) => getEntryKey(entry) === selectedEntryKey)) {
+        if (!displayedEntries.some((entry) => getEntryKey(entry) === selectedEntryKey)) {
             selectedEntryKey = '';
             renderTaskDetail(null);
         }
@@ -543,6 +548,10 @@
 
     classFilterElement.addEventListener('change', renderSteps);
     showPastElement.addEventListener('change', renderSteps);
+    planningToggleCountButton?.addEventListener('click', () => {
+        showAllPlanningDates = !showAllPlanningDates;
+        renderSteps();
+    });
 
     setupTaskSectionToggles();
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,10 @@
         <section class="description-ateliers home-dashboard-grid">
             <article class="atelier sonometre-card home-card-sonometre">
                 <div class="atelier-content">
-                    <h2>Régulation du bruit</h2>
+                    <div class="card-header-with-toggle">
+                        <h2>Régulation du bruit</h2>
+                        <button id="toggle-sonometre-compact" type="button" class="panel-toggle-button" aria-expanded="true">Masquer</button>
+                    </div>
 
                     <div class="sonometre-controls">
                         <label for="seuil">Seuil de bruit (%) :</label>
@@ -86,7 +89,10 @@
             </article>
             <article class="atelier agenda-card home-card-agenda">
                 <div class="atelier-content">
-                    <h2>Planning</h2>
+                    <div class="card-header-with-toggle">
+                        <h2>Planning</h2>
+                        <button id="progression-toggle-count" type="button" class="panel-toggle-button" aria-expanded="false">+</button>
+                    </div>
 
                     <div class="progression-controls">
                         <label for="progression-class-filter">Classe :</label>

--- a/sonometre.js
+++ b/sonometre.js
@@ -14,6 +14,7 @@
   const decrementBtn = document.getElementById('decrement-compteur');
   const incrementBtn = document.getElementById('increment-compteur');
   const resetBtn = document.getElementById('reset-compteur');
+  const compactToggleBtn = document.getElementById('toggle-sonometre-compact');
 
   if (!seuilInput || !sensibiliteInput || !barreNiveau || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn) return;
 
@@ -23,6 +24,7 @@
   let depassements = 0;
   let lastTriggerAt = 0;
   let isPaused = false;
+  let isCompact = false;
   const triggerCooldownMs = 1200;
 
   const playAlertSignal = () => {
@@ -48,6 +50,14 @@
       oscillator.start(startAt);
       oscillator.stop(startAt + beepDuration);
     });
+  };
+
+  const updateCompactMode = () => {
+    if (!sonometreCard || !compactToggleBtn) return;
+
+    sonometreCard.classList.toggle('is-compact', isCompact);
+    compactToggleBtn.textContent = isCompact ? 'Afficher' : 'Masquer';
+    compactToggleBtn.setAttribute('aria-expanded', String(!isCompact));
   };
 
   const updateCompteur = () => {
@@ -178,9 +188,15 @@
     updateCompteur();
   });
 
+  compactToggleBtn?.addEventListener('click', () => {
+    isCompact = !isCompact;
+    updateCompactMode();
+  });
+
   pauseBtn.disabled = false;
   pauseBtn.removeAttribute('disabled');
   updateSeuilLabel();
   updateSensibiliteLabel();
   updateCompteur();
+  updateCompactMode();
 })();

--- a/styles.css
+++ b/styles.css
@@ -1164,11 +1164,6 @@ svg.axe { display: block; margin: 0.5em 0; }
     font-size: 0.98rem;
 }
 
-.task-subtask-duration {
-    margin: 6px 0 0;
-    opacity: 0.85;
-    font-size: 0.9rem;
-}
 
 .task-subtask-timer {
     margin: 8px 0;
@@ -1360,9 +1355,44 @@ svg.axe { display: block; margin: 0.5em 0; }
 .datetime-card .atelier-content h2,
 .task-detail-card .atelier-content h2,
 .agenda-card .atelier-content h2 {
-    margin: 0 0 10px;
+    margin: 0;
     font-size: 1.2rem;
 }
+
+
+.card-header-with-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.panel-toggle-button {
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    padding: 4px 12px;
+    font-size: 0.82rem;
+    cursor: pointer;
+}
+
+.panel-toggle-button:hover {
+    background: rgba(255, 255, 255, 0.24);
+}
+
+.sonometre-card.is-compact .sonometre-controls,
+.sonometre-card.is-compact #niveau-live,
+.sonometre-card.is-compact .sonometre-actions,
+.sonometre-card.is-compact .seuil-marker,
+.sonometre-card.is-compact .seuil-marker-label {
+    display: none;
+}
+
+.sonometre-card.is-compact .barre-wrapper {
+    margin-top: 8px;
+}
+
 
 .sonometre-card .atelier-content > p {
     margin: 6px 0;


### PR DESCRIPTION
### Motivation
- Réduire l’encombrement de la page d’accueil en proposant une vue compacte du module de régulation du bruit et un contrôle pour limiter l’affichage du planning.
- Garder les fonctionnalités essentielles visibles (barre de progression et minuteur/compteur) tout en permettant d’agrandir si besoin.

### Description
- Ajout d’un en-tête réutilisable avec bouton de bascule dans `index.html` pour la carte `Régulation du bruit` et pour la carte `Planning` (`#toggle-sonometre-compact`, `#progression-toggle-count`).
- Implémentation d’un `is-compact` pour la carte sonomètre dans `sonometre.js` qui ajoute/retire la classe `is-compact` et met à jour l’attribut ARIA du bouton pour l’état `Masquer`/`Afficher`.
- Ajout d’un état `showAllPlanningDates` dans `home-progressions.js` et rendu conditionnel qui affiche soit les 3 prochaines entrées soit toutes les dates, contrôlé par le bouton `progression-toggle-count` (`+`/`-`).
- Suppression de la ligne `Durée prévue : ...` dans les cartes de sous-tâches et adaptation du CSS dans `styles.css` pour le style des boutons et la règle d’affichage compacte du sonomètre.

### Testing
- Vérification syntaxique des scripts JavaScript avec `node --check sonometre.js && node --check home-progressions.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de22e2f8d083319b8daeae6588537f)