### PR TITLE
Raccourcit les libellés +/-1 du minuteur sur la page d'accueil

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -220,11 +220,11 @@
 
         const removeMinuteButton = document.createElement('button');
         removeMinuteButton.type = 'button';
-        removeMinuteButton.textContent = '-1 min';
+        removeMinuteButton.textContent = '-1';
 
         const addMinuteButton = document.createElement('button');
         addMinuteButton.type = 'button';
-        addMinuteButton.textContent = '+1 min';
+        addMinuteButton.textContent = '+1';
 
         function setCompactMode(isCompact) {
             card.classList.toggle('task-subtask-card-compact', isCompact);


### PR DESCRIPTION
### Motivation
- Gagner de la place sur la page d'accueil en raccourcissant les libellés des boutons d'ajustement du minuteur sans changer leur comportement.

### Description
- Modifie `home-progressions.js` pour remplacer `removeMinuteButton.textContent = '-1 min'` par `removeMinuteButton.textContent = '-1'` et `addMinuteButton.textContent = '+1 min'` par `addMinuteButton.textContent = '+1'`.

### Testing
- Exécution des vérifications par commandes : `rg -n "removeMinuteButton.textContent|addMinuteButton.textContent|\+1 min|-1 min" home-progressions.js` et `git -C /workspace/site show --stat --oneline HEAD`, les deux ont réussi ; il n'existe pas d'autres tests automatisés pour ce composant.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06b23987c83318a8707d3a1136806)