### PR TITLE
Ajout du basculeur +/- pour les minuteurs de l'écran d'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -185,9 +185,19 @@
         const card = document.createElement('article');
         card.className = 'task-subtask-card';
 
+        const header = document.createElement('div');
+        header.className = 'task-subtask-header';
+
         const title = document.createElement('h5');
         title.className = 'task-subtask-title';
         title.textContent = subtask.name;
+
+        const compactToggleButton = document.createElement('button');
+        compactToggleButton.type = 'button';
+        compactToggleButton.className = 'task-subtask-compact-toggle';
+        compactToggleButton.textContent = '-';
+        compactToggleButton.setAttribute('aria-expanded', 'true');
+        compactToggleButton.setAttribute('aria-label', 'Basculer l’affichage des boutons du minuteur');
 
         const timer = document.createElement('p');
         timer.className = 'task-subtask-timer';
@@ -215,6 +225,15 @@
         const addMinuteButton = document.createElement('button');
         addMinuteButton.type = 'button';
         addMinuteButton.textContent = '+1 min';
+
+        function setCompactMode(isCompact) {
+            card.classList.toggle('task-subtask-card-compact', isCompact);
+            compactToggleButton.textContent = isCompact ? '+' : '-';
+            compactToggleButton.setAttribute('aria-expanded', String(!isCompact));
+            compactToggleButton.setAttribute('aria-label', isCompact
+                ? 'Afficher les boutons du minuteur'
+                : 'Masquer les boutons du minuteur');
+        }
 
         function updateDisplay() {
             timer.textContent = formatRemaining(remainingSeconds);
@@ -291,14 +310,20 @@
         });
         removeMinuteButton.addEventListener('click', () => adjustTime(-60));
         addMinuteButton.addEventListener('click', () => adjustTime(60));
+        compactToggleButton.addEventListener('click', () => {
+            const isCompact = !card.classList.contains('task-subtask-card-compact');
+            setCompactMode(isCompact);
+        });
 
+        header.appendChild(title);
+        header.appendChild(compactToggleButton);
         actions.appendChild(startButton);
         actions.appendChild(pauseButton);
         actions.appendChild(resetButton);
         actions.appendChild(removeMinuteButton);
         actions.appendChild(addMinuteButton);
 
-        card.appendChild(title);
+        card.appendChild(header);
         card.appendChild(timer);
         card.appendChild(actions);
 

--- a/styles.css
+++ b/styles.css
@@ -1167,6 +1167,31 @@ svg.axe { display: block; margin: 0.5em 0; }
     font-size: 0.98rem;
 }
 
+.task-subtask-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.task-subtask-compact-toggle {
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    width: 24px;
+    height: 24px;
+    font-size: 0.95rem;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0;
+    cursor: pointer;
+    flex: 0 0 24px;
+}
+
+.task-subtask-compact-toggle:hover {
+    background: rgba(255, 255, 255, 0.24);
+}
 
 .task-subtask-timer {
     margin: 10px 0;
@@ -1181,6 +1206,10 @@ svg.axe { display: block; margin: 0.5em 0; }
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
+}
+
+.task-subtask-card-compact .task-subtask-actions {
+    display: none;
 }
 
 .task-subtask-actions button {


### PR DESCRIPTION
### Motivation
- Permettre pour chaque minuteur du planning de basculer entre un affichage synthétique (sans les boutons d'action) et l'affichage complet avec les boutons. 
- Offrir un contrôle simple (+/−) et améliorer l'accessibilité en mettant à jour les attributs ARIA lors du basculement.

### Description
- Ajout d'un en-tête `task-subtask-header` et insertion d'un bouton `task-subtask-compact-toggle` dans `createSubtaskTimerCard` (fichier `home-progressions.js`) pour piloter le mode compact. 
- Implémentation de la fonction `setCompactMode(isCompact)` qui applique la classe `task-subtask-card-compact` sur la carte et met à jour le texte et les attributs ARIA du bouton. 
- Ajout des styles dans `styles.css` pour `task-subtask-header`, `task-subtask-compact-toggle` et la règle `.task-subtask-card-compact .task-subtask-actions { display: none; }` pour masquer les actions en mode compact.

### Testing
- Exécution de `node --check home-progressions.js` qui a réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff4e55cf08331841c715d59888ae3)