### PR TITLE
Ajout d’un module de combat simple contre un ennemi unique

### DIFF
--- a/AssistantJDR/index.html
+++ b/AssistantJDR/index.html
@@ -42,6 +42,34 @@
         <button type="button" onclick="addMonster()">Ajouter un Monstre</button>
         <button type="button" onclick="simulateCombat()">Simuler le Combat</button>
     </form>
+    <section id="singleEnemyCombatSection">
+        <h2>Combat</h2>
+        <fieldset>
+            <legend>Adversaire unique</legend>
+            <label for="enemyName">Nom de l’ennemi :</label>
+            <input type="text" id="enemyName" name="enemyName" value="Gobelin" required><br>
+            <label for="enemySkill">Habileté de l’ennemi :</label>
+            <input type="number" id="enemySkill" name="enemySkill" value="8" min="0" required><br>
+            <label for="enemyEndurance">Endurance de l’ennemi :</label>
+            <input type="number" id="enemyEndurance" name="enemyEndurance" value="10" min="1" required><br>
+        </fieldset>
+        <div class="combat-buttons">
+            <button type="button" id="startCombatBtn">Démarrer le combat</button>
+            <button type="button" id="assaultBtn" disabled>Lancer un assaut</button>
+            <button type="button" id="endCombatBtn">Terminer le combat</button>
+        </div>
+        <div id="combatStatus">
+            <p>Endurance actuelle du héros : <strong id="heroCurrentEndurance">-</strong></p>
+            <p>Endurance actuelle de l’ennemi : <strong id="enemyCurrentEndurance">-</strong></p>
+            <p>Force d’attaque du héros : <strong id="heroAttackStrength">-</strong></p>
+            <p>Force d’attaque de l’ennemi : <strong id="enemyAttackStrength">-</strong></p>
+            <p>Résultat du dernier assaut : <strong id="lastAssaultResult">Aucun</strong></p>
+        </div>
+        <div id="assaultHistoryContainer">
+            <h3>Historique court des assauts</h3>
+            <ul id="assaultHistory"></ul>
+        </div>
+    </section>
     <div id="combatLog"></div>
 
     <script src="script.js"></script>

--- a/AssistantJDR/script.js
+++ b/AssistantJDR/script.js
@@ -1,4 +1,6 @@
 let monsterCount = 1;
