### PR TITLE
Améliore les minuteurs des sous‑tâches sur la page d’accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -140,10 +140,47 @@
         return `${minutes}:${remainingSeconds}`;
     }
 
-    function createSubtaskTimerCard(subtask) {
-        const totalSeconds = Math.round(subtask.durationMinutes * 60);
+    function playTimerAlert() {
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) {
+            return;
+        }
+
+        const audioContext = new AudioContextClass();
+        const now = audioContext.currentTime;
+        const notes = [784, 1047, 784, 1175, 988, 1319];
+
+        notes.forEach((frequency, index) => {
+            const startAt = now + (index * 0.22);
+            const stopAt = startAt + 0.18;
+
+            const oscillator = audioContext.createOscillator();
+            oscillator.type = index % 2 === 0 ? 'square' : 'sawtooth';
+            oscillator.frequency.setValueAtTime(frequency, startAt);
+
+            const gainNode = audioContext.createGain();
+            gainNode.gain.setValueAtTime(0.0001, startAt);
+            gainNode.gain.exponentialRampToValueAtTime(0.42, startAt + 0.02);
+            gainNode.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+
+            oscillator.connect(gainNode);
+            gainNode.connect(audioContext.destination);
+            oscillator.start(startAt);
+            oscillator.stop(stopAt + 0.02);
+        });
+
+        window.setTimeout(() => {
+            audioContext.close();
+        }, Math.ceil((notes.length * 220) + 250));
+    }
+
+    function createSubtaskTimerCard(subtask, options = {}) {
+        const onComplete = typeof options.onComplete === 'function' ? options.onComplete : null;
+        const initialTotalSeconds = Math.max(0, Math.round(subtask.durationMinutes * 60));
+        let totalSeconds = initialTotalSeconds;
         let remainingSeconds = totalSeconds;
         let intervalId = null;
+        let hasTriggeredCompletion = false;
 
         const card = document.createElement('article');
         card.className = 'task-subtask-card';
@@ -171,6 +208,14 @@
         resetButton.type = 'button';
         resetButton.textContent = 'Remise à zéro';
 
+        const removeMinuteButton = document.createElement('button');
+        removeMinuteButton.type = 'button';
+        removeMinuteButton.textContent = '-1 min';
+
+        const addMinuteButton = document.createElement('button');
+        addMinuteButton.type = 'button';
+        addMinuteButton.textContent = '+1 min';
+
         function updateDisplay() {
             timer.textContent = formatRemaining(remainingSeconds);
             const isDone = remainingSeconds <= 0;
@@ -182,6 +227,7 @@
 
             startButton.disabled = isDone;
             pauseButton.disabled = !intervalId;
+            removeMinuteButton.disabled = remainingSeconds <= 0;
         }
 
         function stopTimer() {
@@ -192,7 +238,19 @@
             updateDisplay();
         }
 
-        startButton.addEventListener('click', () => {
+        function finishTimer() {
+            remainingSeconds = 0;
+            stopTimer();
+            if (!hasTriggeredCompletion) {
+                hasTriggeredCompletion = true;
+                playTimerAlert();
+                if (onComplete) {
+                    onComplete();
+                }
+            }
+        }
+
+        function startTimer() {
             if (intervalId || remainingSeconds <= 0) {
                 return;
             }
@@ -200,33 +258,56 @@
             intervalId = setInterval(() => {
                 remainingSeconds -= 1;
                 if (remainingSeconds <= 0) {
-                    remainingSeconds = 0;
-                    stopTimer();
+                    finishTimer();
                 } else {
                     updateDisplay();
                 }
             }, 1000);
 
             updateDisplay();
-        });
+        }
 
+        function adjustTime(deltaSeconds) {
+            remainingSeconds = Math.max(0, remainingSeconds + deltaSeconds);
+            totalSeconds = Math.max(remainingSeconds, totalSeconds + deltaSeconds, 0);
+            if (remainingSeconds > 0) {
+                hasTriggeredCompletion = false;
+            }
+            if (remainingSeconds <= 0) {
+                finishTimer();
+                return;
+            }
+            updateDisplay();
+        }
+
+        startButton.addEventListener('click', startTimer);
         pauseButton.addEventListener('click', stopTimer);
         resetButton.addEventListener('click', () => {
             stopTimer();
+            totalSeconds = initialTotalSeconds;
             remainingSeconds = totalSeconds;
+            hasTriggeredCompletion = false;
             updateDisplay();
         });
+        removeMinuteButton.addEventListener('click', () => adjustTime(-60));
+        addMinuteButton.addEventListener('click', () => adjustTime(60));
 
         actions.appendChild(startButton);
         actions.appendChild(pauseButton);
         actions.appendChild(resetButton);
+        actions.appendChild(removeMinuteButton);
+        actions.appendChild(addMinuteButton);
 
         card.appendChild(title);
         card.appendChild(timer);
         card.appendChild(actions);
 
         updateDisplay();
-        return card;
+        return {
+            element: card,
+            start: startTimer,
+            isComplete: () => remainingSeconds <= 0
+        };
     }
 
     function sanitizeSessionHtml(html) {
@@ -397,8 +478,17 @@
             if (inlineSubtasks) {
                 const subtaskGrid = document.createElement('div');
                 subtaskGrid.className = 'task-subtasks-grid';
-                inlineSubtasks.forEach((subtask) => {
-                    subtaskGrid.appendChild(createSubtaskTimerCard(subtask));
+                const timerCards = inlineSubtasks.map((subtask, index) => createSubtaskTimerCard(subtask, {
+                    onComplete: () => {
+                        const nextTimer = timerCards[index + 1];
+                        if (nextTimer && !nextTimer.isComplete()) {
+                            nextTimer.start();
+                        }
+                    }
+                }));
+
+                timerCards.forEach((timerCard) => {
+                    subtaskGrid.appendChild(timerCard.element);
                 });
                 item.appendChild(subtaskGrid);
             } else {

--- a/styles.css
+++ b/styles.css
@@ -1157,8 +1157,9 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .task-subtask-card-complete {
-    border-color: #47d16d;
-    box-shadow: 0 0 0 2px rgba(71, 209, 109, 0.25);
+    background: linear-gradient(135deg, rgba(31, 135, 76, 0.95) 0%, rgba(13, 94, 50, 0.98) 100%);
+    border-color: #6ff0a5;
+    box-shadow: 0 0 0 2px rgba(111, 240, 165, 0.3);
 }
 
 .task-subtask-title {
@@ -1168,9 +1169,11 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 
 .task-subtask-timer {
-    margin: 8px 0;
-    font-size: 1.35rem;
-    font-weight: 700;
+    margin: 10px 0;
+    text-align: center;
+    font-size: 1.9rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
     font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
### Motivation
- Rendre les minuteurs de sous‑tâches plus lisibles et utilisables depuis la page d’accueil. 
- Signaler clairement la fin d’un minuteur et permettre d’enchaîner automatiquement la sous‑tâche suivante. 
- Offrir la possibilité d’ajuster la durée à la volée et d’avoir une alerte sonore suffisamment marquée.

### Description
- Ajout d’une alerte sonore via Web Audio API avec la nouvelle fonction `playTimerAlert()` et déclenchement à la fin d’un minuteur dans `home-progressions.js`.
- Refactor de `createSubtaskTimerCard` pour accepter un `options` (`onComplete`), gérer `totalSeconds`/`remainingSeconds`, retourner un objet `{ element, start, isComplete }`, et ajouter les contrôles `+1 min` et `-1 min` ainsi que la logique `finishTimer()` pour un état de fin unique.
- Enchaînement automatique implémenté dans `buildTasksList` en créant `timerCards` et en appelant `nextTimer.start()` depuis le `onComplete` de la sous‑tâche précédente.
- Styles mis à jour dans `styles.css` : agrandissement et centrage du texte du minuteur (`.task-subtask-timer`) et application d’un fond vert/ombre cohérent au style du site pour `.task-subtask-card-complete`.
- Fichiers modifiés : `home-progressions.js`, `styles.css`.

### Testing
- Vérification de syntaxe JavaScript exécutée avec `node --check home-progressions.js` qui a réussi.
- Aucun test automatisé additionnel présent, vérification visuelle et comportementale prévue en navigateur (non automatisée ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df960221a883318424332ea07cd12b)