### PR TITLE
Cacher le panneau « message important » sans sélection et améliorer l’affichage des sous‑tâches

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -354,21 +354,24 @@
         }, 220);
     }
 
-    function renderImportantMessages(messages) {
+    function renderImportantMessages(messages, options = {}) {
         if (!importantMessagesPanelElement || !importantMessageTextElement) {
             return;
         }
 
+        const { hideWhenEmpty = false } = options;
         stopImportantMessagesRotation();
         currentImportantMessageIndex = 0;
 
         if (!messages.length) {
+            importantMessagesPanelElement.hidden = hideWhenEmpty;
             importantMessagesPanelElement.classList.remove('has-important-messages');
             importantMessageTextElement.className = 'important-messages-empty';
             importantMessageTextElement.textContent = 'Aucun message important.';
             return;
         }
 
+        importantMessagesPanelElement.hidden = false;
         const uniqueMessages = Array.from(new Set(messages));
         importantMessagesPanelElement.classList.add('has-important-messages');
         importantMessageTextElement.className = 'important-messages-content';
@@ -383,12 +386,12 @@
     }
 
     function buildTasksList(tasks) {
-        const list = document.createElement('ol');
+        const list = document.createElement('ul');
         list.className = 'task-detail-tasks';
 
         tasks.forEach((task) => {
             const item = document.createElement('li');
-            const label = document.createElement('span');
+            const label = document.createElement('strong');
             const inlineSubtasks = parseInlineSubtasks(task.label);
 
             if (inlineSubtasks) {
@@ -511,9 +514,13 @@
             return;
         }
 
-        const importantMessages = displayedEntries
-            .flatMap((entry) => parseSessionDetails(entry.detailsText || '').importantMessages || []);
-        renderImportantMessages(importantMessages);
+        const selectedEntry = displayedEntries.find((entry) => getEntryKey(entry) === selectedEntryKey);
+        if (selectedEntry) {
+            const importantMessages = parseSessionDetails(selectedEntry.detailsText || '').importantMessages || [];
+            renderImportantMessages(importantMessages);
+        } else {
+            renderImportantMessages([], { hideWhenEmpty: true });
+        }
 
         displayedEntries.forEach((entry) => {
             const item = document.createElement('li');

--- a/styles.css
+++ b/styles.css
@@ -1125,11 +1125,13 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .task-detail-tasks {
     margin: 0;
-    padding-left: 20px;
+    padding-left: 0;
+    list-style: none;
 }
 
 .task-detail-tasks .task-detail-tasks {
     margin-top: 6px;
+    padding-left: 16px;
 }
 
 .task-group-title {


### PR DESCRIPTION
### Motivation
- Éviter d’afficher un message important générique lorsque l’utilisateur n’a sélectionné aucune date/entrée du planning.
- Rendre le détail des tâches plus lisible en mettant le nom de la tâche en évidence et en supprimant la numérotation des sous‑tâches.

### Description
- Modifie `renderImportantMessages` pour accepter une option `hideWhenEmpty` et utiliser `element.hidden` pour masquer le panneau quand il n’y a rien à afficher.
- Calcule et affiche désormais les messages importants uniquement pour l’entrée sélectionnée au lieu d’agréger toutes les entrées visibles (`home-progressions.js`).
- Change la structure des sous‑tâches de `<ol>` vers `<ul>` et remplace le label inline par un élément `<strong>` pour mettre le nom de la tâche en gras (`home-progressions.js`).
- Ajuste le style CSS (`styles.css`) pour supprimer les puces des listes de sous‑tâches et corriger les retraits afin d’éviter la numérotation/puce visible.

### Testing
- Exécuté `node --check home-progressions.js` et la vérification de syntaxe a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de75cf0fec8331bb512b8ce585c446)