### PR TITLE
Ajuste l’auto-sensibilité et la séquence de bips du sonomètre

### DIFF
--- a/sonometre.js
+++ b/sonometre.js
@@ -37,36 +37,37 @@
   const maxAutoAdjustDelta = 15;
   const depassementTimestamps = [];
 
+  const getBeepCount = () => {
+    if (depassements > 10) return 3;
+    if (depassements > 5) return 2;
+    return 1;
+  };
+
   const playAlertSignal = () => {
     if (!audioContext) return;
 
     const now = audioContext.currentTime;
-    const peakGain = Math.min(1.6, 0.75 + depassements * 0.08);
-    const envelope = audioContext.createGain();
-    envelope.gain.setValueAtTime(0.0001, now);
-    envelope.gain.exponentialRampToValueAtTime(peakGain, now + 0.02);
-    envelope.gain.exponentialRampToValueAtTime(0.0001, now + 0.5);
-    envelope.connect(audioContext.destination);
-
-    let beepCount = 1;
-    if (depassements >= 5 && depassements <= 10) {
-      beepCount = 2;
-    } else if (depassements > 10) {
-      beepCount = 3;
-    }
-
+    const peakGain = Math.min(1.8, 0.8 + depassements * 0.08);
+    const beepCount = getBeepCount();
     const freqs = [920, 640, 920].slice(0, beepCount);
-    const beepDuration = 0.12;
-    const gap = 0.05;
+    const beepDuration = 0.14;
+    const gap = 0.08;
 
     freqs.forEach((freq, index) => {
-      const oscillator = audioContext.createOscillator();
+      const envelope = audioContext.createGain();
       const startAt = now + index * (beepDuration + gap);
+      const stopAt = startAt + beepDuration;
+      envelope.gain.setValueAtTime(0.0001, startAt);
+      envelope.gain.exponentialRampToValueAtTime(peakGain, startAt + 0.015);
+      envelope.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+      envelope.connect(audioContext.destination);
+
+      const oscillator = audioContext.createOscillator();
       oscillator.type = 'square';
       oscillator.frequency.setValueAtTime(freq, startAt);
       oscillator.connect(envelope);
       oscillator.start(startAt);
-      oscillator.stop(startAt + beepDuration);
+      oscillator.stop(stopAt);
     });
   };
 
@@ -122,7 +123,8 @@
     }
   };
 
-  const autoAdjustSensibilite = (now, niveauAmbiantCible) => {
+  const autoAdjustSensibilite = (now, niveauAmbiantCible, { onDepassement = false, onStagnation = false } = {}) => {
+    if (!onDepassement && !onStagnation) return;
     if (now - lastAutoAdjustAt < autoAdjustCooldownMs) return;
     if (ambientRmsEstimate <= 0.05) return;
 
@@ -136,11 +138,11 @@
     const delta = Math.max(-maxAutoAdjustDelta, Math.min(maxAutoAdjustDelta, diff));
     setSensibilite(sensibiliteActuelle + delta);
 
-    if (depassementTimestamps.length >= rapidIncreaseThreshold && diff > 0) {
+    if (onDepassement && depassementTimestamps.length >= rapidIncreaseThreshold && diff > 0) {
       setSensibilite(sensibiliteActuelle - maxAutoAdjustDelta);
     }
 
-    if (lastDepassementAt > 0 && now - lastDepassementAt >= stagnationWindowMs) {
+    if (onStagnation) {
       lastDepassementAt = now;
     }
 
@@ -195,9 +197,10 @@
       depassementTimestamps.push(now);
       updateCompteur();
       playAlertSignal();
+      autoAdjustSensibilite(now, niveauAmbiantCible, { onDepassement: true });
+    } else if (lastDepassementAt > 0 && now - lastDepassementAt >= stagnationWindowMs) {
+      autoAdjustSensibilite(now, niveauAmbiantCible, { onStagnation: true });
     }
-
-    autoAdjustSensibilite(now, niveauAmbiantCible);
 
     requestAnimationFrame(render);
   };


### PR DESCRIPTION
### Motivation
- Implémenter l’ajustement automatique de la sensibilité uniquement lors d’un dépassement et lorsqu’il n’y a pas eu de dépassement pendant une longue période. 
- Rendre les bips successifs audibles même après de nombreux dépassements et appliquer la règle métier de nombre de bips (2 bips >5, 3 bips >10). 

### Description
- Ajout de la fonction `getBeepCount()` pour centraliser la logique de nombre de bips selon `depassements` (>5 => 2, >10 => 3). 
- Réécriture de `playAlertSignal()` pour créer une enveloppe (`Gain`) indépendante par bip, augmenter légèrement le `peakGain` et ajuster la durée (`beepDuration`) et l’espacement (`gap`) pour améliorer l’audibilité. 
- Modification de `autoAdjustSensibilite()` pour accepter des déclencheurs explicites (`onDepassement`, `onStagnation`) et ne s’exécuter que lorsque l’un de ces cas se produit, avec respect du `autoAdjustCooldownMs`. 
- Déclenchement de l’ajustement automatique dans la boucle `render()` uniquement immédiatement après un dépassement ou lorsqu’un intervalle de stagnation est atteint, et conservation des protections existantes (estimation ambiante, limites de delta). 

### Testing
- Vérification syntaxique avec `node --check sonometre.js` exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e20ddb8b7c8331831b0c9da4c6e70e)