### PR TITLE
Ajouter popup date/heure et augmentation progressive du bip du sonomètre

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -1,6 +1,9 @@
 (function () {
     const timeElement = document.getElementById('live-time');
     const dateElement = document.getElementById('live-date');
+    const openPopupButton = document.getElementById('open-datetime-popup');
+    const closePopupButton = document.getElementById('close-datetime-popup');
+    const datetimePopup = document.getElementById('datetime-popup');
 
     if (!timeElement || !dateElement) {
         return;
@@ -19,4 +22,22 @@
 
     updateDateTime();
     setInterval(updateDateTime, 1000);
+
+    const closePopup = () => {
+        if (!datetimePopup) return;
+        datetimePopup.hidden = true;
+    };
+
+    openPopupButton?.addEventListener('click', () => {
+        if (!datetimePopup) return;
+        datetimePopup.hidden = false;
+    });
+
+    closePopupButton?.addEventListener('click', closePopup);
+
+    datetimePopup?.addEventListener('click', (event) => {
+        if (event.target === datetimePopup) {
+            closePopup();
+        }
+    });
 })();

--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
             </article>
             <article class="atelier datetime-card home-card-datetime">
                 <div class="atelier-content">
+                    <div class="datetime-header-actions">
+                        <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir la popup date et heure">🗖</button>
+                    </div>
                     <p id="live-time" class="datetime-value">--:--:--</p>
                     <p id="live-date" class="datetime-label">--</p>
                 </div>
@@ -121,6 +124,12 @@
     <footer>
         <p>© Lycée XXXX - Tous droits réservés.</p>
     </footer>
+
+    <div id="datetime-popup" class="datetime-popup" hidden>
+        <div class="datetime-popup-panel">
+            <button id="close-datetime-popup" type="button" class="datetime-popup-close">Fermer</button>
+        </div>
+    </div>
 
     <script src="sonometre.js"></script>
     <script src="home-progressions.js"></script>

--- a/sonometre.js
+++ b/sonometre.js
@@ -31,9 +31,10 @@
     if (!audioContext) return;
 
     const now = audioContext.currentTime;
+    const peakGain = Math.min(1.6, 0.75 + depassements * 0.08);
     const envelope = audioContext.createGain();
     envelope.gain.setValueAtTime(0.0001, now);
-    envelope.gain.exponentialRampToValueAtTime(0.55, now + 0.02);
+    envelope.gain.exponentialRampToValueAtTime(peakGain, now + 0.02);
     envelope.gain.exponentialRampToValueAtTime(0.0001, now + 0.5);
     envelope.connect(audioContext.destination);
 

--- a/styles.css
+++ b/styles.css
@@ -1503,6 +1503,58 @@ svg.axe { display: block; margin: 0.5em 0; }
     padding-block: 10px;
 }
 
+.datetime-header-actions {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 4px;
+}
+
+.datetime-icon-button {
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-size: 1rem;
+    width: 34px;
+    height: 34px;
+    cursor: pointer;
+}
+
+.datetime-icon-button:hover {
+    background: rgba(255, 255, 255, 0.25);
+}
+
+.datetime-popup {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5000;
+}
+
+.datetime-popup-panel {
+    width: 90vw;
+    height: 90vh;
+    background: #ffffff;
+    border-radius: 12px;
+    position: relative;
+}
+
+.datetime-popup-close {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    border: 1px solid #222;
+    border-radius: 8px;
+    padding: 8px 12px;
+    background: #fff;
+    color: #111;
+    cursor: pointer;
+}
+
 .datetime-value {
     font-size: clamp(1.5rem, 4vw, 2.4rem);
     margin: 2px 0;


### PR DESCRIPTION
### Motivation
- Permettre d'ouvrir une popup vide (fond blanc) depuis le bloc date/heure pour afficher du contenu additionnel en surcouche de l'accueil à 90% de la fenêtre.
- Rendre le bip du sonomètre plus perceptible en augmentant progressivement l'intensité sonore à chaque dépassement détecté.

### Description
- Ajout d'un pictogramme cliquable et de la structure HTML de la popup dans `index.html` (`#open-datetime-popup`, `#datetime-popup`, `#close-datetime-popup`).
- Ajout des styles dans `styles.css` pour le bouton pictogramme (`.datetime-icon-button`) et pour l'overlay + panneau blanc dimensionné `90vw x 90vh` (`.datetime-popup`, `.datetime-popup-panel`, `.datetime-popup-close`).
- Ajout d'écouteurs dans `home-datetime.js` pour ouvrir/fermer la popup via le bouton, via le bouton de fermeture et en cliquant sur l'overlay (fermeture si le clic cible l'overlay).
- Modification de `sonometre.js` pour calculer un `peakGain` progressif (`const peakGain = Math.min(1.6, 0.75 + depassements * 0.08)`) et l'utiliser pour l'enveloppe audio afin d'augmenter le volume du bip en fonction du nombre de dépassements, avec un palier max pour sécurité.

### Testing
- Vérification automatique de la syntaxe JavaScript exécutée avec `node --check home-datetime.js && node --check sonometre.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09f985b688331b9ac5517bba229d0)