+const MAX_ASSAULT_HISTORY = 10;
+let singleEnemyCombat = null;
 
 function addMonster() {
     monsterCount++;
@@ -141,3 +143,119 @@ function simulateCombat() {
     // Afficher le journal de combat
     document.getElementById('combatLog').innerHTML = combatLog.join('<br>');
 }
+
+function roll2d6() {
+    return rollDice(2);
+}
+
+function updateSingleEnemyDisplay() {
+    const heroEnduranceEl = document.getElementById('heroCurrentEndurance');
+    const enemyEnduranceEl = document.getElementById('enemyCurrentEndurance');
+    const heroAttackStrengthEl = document.getElementById('heroAttackStrength');
+    const enemyAttackStrengthEl = document.getElementById('enemyAttackStrength');
+    const lastAssaultResultEl = document.getElementById('lastAssaultResult');
+    const assaultBtn = document.getElementById('assaultBtn');
+    const historyEl = document.getElementById('assaultHistory');
+
+    if (!singleEnemyCombat) {
+        heroEnduranceEl.textContent = '-';
+        enemyEnduranceEl.textContent = '-';
+        heroAttackStrengthEl.textContent = '-';
+        enemyAttackStrengthEl.textContent = '-';
+        lastAssaultResultEl.textContent = 'Aucun';
+        assaultBtn.disabled = true;
+        historyEl.innerHTML = '';
+        return;
+    }
+
+    heroEnduranceEl.textContent = singleEnemyCombat.heroEndurance;
+    enemyEnduranceEl.textContent = singleEnemyCombat.enemyEndurance;
+    heroAttackStrengthEl.textContent = singleEnemyCombat.heroAttackStrength ?? '-';
+    enemyAttackStrengthEl.textContent = singleEnemyCombat.enemyAttackStrength ?? '-';
+    lastAssaultResultEl.textContent = singleEnemyCombat.lastResult || 'Aucun';
+    assaultBtn.disabled = !singleEnemyCombat.inProgress;
+
+    historyEl.innerHTML = singleEnemyCombat.history
+        .map((entry) => `<li>${entry}</li>`)
+        .join('');
+}
+
+function startSingleEnemyCombat() {
+    const enemyName = document.getElementById('enemyName').value.trim() || 'Ennemi';
+    const enemySkill = parseInt(document.getElementById('enemySkill').value, 10);
+    const enemyEndurance = parseInt(document.getElementById('enemyEndurance').value, 10);
+    const heroSkill = parseInt(document.getElementById('heroAttack').value, 10);
+    const heroEndurance = parseInt(document.getElementById('heroPV').value, 10);
+
+    if ([enemySkill, enemyEndurance, heroSkill, heroEndurance].some((value) => Number.isNaN(value))) {
+        return;
+    }
+
+    singleEnemyCombat = {
+        enemyName,
+        heroSkill,
+        heroEndurance,
+        enemySkill,
+        enemyEndurance,
+        heroAttackStrength: null,
+        enemyAttackStrength: null,
+        lastResult: 'Combat démarré.',
+        history: [],
+        assaultCount: 0,
+        inProgress: true
+    };
+
+    updateSingleEnemyDisplay();
+}
+
+function launchAssault() {
+    if (!singleEnemyCombat || !singleEnemyCombat.inProgress) {
+        return;
+    }
+
+    const enemyRoll = roll2d6();
+    const heroRoll = roll2d6();
+    singleEnemyCombat.enemyAttackStrength = enemyRoll + singleEnemyCombat.enemySkill;
+    singleEnemyCombat.heroAttackStrength = heroRoll + singleEnemyCombat.heroSkill;
+    singleEnemyCombat.assaultCount += 1;
+
+    let resultText = '';
+    if (singleEnemyCombat.heroAttackStrength > singleEnemyCombat.enemyAttackStrength) {
+        singleEnemyCombat.enemyEndurance -= 2;
+        resultText = `${singleEnemyCombat.enemyName} blessé (-2 END).`;
+    } else if (singleEnemyCombat.enemyAttackStrength > singleEnemyCombat.heroAttackStrength) {
+        singleEnemyCombat.heroEndurance -= 2;
+        resultText = `Héros blessé (-2 END).`;
+    } else {
+        resultText = 'Égalité, aucun dégât.';
+    }
+
+    const line = `Assaut ${singleEnemyCombat.assaultCount} : Héros ${singleEnemyCombat.heroAttackStrength} / Ennemi ${singleEnemyCombat.enemyAttackStrength} → ${resultText}`;
+    singleEnemyCombat.history.push(line);
+    if (singleEnemyCombat.history.length > MAX_ASSAULT_HISTORY) {
+        singleEnemyCombat.history = singleEnemyCombat.history.slice(-MAX_ASSAULT_HISTORY);
+    }
+
+    if (singleEnemyCombat.enemyEndurance <= 0) {
+        singleEnemyCombat.inProgress = false;
+        singleEnemyCombat.lastResult = 'Ennemi vaincu';
+    } else if (singleEnemyCombat.heroEndurance <= 0) {
+        singleEnemyCombat.inProgress = false;
+        singleEnemyCombat.lastResult = 'Votre personnage est mort';
+    } else {
+        singleEnemyCombat.lastResult = resultText;
+    }
+
+    updateSingleEnemyDisplay();
+}
+
+function endSingleEnemyCombat() {
+    singleEnemyCombat = null;
+    updateSingleEnemyDisplay();
+}
+
+document.getElementById('startCombatBtn').addEventListener('click', startSingleEnemyCombat);
+document.getElementById('assaultBtn').addEventListener('click', launchAssault);
+document.getElementById('endCombatBtn').addEventListener('click', endSingleEnemyCombat);
+
+updateSingleEnemyDisplay();

--- a/AssistantJDR/style.css
+++ b/AssistantJDR/style.css
@@ -57,3 +57,22 @@ button:hover {
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
+
+#singleEnemyCombatSection {
+    max-width: 600px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.combat-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#assaultHistoryContainer ul {
+    padding-left: 20px;
+}


### PR DESCRIPTION
### Motivation
- Fournir un outil simple pour résoudre les combats contre un seul adversaire afin d’éviter les calculs manuels. 
- Respecter les règles demandées : jet de `2d6` + habileté pour chaque camp et application de `-2 END` au perdant, aucun dégât en cas d’égalité. 
- Garder l’interface claire et légère sans ajouter les règles avancées (multi-ennemis, Chance, règles spéciales).

### Description
- Ajout d’une nouvelle section **Combat** dans `AssistantJDR/index.html` contenant les champs `Nom de l’ennemi`, `Habileté de l’ennemi`, `Endurance de l’ennemi`, les boutons `Démarrer le combat`, `Lancer un assaut`, `Terminer le combat` et un historique court des assauts. 
- Implémentation dans `AssistantJDR/script.js` des fonctions principales `startSingleEnemyCombat`, `launchAssault`, `endSingleEnemyCombat`, `roll2d6` et `updateSingleEnemyDisplay` pour gérer l’état du combat, calculer les forces (`2d6 + habileté`) et appliquer les dégâts `-2 END`. 
- Historique limité aux `10` dernières entrées et formaté comme `Assaut N : Héros X / Ennemi Y → résultat`, avec affichage dynamique de l’endurance et des forces d’attaque. 
- Ajout de styles dans `AssistantJDR/style.css` pour intégrer proprement la nouvelle section à l’interface existante.

### Testing
- Aucun test automatisé n’a été exécuté pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0858c20f7883318e83b4d97e88386a)