### PR TITLE
Remplacer l'auto-réglage du sonomètre par boutons Calme/Bruyant

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@
                         <span id="seuil-valeur">55%</span>
                     </div>
 
-                    <div class="sonometre-controls">
-                        <label for="sensibilite">Sensibilité :</label>
-                        <input id="sensibilite" type="range" min="50" max="200" value="100" step="1">
-                        <span id="sensibilite-valeur">100%</span>
+                    <div class="sonometre-controls sonometre-bruit-mode" role="group" aria-label="Niveau de bruit ambiant">
+                        <span>Ambiance actuelle :</span>
+                        <button id="mode-calme" type="button" class="sonometre-mode-btn is-active" data-sensibilite="115">Calme</button>
+                        <button id="mode-bruyant" type="button" class="sonometre-mode-btn" data-sensibilite="80">Bruyant</button>
                     </div>
 
                     <div class="barre-wrapper" aria-label="Niveau sonore en direct">

--- a/sonometre.js
+++ b/sonometre.js
@@ -1,8 +1,8 @@
 (() => {
   const seuilInput = document.getElementById('seuil');
   const seuilValeur = document.getElementById('seuil-valeur');
-  const sensibiliteInput = document.getElementById('sensibilite');
-  const sensibiliteValeur = document.getElementById('sensibilite-valeur');
+  const modeCalmeBtn = document.getElementById('mode-calme');
+  const modeBruyantBtn = document.getElementById('mode-bruyant');
   const barreNiveau = document.getElementById('barre-niveau');
   const seuilMarker = document.getElementById('seuil-marker');
   const seuilMarkerLabel = document.getElementById('seuil-marker-label');
@@ -16,26 +16,16 @@
   const resetBtn = document.getElementById('reset-compteur');
   const compactToggleBtn = document.getElementById('toggle-sonometre-compact');
 
-  if (!seuilInput || !sensibiliteInput || !barreNiveau || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn) return;
+  if (!seuilInput || !barreNiveau || !startBtn || !pauseBtn || !decrementBtn || !incrementBtn || !resetBtn || !modeCalmeBtn || !modeBruyantBtn) return;
 
   let audioContext;
   let analyser;
   let dataArray;
   let depassements = 0;
   let lastTriggerAt = 0;
-  let lastDepassementAt = 0;
-  let lastAutoAdjustAt = 0;
-  let ambientRmsEstimate = 0;
   let isPaused = false;
   let isCompact = false;
   const triggerCooldownMs = 1200;
-  const rapidIncreaseWindowMs = 20000;
-  const rapidIncreaseThreshold = 4;
-  const stagnationWindowMs = 30000;
-  const autoAdjustCooldownMs = 1000;
-  const targetMarginBelowThreshold = 2;
-  const maxAutoAdjustDelta = 15;
-  const depassementTimestamps = [];
 
   const getBeepCount = () => {
     if (depassements > 10) return 3;
@@ -106,47 +96,18 @@
     }
   };
 
-  const updateSensibiliteLabel = () => {
-    const sensibilite = Number(sensibiliteInput.value);
-    sensibiliteValeur.textContent = `${sensibilite}%`;
-  };
+  let sensibilite = Number(modeCalmeBtn.dataset.sensibilite || 115);
 
-  const setSensibilite = (newValue) => {
-    const min = Number(sensibiliteInput.min || 50);
-    const max = Number(sensibiliteInput.max || 200);
-    const clamped = Math.min(max, Math.max(min, newValue));
-    const rounded = Math.round(clamped);
+  const setBruitMode = (mode) => {
+    const isCalme = mode === 'calme';
+    sensibilite = isCalme
+      ? Number(modeCalmeBtn.dataset.sensibilite || 115)
+      : Number(modeBruyantBtn.dataset.sensibilite || 80);
 
-    if (Number(sensibiliteInput.value) !== rounded) {
-      sensibiliteInput.value = String(rounded);
-      updateSensibiliteLabel();
-    }
-  };
-
-  const autoAdjustSensibilite = (now, niveauAmbiantCible, { onDepassement = false, onStagnation = false } = {}) => {
-    if (!onDepassement && !onStagnation) return;
-    if (now - lastAutoAdjustAt < autoAdjustCooldownMs) return;
-    if (ambientRmsEstimate <= 0.05) return;
-
-    while (depassementTimestamps.length && now - depassementTimestamps[0] > rapidIncreaseWindowMs) {
-      depassementTimestamps.shift();
-    }
-
-    const sensibiliteActuelle = Number(sensibiliteInput.value);
-    const sensibiliteCible = (niveauAmbiantCible * 64) / ambientRmsEstimate;
-    const diff = sensibiliteCible - sensibiliteActuelle;
-    const delta = Math.max(-maxAutoAdjustDelta, Math.min(maxAutoAdjustDelta, diff));
-    setSensibilite(sensibiliteActuelle + delta);
-
-    if (onDepassement && depassementTimestamps.length >= rapidIncreaseThreshold && diff > 0) {
-      setSensibilite(sensibiliteActuelle - maxAutoAdjustDelta);
-    }
-
-    if (onStagnation) {
-      lastDepassementAt = now;
-    }
-
-    lastAutoAdjustAt = now;
+    modeCalmeBtn.classList.toggle('is-active', isCalme);
+    modeBruyantBtn.classList.toggle('is-active', !isCalme);
+    modeCalmeBtn.setAttribute('aria-pressed', String(isCalme));
+    modeBruyantBtn.setAttribute('aria-pressed', String(!isCalme));
   };
 
   const calculateRms = (arr) => {
@@ -172,18 +133,9 @@
     }
 
     analyser.getByteTimeDomainData(dataArray);
-    const sensibilite = Number(sensibiliteInput.value);
     const rms = calculateRms(dataArray);
     const level = normalizeVolume(rms, sensibilite);
     const seuil = Number(seuilInput.value);
-    const niveauAmbiantCible = Math.max(5, seuil - targetMarginBelowThreshold);
-
-    const facteurLissage = level >= seuil ? 0.05 : 0.12;
-    if (ambientRmsEstimate === 0) {
-      ambientRmsEstimate = rms;
-    } else {
-      ambientRmsEstimate = ambientRmsEstimate + (rms - ambientRmsEstimate) * facteurLissage;
-    }
 
     barreNiveau.style.width = `${level}%`;
     barreNiveau.classList.toggle('warning', level >= seuil);
@@ -193,13 +145,8 @@
     if (level >= seuil && now - lastTriggerAt > triggerCooldownMs) {
       depassements += 1;
       lastTriggerAt = now;
-      lastDepassementAt = now;
-      depassementTimestamps.push(now);
       updateCompteur();
       playAlertSignal();
-      autoAdjustSensibilite(now, niveauAmbiantCible, { onDepassement: true });
-    } else if (lastDepassementAt > 0 && now - lastDepassementAt >= stagnationWindowMs) {
-      autoAdjustSensibilite(now, niveauAmbiantCible, { onStagnation: true });
     }
 
     requestAnimationFrame(render);
@@ -221,12 +168,6 @@
       pauseBtn.disabled = false;
       pauseBtn.removeAttribute('disabled');
       pauseBtn.textContent = 'Mettre en pause';
-      const now = Date.now();
-      lastAutoAdjustAt = now;
-      lastDepassementAt = now;
-      depassementTimestamps.length = 0;
-      ambientRmsEstimate = 0;
-
       render();
     } catch (err) {
       startBtn.disabled = false;
@@ -251,7 +192,8 @@
   };
 
   seuilInput.addEventListener('input', updateSeuilLabel);
-  sensibiliteInput.addEventListener('input', updateSensibiliteLabel);
+  modeCalmeBtn.addEventListener('click', () => setBruitMode('calme'));
+  modeBruyantBtn.addEventListener('click', () => setBruitMode('bruyant'));
   startBtn.addEventListener('click', start);
   pauseBtn.addEventListener('click', togglePause);
   decrementBtn.addEventListener('click', () => {
@@ -275,7 +217,7 @@
   pauseBtn.disabled = false;
   pauseBtn.removeAttribute('disabled');
   updateSeuilLabel();
-  updateSensibiliteLabel();
+  setBruitMode('calme');
   updateCompteur();
   updateCompactMode();
 })();

--- a/styles.css
+++ b/styles.css
@@ -1009,6 +1009,30 @@ svg.axe { display: block; margin: 0.5em 0; }
     accent-color: #1e90ff;
 }
 
