### PR TITLE
Retire le libellé « Sous-tâches » de la page d'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -316,10 +316,6 @@
             const inlineSubtasks = parseInlineSubtasks(task.label);
 
             if (inlineSubtasks) {
-                label.className = 'task-group-title';
-                label.textContent = 'Sous-tâches';
-                item.appendChild(label);
-
                 const subtaskGrid = document.createElement('div');
                 subtaskGrid.className = 'task-subtasks-grid';
                 inlineSubtasks.forEach((subtask) => {


### PR DESCRIPTION
### Motivation
- Réduire l'encombrement visuel de la liste de détails des tâches en supprimant le libellé superflu « Sous-tâches ». 

### Description
- Supprime la création et l'ajout du `span` contenant `label.className = 'task-group-title'` et `label.textContent = 'Sous-tâches'` dans la fonction `buildTasksList` de `home-progressions.js`, tout en conservant le rendu de la grille des sous-tâches (`task-subtasks-grid`).

### Testing
- Aucun test automatisé n'a été exécuté pour ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de286544f883319ef94129f8967eae)