### PR TITLE
Afficher les messages importants dans le bloc Planning

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -9,6 +9,8 @@
     const taskListElement = document.getElementById('progression-task-list');
     const taskToggleButtons = Array.from(document.querySelectorAll('.task-toggle-button'));
     const planningToggleCountButton = document.getElementById('progression-toggle-count');
+    const importantMessagesPanelElement = document.getElementById('important-messages-panel');
+    const importantMessageTextElement = document.getElementById('important-message-text');
 
     if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
@@ -22,6 +24,8 @@
     let detailsIdx = -1;
     let selectedEntryKey = '';
     let showAllPlanningDates = false;
+    let importantMessagesIntervalId = null;
+    let currentImportantMessageIndex = 0;
 
     function normalize(value) {
         return (value || '')
@@ -288,7 +292,17 @@
     }
 
     function parseSessionDetails(detailsText) {
-        const parsed = parseBracketContent(detailsText || '', 0);
+        const sourceText = detailsText || '';
+        const importantMessages = [];
+        const textWithoutMessages = sourceText.replace(/\$([^$]+)\$/g, (_, message) => {
+            const cleanedMessage = cleanText(message);
+            if (cleanedMessage) {
+                importantMessages.push(cleanedMessage);
+            }
+            return ' ';
+        });
+
+        const parsed = parseBracketContent(textWithoutMessages, 0);
         const content = cleanText(parsed.plainText);
 
         function normalizeTasks(tasks) {
@@ -302,8 +316,44 @@
 
         return {
             content,
-            tasks: normalizeTasks(parsed.tasks || [])
+            tasks: normalizeTasks(parsed.tasks || []),
+            importantMessages
         };
+    }
+
+    function stopImportantMessagesRotation() {
+        if (importantMessagesIntervalId) {
+            clearInterval(importantMessagesIntervalId);
+            importantMessagesIntervalId = null;
+        }
+    }
+
+    function renderImportantMessages(messages) {
+        if (!importantMessagesPanelElement || !importantMessageTextElement) {
+            return;
+        }
+
+        stopImportantMessagesRotation();
+        currentImportantMessageIndex = 0;
+
+        if (!messages.length) {
+            importantMessagesPanelElement.classList.remove('has-important-messages');
+            importantMessageTextElement.className = 'important-messages-empty';
+            importantMessageTextElement.textContent = 'Aucun message important.';
+            return;
+        }
+
+        const uniqueMessages = Array.from(new Set(messages));
+        importantMessagesPanelElement.classList.add('has-important-messages');
+        importantMessageTextElement.className = 'important-messages-content';
+        importantMessageTextElement.textContent = uniqueMessages[currentImportantMessageIndex];
+
+        if (uniqueMessages.length > 1) {
+            importantMessagesIntervalId = setInterval(() => {
+                currentImportantMessageIndex = (currentImportantMessageIndex + 1) % uniqueMessages.length;
+                importantMessageTextElement.textContent = uniqueMessages[currentImportantMessageIndex];
+            }, 30000);
+        }
     }
 
     function buildTasksList(tasks) {
@@ -430,9 +480,14 @@
 
         if (!displayedEntries.length) {
             renderTaskDetail(null);
+            renderImportantMessages([]);
             setStatus('Aucune tâche trouvée.', true);
             return;
         }
+
+        const importantMessages = displayedEntries
+            .flatMap((entry) => parseSessionDetails(entry.detailsText || '').importantMessages || []);
+        renderImportantMessages(importantMessages);
 
         displayedEntries.forEach((entry) => {
             const item = document.createElement('li');
@@ -554,6 +609,7 @@
     setStatus('Chargement du planning...');
     loadRows().catch((error) => {
         listElement.innerHTML = '';
+        renderImportantMessages([]);
         setStatus(`Impossible de charger le suivi : ${error.message}`, true);
     });
 })();

--- a/index.html
+++ b/index.html
@@ -109,6 +109,10 @@
 
                     <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
                     <ul id="progression-steps-list" class="calendar-events-list"></ul>
+                    <section id="important-messages-panel" class="important-messages-panel" aria-live="polite">
+                        <h3>Messages importants</h3>
+                        <p id="important-message-text" class="important-messages-empty">Aucun message important.</p>
+                    </section>
                 </div>
             </article>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -1262,6 +1262,40 @@ svg.axe { display: block; margin: 0.5em 0; }
     padding: 10px;
 }
 
+.important-messages-panel {
+    margin-top: 16px;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgba(0, 0, 0, 0.3);
+}
+
+.important-messages-panel h3 {
+    margin: 0 0 8px;
+    font-size: 1rem;
+}
+
+.important-messages-panel.has-important-messages {
+    background: rgba(220, 20, 60, 0.65);
+    border-color: rgba(255, 160, 160, 0.85);
+}
+
+.important-messages-empty,
+.important-messages-content {
+    margin: 0;
+    min-height: 24px;
+    line-height: 1.45;
+}
+
+.important-messages-empty {
+    opacity: 0.85;
+    font-style: italic;
+}
+
+.important-messages-content {
+    font-weight: 700;
+}
+
 .calendar-events-list strong {
     display: block;
     margin-bottom: 4px;


### PR DESCRIPTION
### Motivation
- Permettre l'affichage distinct des messages importants extraits du "contenu de séance" pour les mettre en évidence sous le planning. 
- Ne plus afficher ces messages dans le texte principal de la séance et les faire défiler automatiquement pour attirer l'attention.

### Description
- Ajout d'un panneau HTML empilé sous la liste du planning dans `index.html` (`#important-messages-panel` / `#important-message-text`).
- Extraction des messages encadrés par `$...$` dans `home-progressions.js` et suppression de ces fragments du contenu affiché avec la regex `/\$([^$]+)\$/g` avant le parsing existant; les messages sont collectés, dédupliqués et exposés au panneau dédié.
- Mise en place d'une rotation automatique des messages toutes les `30000` ms (30 secondes) avec arrêt propre de l'intervalle lorsqu'il n'y a plus de messages.
- Ajout de styles dans `styles.css` pour le panneau et activation d'un fond rouge via la classe `has-important-messages` quand des messages sont présents.

### Testing
- `node --check home-progressions.js` a été exécuté et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2db1aa9c8331ba34aac505eb2008)