### PR TITLE
Accueil : espacement Planning, pictogramme Date/Heure centré et bips sonomètre

### DIFF
--- a/sonometre.js
+++ b/sonometre.js
@@ -38,7 +38,14 @@
     envelope.gain.exponentialRampToValueAtTime(0.0001, now + 0.5);
     envelope.connect(audioContext.destination);
 
-    const freqs = [920, 640, 920];
+    let beepCount = 1;
+    if (depassements >= 5 && depassements <= 10) {
+      beepCount = 2;
+    } else if (depassements > 10) {
+      beepCount = 3;
+    }
+
+    const freqs = [920, 640, 920].slice(0, beepCount);
     const beepDuration = 0.12;
     const gap = 0.05;
 

--- a/styles.css
+++ b/styles.css
@@ -1463,6 +1463,10 @@ svg.axe { display: block; margin: 0.5em 0; }
     gap: 10px;
 }
 
+.agenda-card .card-header-with-toggle {
+    margin-bottom: 8px;
+}
+
 .panel-toggle-button {
     border: 1px solid rgba(255, 255, 255, 0.55);
     border-radius: 999px;
@@ -1503,11 +1507,19 @@ svg.axe { display: block; margin: 0.5em 0; }
     padding-block: 10px;
 }
 
-.datetime-header-actions {
-    width: 100%;
+.datetime-card .atelier-content {
     display: flex;
-    justify-content: flex-end;
-    margin-bottom: 4px;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+}
+
+.datetime-header-actions {
+    display: flex;
+    justify-content: center;
+    margin-top: auto;
+    padding-top: 8px;
 }
 
 .datetime-icon-button {


### PR DESCRIPTION
### Motivation
- Corriger l'ergonomie de l'écran d'accueil pour éviter que le bouton `+/-` de la carte « Planning » soit trop collé au sélecteur de classe.
- Recentrer et positionner le pictogramme du bloc `Date & Heure` en bas de sa carte pour une présentation plus nette.
- Adapter le signal sonore du sonomètre pour qu'il soit proportionnel au nombre de dépassements (1/2/3 bips). 

### Description
- Ajout d'un espacement sous l'en-tête de la carte Planning via `.agenda-card .card-header-with-toggle { margin-bottom: 8px; }` dans `styles.css`.
- Reconfiguration du bloc date/heure en mettant `.datetime-card .atelier-content` en colonne centrée et en alignant la zone d'actions (`.datetime-header-actions`) en bas et au centre de la carte dans `styles.css`.
- Mise à jour de la logique de `playAlertSignal` dans `sonometre.js` pour calculer `beepCount` selon `depassements` (1 bip si < 5, 2 bips si entre 5 et 10 inclus, 3 bips si > 10) et n'utiliser que les fréquences nécessaires (`[920,640,920].slice(0, beepCount)`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check sonometre.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1bb4662a88331be29d71dba35f15a)