+
+.sonometre-bruit-mode {
+    gap: 10px;
+}
+
+.sonometre-mode-btn {
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 999px;
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.sonometre-mode-btn:hover {
+    background: rgba(255, 255, 255, 0.22);
+}
+
+.sonometre-mode-btn.is-active {
+    background: #1e90ff;
+    border-color: #1e90ff;
+}
+
 .barre-wrapper {
     position: relative;
     width: 100%;
@@ -1489,7 +1513,31 @@ svg.axe { display: block; margin: 0.5em 0; }
     display: none;
 }
 
-.sonometre-card.is-compact .barre-wrapper {
+.sonometre-card.is-compact 
+.sonometre-bruit-mode {
+    gap: 10px;
+}
+
+.sonometre-mode-btn {
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 999px;
+    padding: 6px 14px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.sonometre-mode-btn:hover {
+    background: rgba(255, 255, 255, 0.22);
+}
+
+.sonometre-mode-btn.is-active {
+    background: #1e90ff;
+    border-color: #1e90ff;
+}
+
+.barre-wrapper {
     margin-top: 8px;
 }
 


### PR DESCRIPTION
### Motivation
- Simplifier le comportement du sonomètre en supprimant l’ajustement automatique de la sensibilité et en permettant à l’utilisateur d’indiquer l’ambiance courante via deux boutons (`Calme` / `Bruyant`) pour adapter la sensibilité.

### Description
- `index.html` : remplacement du curseur `sensibilite` par un groupe de boutons de mode (`#mode-calme`, `#mode-bruyant`) avec attributs `data-sensibilite` et état actif par défaut `Calme`.
- `sonometre.js` : suppression de la logique d’auto-ajustement et des variables associées, ajout de la variable `sensibilite` pilotée par `setBruitMode(mode)`, et liaison des boutons pour choisir le mode; le reste des fonctionnalités (seuil, barre live, compteur, alertes sonores, pause, mode compact) est conservé.
- `styles.css` : ajout des règles visuelles pour les boutons de mode (`.sonometre-mode-btn`, état `:hover` et `.is-active`) et ajustements mineurs pour l’affichage compact.

### Testing
- Exécution d’un contrôle statique via `rg -n "sensibilite|depassementTimestamps|autoAdjust|mode-calme|mode-bruyant" index.html sonometre.js styles.css` pour vérifier la présence des nouveaux sélecteurs et la suppression des anciennes références, commande exécutée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d3b3ef948331bd9a01a06d28d850)