### PR TITLE
Centrage et transitions pour les messages importants sur la page d’accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -25,6 +25,7 @@
     let selectedEntryKey = '';
     let showAllPlanningDates = false;
     let importantMessagesIntervalId = null;
+    let importantMessageTransitionTimeoutId = null;
     let currentImportantMessageIndex = 0;
 
     function normalize(value) {
@@ -326,6 +327,31 @@
             clearInterval(importantMessagesIntervalId);
             importantMessagesIntervalId = null;
         }
+
+        if (importantMessageTransitionTimeoutId) {
+            clearTimeout(importantMessageTransitionTimeoutId);
+            importantMessageTransitionTimeoutId = null;
+        }
+    }
+
+    function updateImportantMessageWithTransition(message) {
+        const supportsMotion = !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+        if (!supportsMotion) {
+            importantMessageTextElement.textContent = message;
+            return;
+        }
+
+        importantMessageTextElement.classList.remove('is-transitioning-in');
+        void importantMessageTextElement.offsetWidth;
+        importantMessageTextElement.classList.add('is-transitioning-out');
+
+        importantMessageTransitionTimeoutId = setTimeout(() => {
+            importantMessageTextElement.textContent = message;
+            importantMessageTextElement.classList.remove('is-transitioning-out');
+            importantMessageTextElement.classList.add('is-transitioning-in');
+            importantMessageTransitionTimeoutId = null;
+        }, 220);
     }
 
     function renderImportantMessages(messages) {
@@ -351,8 +377,8 @@
         if (uniqueMessages.length > 1) {
             importantMessagesIntervalId = setInterval(() => {
                 currentImportantMessageIndex = (currentImportantMessageIndex + 1) % uniqueMessages.length;
-                importantMessageTextElement.textContent = uniqueMessages[currentImportantMessageIndex];
-            }, 30000);
+                updateImportantMessageWithTransition(uniqueMessages[currentImportantMessageIndex]);
+            }, 8000);
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -110,7 +110,6 @@
                     <p id="progression-status" class="calendar-status" aria-live="polite">Initialisation...</p>
                     <ul id="progression-steps-list" class="calendar-events-list"></ul>
                     <section id="important-messages-panel" class="important-messages-panel" aria-live="polite">
-                        <h3>Messages importants</h3>
                         <p id="important-message-text" class="important-messages-empty">Aucun message important.</p>
                     </section>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -1268,11 +1268,7 @@ svg.axe { display: block; margin: 0.5em 0; }
     border-radius: 8px;
     border: 1px solid rgba(255, 255, 255, 0.22);
     background: rgba(0, 0, 0, 0.3);
-}
-
-.important-messages-panel h3 {
-    margin: 0 0 8px;
-    font-size: 1rem;
+    text-align: center;
 }
 
 .important-messages-panel.has-important-messages {
@@ -1285,6 +1281,7 @@ svg.axe { display: block; margin: 0.5em 0; }
     margin: 0;
     min-height: 24px;
     line-height: 1.45;
+    text-align: center;
 }
 
 .important-messages-empty {
@@ -1294,6 +1291,37 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .important-messages-content {
     font-weight: 700;
+}
+
+.important-messages-content.is-transitioning-out {
+    opacity: 0;
+    transform: translateY(-6px);
+}
+
+.important-messages-content.is-transitioning-in {
+    animation: importantMessageFadeIn 380ms ease;
+}
+
+@keyframes importantMessageFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .important-messages-content.is-transitioning-in {
+        animation: none;
+    }
+
+    .important-messages-content.is-transitioning-out {
+        opacity: 1;
+        transform: none;
+    }
 }
 
 .calendar-events-list strong {


### PR DESCRIPTION
### Motivation
- Rendre le panneau des messages importants plus lisible et attractif en retirant le titre redondant, en centrant le texte et en ajoutant une transition visuelle lors du changement de message.
- Améliorer la perception des messages en accélérant légèrement la rotation et en évitant les artefacts de timers résiduels tout en respectant `prefers-reduced-motion`.

### Description
- Retiré le titre du panneau dans `index.html` pour ne conserver que le texte du message (`<h3>` supprimé).
- Centré le contenu du panneau en ajoutant `text-align: center;` au sélecteur `.important-messages-panel` et au texte via `styles.css`.
- Ajouté des styles d’animation et des classes utilitaires (`.is-transitioning-out`, `.is-transitioning-in`) et la clé `@keyframes importantMessageFadeIn` dans `styles.css`, avec gestion de `prefers-reduced-motion`.
- Modifié `home-progressions.js` pour implémenter la transition : ajout de `importantMessageTransitionTimeoutId`, nettoyage des timers dans `stopImportantMessagesRotation`, nouvelle fonction `updateImportantMessageWithTransition(message)` et remplacement de l’affectation directe du texte par cette fonction; la rotation passe de 30s à 8s.

### Testing
- Exécuté `node --check home-progressions.js` qui a réussi.
- Exécuté `git diff --check` qui n’a rapporté d’erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4fc78cf48331a13e681d40a50592)