### PR TITLE
Ajout du pictogramme 🎲 et affichage du résultat dans le bloc Date & Heure

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -2,8 +2,10 @@
     const timeElement = document.getElementById('live-time');
     const dateElement = document.getElementById('live-date');
     const openPopupButton = document.getElementById('open-datetime-popup');
+    const rollDiceButton = document.getElementById('roll-dice-button');
     const closePopupButton = document.getElementById('close-datetime-popup');
     const datetimePopup = document.getElementById('datetime-popup');
+    const diceResultElement = document.getElementById('dice-result');
 
     if (!timeElement || !dateElement) {
         return;
@@ -38,6 +40,38 @@
     datetimePopup?.addEventListener('click', (event) => {
         if (event.target === datetimePopup) {
             closePopup();
+        }
+    });
+
+    const askPositiveInteger = (message, fallbackValue) => {
+        const response = window.prompt(message, String(fallbackValue));
+        if (response === null) return null;
+        const value = Number.parseInt(response, 10);
+        if (!Number.isFinite(value) || value <= 0) return null;
+        return value;
+    };
+
+    rollDiceButton?.addEventListener('click', () => {
+        const numberOfDice = askPositiveInteger('Combien de dés voulez-vous lancer ?', 1);
+        if (numberOfDice === null) {
+            if (diceResultElement) {
+                diceResultElement.textContent = 'Lancer annulé (nombre de dés invalide).';
+            }
+            return;
+        }
+
+        const facesPerDie = askPositiveInteger('Combien de faces par dé ?', 6);
+        if (facesPerDie === null) {
+            if (diceResultElement) {
+                diceResultElement.textContent = 'Lancer annulé (nombre de faces invalide).';
+            }
+            return;
+        }
+
+        const rolls = Array.from({ length: numberOfDice }, () => Math.floor(Math.random() * facesPerDie) + 1);
+        const total = rolls.reduce((sum, currentValue) => sum + currentValue, 0);
+        if (diceResultElement) {
+            diceResultElement.textContent = `Résultat (${numberOfDice}d${facesPerDie}) : [${rolls.join(', ')}] → Total ${total}`;
         }
     });
 })();

--- a/index.html
+++ b/index.html
@@ -60,11 +60,13 @@
             </article>
             <article class="atelier datetime-card home-card-datetime">
                 <div class="atelier-content">
-                    <div class="datetime-header-actions">
-                        <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir la popup date et heure">🗖</button>
-                    </div>
                     <p id="live-time" class="datetime-value">--:--:--</p>
                     <p id="live-date" class="datetime-label">--</p>
+                    <div class="datetime-header-actions">
+                        <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir l'écran blanc">🗖</button>
+                        <button id="roll-dice-button" type="button" class="datetime-icon-button" aria-label="Simuler un lancer de dés">🎲</button>
+                    </div>
+                    <p id="dice-result" class="dice-result" aria-live="polite">Cliquez sur 🎲 pour lancer des dés.</p>
                 </div>
             </article>
             <article class="atelier task-detail-card home-card-detail">

--- a/styles.css
+++ b/styles.css
@@ -1518,6 +1518,7 @@ svg.axe { display: block; margin: 0.5em 0; }
 .datetime-header-actions {
     display: flex;
     justify-content: center;
+    gap: 10px;
     margin-top: auto;
     padding-top: 8px;
 }
@@ -1578,6 +1579,12 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .datetime-label {
     font-size: 1rem;
+}
+
+.dice-result {
+    margin: 8px 0 0;
+    font-size: 0.92rem;
+    text-align: center;
 }
 
 .task-detail-section-header {


### PR DESCRIPTION
### Motivation
- Permettre depuis la carte Date & Heure de lancer des dés directement depuis l’interface et d’afficher le résultat sous le pictogramme, tout en conservant le pictogramme « écran blanc » en bas du bloc.
- Offrir une interaction simple pour simuler des lancers (nombre de dés / faces) sans ajouter de dépendances externes.

### Description
- Déplacé les actions sous la date et conservé le pictogramme « écran blanc » en bas du bloc en modifiant `index.html` et l’`aria-label` du bouton `#open-datetime-popup`.
- Ajouté un bouton `#roll-dice-button` (🎲) et une zone textuelle `#dice-result` sous les icônes pour afficher le retour utilisateur dans `index.html`.
- Implémenté la logique de lancer de dés dans `home-datetime.js` avec la fonction utilitaire `askPositiveInteger` qui demande via `prompt` le nombre de dés et le nombre de faces, valide les entrées, calcule chaque lancer et affiche les valeurs et le total dans `#dice-result`.
- Ajusté le style dans `styles.css` pour espacer les icônes (`.datetime-header-actions { gap: 10px; }`) et pour le style de la ligne de résultat (`.dice-result`).

### Testing
- Exécuté `node --check home-datetime.js`, résultat : succès.
- Exécuté `node --check classroom-screen.js`, résultat : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1da848b2c8331b29fe94f43fc0cc2)