### PR TITLE
Retirer le texte d’invite du bloc date/heure

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
                         <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir l'écran blanc">🗖</button>
                         <button id="roll-dice-button" type="button" class="datetime-icon-button" aria-label="Simuler un lancer de dés">🎲</button>
                     </div>
-                    <p id="dice-result" class="dice-result" aria-live="polite">Cliquez sur 🎲 pour lancer des dés.</p>
+                    <p id="dice-result" class="dice-result" aria-live="polite"></p>
                 </div>
             </article>
             <article class="atelier task-detail-card home-card-detail">


### PR DESCRIPTION
### Motivation
- Supprimer la phrase d’invite affichée par défaut dans le bloc « date et heure » pour éviter le texte intrusif « Cliquez sur 🎲 pour lancer des dés. ». 

### Description
- Modifie `index.html` pour remplacer le contenu de l’élément `#dice-result` par une chaîne vide tout en conservant l'élément et ses attributs. 

### Testing
- Vérification du diff avec `git -C /workspace/site diff -- index.html` a confirmé la suppression du texte et l’ajout d’une ligne vide. 
- Inspection des lignes modifiées avec `nl -ba /workspace/site/index.html | sed -n '58,74p'` a affiché l’élément `#dice-result` désormais vide. 
- Le commit final (`git -C /workspace/site commit -m`) a été créé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1df7451888331a39673faad478dd3)