### PR TITLE
Add single-enemy combat UI and turn-based assault logic; integrate into compagnon page

### DIFF
--- a/AssistantJDR/index.html
+++ b/AssistantJDR/index.html
@@ -42,6 +42,34 @@
         <button type="button" onclick="addMonster()">Ajouter un Monstre</button>
         <button type="button" onclick="simulateCombat()">Simuler le Combat</button>
     </form>
+    <section id="singleEnemyCombatSection">
+        <h2>Combat</h2>
+        <fieldset>
+            <legend>Adversaire unique</legend>
+            <label for="enemyName">Nom de l’ennemi :</label>
+            <input type="text" id="enemyName" name="enemyName" value="Gobelin" required><br>
+            <label for="enemySkill">Habileté de l’ennemi :</label>
+            <input type="number" id="enemySkill" name="enemySkill" value="8" min="0" required><br>
+            <label for="enemyEndurance">Endurance de l’ennemi :</label>
+            <input type="number" id="enemyEndurance" name="enemyEndurance" value="10" min="1" required><br>
+        </fieldset>
+        <div class="combat-buttons">
+            <button type="button" id="startCombatBtn">Démarrer le combat</button>
+            <button type="button" id="assaultBtn" disabled>Lancer un assaut</button>
+            <button type="button" id="endCombatBtn">Terminer le combat</button>
+        </div>
+        <div id="combatStatus">
+            <p>Endurance actuelle du héros : <strong id="heroCurrentEndurance">-</strong></p>
+            <p>Endurance actuelle de l’ennemi : <strong id="enemyCurrentEndurance">-</strong></p>
+            <p>Force d’attaque du héros : <strong id="heroAttackStrength">-</strong></p>
+            <p>Force d’attaque de l’ennemi : <strong id="enemyAttackStrength">-</strong></p>
+            <p>Résultat du dernier assaut : <strong id="lastAssaultResult">Aucun</strong></p>
+        </div>
+        <div id="assaultHistoryContainer">
+            <h3>Historique court des assauts</h3>
+            <ul id="assaultHistory"></ul>
+        </div>
+    </section>
     <div id="combatLog"></div>
 
     <script src="script.js"></script>

--- a/AssistantJDR/script.js
+++ b/AssistantJDR/script.js
@@ -1,4 +1,6 @@
 let monsterCount = 1;
+const MAX_ASSAULT_HISTORY = 10;
+let singleEnemyCombat = null;
 
 function addMonster() {
     monsterCount++;
@@ -141,3 +143,119 @@ function simulateCombat() {
     // Afficher le journal de combat
     document.getElementById('combatLog').innerHTML = combatLog.join('<br>');
 }
+
+function roll2d6() {
+    return rollDice(2);
+}
+
+function updateSingleEnemyDisplay() {
+    const heroEnduranceEl = document.getElementById('heroCurrentEndurance');
+    const enemyEnduranceEl = document.getElementById('enemyCurrentEndurance');
+    const heroAttackStrengthEl = document.getElementById('heroAttackStrength');
+    const enemyAttackStrengthEl = document.getElementById('enemyAttackStrength');
+    const lastAssaultResultEl = document.getElementById('lastAssaultResult');
+    const assaultBtn = document.getElementById('assaultBtn');
+    const historyEl = document.getElementById('assaultHistory');
+
+    if (!singleEnemyCombat) {
+        heroEnduranceEl.textContent = '-';
+        enemyEnduranceEl.textContent = '-';
+        heroAttackStrengthEl.textContent = '-';
+        enemyAttackStrengthEl.textContent = '-';
+        lastAssaultResultEl.textContent = 'Aucun';
+        assaultBtn.disabled = true;
+        historyEl.innerHTML = '';
+        return;
+    }
+
+    heroEnduranceEl.textContent = singleEnemyCombat.heroEndurance;
+    enemyEnduranceEl.textContent = singleEnemyCombat.enemyEndurance;
+    heroAttackStrengthEl.textContent = singleEnemyCombat.heroAttackStrength ?? '-';
+    enemyAttackStrengthEl.textContent = singleEnemyCombat.enemyAttackStrength ?? '-';
+    lastAssaultResultEl.textContent = singleEnemyCombat.lastResult || 'Aucun';
+    assaultBtn.disabled = !singleEnemyCombat.inProgress;
+
+    historyEl.innerHTML = singleEnemyCombat.history
+        .map((entry) => `<li>${entry}</li>`)
+        .join('');
+}
+
+function startSingleEnemyCombat() {
+    const enemyName = document.getElementById('enemyName').value.trim() || 'Ennemi';
+    const enemySkill = parseInt(document.getElementById('enemySkill').value, 10);
+    const enemyEndurance = parseInt(document.getElementById('enemyEndurance').value, 10);
+    const heroSkill = parseInt(document.getElementById('heroAttack').value, 10);
+    const heroEndurance = parseInt(document.getElementById('heroPV').value, 10);
+
+    if ([enemySkill, enemyEndurance, heroSkill, heroEndurance].some((value) => Number.isNaN(value))) {
+        return;
+    }
+
+    singleEnemyCombat = {
+        enemyName,
+        heroSkill,
+        heroEndurance,
+        enemySkill,
+        enemyEndurance,
+        heroAttackStrength: null,
+        enemyAttackStrength: null,
+        lastResult: 'Combat démarré.',
+        history: [],
+        assaultCount: 0,
+        inProgress: true
+    };
+
+    updateSingleEnemyDisplay();
+}
+
+function launchAssault() {
+    if (!singleEnemyCombat || !singleEnemyCombat.inProgress) {
+        return;
+    }
+
+    const enemyRoll = roll2d6();
+    const heroRoll = roll2d6();
+    singleEnemyCombat.enemyAttackStrength = enemyRoll + singleEnemyCombat.enemySkill;
+    singleEnemyCombat.heroAttackStrength = heroRoll + singleEnemyCombat.heroSkill;
+    singleEnemyCombat.assaultCount += 1;
+
+    let resultText = '';
+    if (singleEnemyCombat.heroAttackStrength > singleEnemyCombat.enemyAttackStrength) {
+        singleEnemyCombat.enemyEndurance -= 2;
+        resultText = `${singleEnemyCombat.enemyName} blessé (-2 END).`;
+    } else if (singleEnemyCombat.enemyAttackStrength > singleEnemyCombat.heroAttackStrength) {
+        singleEnemyCombat.heroEndurance -= 2;
+        resultText = `Héros blessé (-2 END).`;
+    } else {
+        resultText = 'Égalité, aucun dégât.';
+    }
+
+    const line = `Assaut ${singleEnemyCombat.assaultCount} : Héros ${singleEnemyCombat.heroAttackStrength} / Ennemi ${singleEnemyCombat.enemyAttackStrength} → ${resultText}`;
+    singleEnemyCombat.history.push(line);
+    if (singleEnemyCombat.history.length > MAX_ASSAULT_HISTORY) {
+        singleEnemyCombat.history = singleEnemyCombat.history.slice(-MAX_ASSAULT_HISTORY);
+    }
+
+    if (singleEnemyCombat.enemyEndurance <= 0) {
+        singleEnemyCombat.inProgress = false;
+        singleEnemyCombat.lastResult = 'Ennemi vaincu';
+    } else if (singleEnemyCombat.heroEndurance <= 0) {
+        singleEnemyCombat.inProgress = false;
+        singleEnemyCombat.lastResult = 'Votre personnage est mort';
+    } else {
+        singleEnemyCombat.lastResult = resultText;
+    }
+
+    updateSingleEnemyDisplay();
+}
+
+function endSingleEnemyCombat() {
+    singleEnemyCombat = null;
+    updateSingleEnemyDisplay();
+}
+
+document.getElementById('startCombatBtn').addEventListener('click', startSingleEnemyCombat);
+document.getElementById('assaultBtn').addEventListener('click', launchAssault);
+document.getElementById('endCombatBtn').addEventListener('click', endSingleEnemyCombat);
+
+updateSingleEnemyDisplay();

--- a/AssistantJDR/style.css
+++ b/AssistantJDR/style.css
@@ -57,3 +57,22 @@ button:hover {
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
+
+#singleEnemyCombatSection {
+    max-width: 600px;
+    margin: 20px auto;
+    padding: 20px;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.combat-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+#assaultHistoryContainer ul {
+    padding-left: 20px;
+}

--- a/compagnon.html
+++ b/compagnon.html
@@ -135,6 +135,38 @@
       <div class="status" id="status"></div>
       <div class="dice-box" id="diceResult"></div>
     </section>
+
+    <section class="card">
+      <h2>Combat</h2>
+      <div class="grid">
+        <div>
+          <label for="combatEnemyName">Nom de l’ennemi</label>
+          <input id="combatEnemyName" type="text" value="Gobelin" />
+        </div>
+        <div>
+          <label for="combatEnemySkill">Habileté de l’ennemi</label>
+          <input id="combatEnemySkill" type="number" min="0" value="8" />
+        </div>
+        <div>
+          <label for="combatEnemyEndurance">Endurance de l’ennemi</label>
+          <input id="combatEnemyEndurance" type="number" min="1" value="10" />
+        </div>
+      </div>
+      <div class="actions" style="margin-top:.6rem;">
+        <button class="primary" id="startCombatBtn">Démarrer le combat</button>
+        <button class="secondary" id="assaultBtn" disabled>Lancer un assaut</button>
+        <button class="danger" id="endCombatBtn">Terminer le combat</button>
+      </div>
+      <div class="status" id="combatResultStatus"></div>
+      <div class="grid" style="margin-top:.6rem;">
+        <div>Endurance actuelle du héros : <strong id="combatHeroEndurance">—</strong></div>
+        <div>Endurance actuelle de l’ennemi : <strong id="combatEnemyEnduranceCurrent">—</strong></div>
+        <div>Force d’attaque du héros : <strong id="combatHeroAttackStrength">—</strong></div>
+        <div>Force d’attaque de l’ennemi : <strong id="combatEnemyAttackStrength">—</strong></div>
+      </div>
+      <h3 style="margin-bottom:.5rem;">Historique court des assauts</h3>
+      <ul id="combatHistory"></ul>
+    </section>
   </main>
 
   <script>
@@ -147,6 +179,8 @@
 
     const maxFields = ['habileteMax', 'enduranceMax', 'chanceMax'];
     let metamorphoseActive = false;
+    const MAX_ASSAULT_HISTORY = 10;
+    let combatState = null;
 
     function rollDie() {
       return Math.floor(Math.random() * 6) + 1;
@@ -381,6 +415,106 @@
       localStorage.removeItem(STORAGE_KEY);
       setStatus('Données réinitialisées.');
       setDiceMessage('');
+      endCombat();
+    }
+
+    function refreshCombatUi() {
+      const assaultBtn = document.getElementById('assaultBtn');
+      const heroEndurance = document.getElementById('combatHeroEndurance');
+      const enemyEndurance = document.getElementById('combatEnemyEnduranceCurrent');
+      const heroAttack = document.getElementById('combatHeroAttackStrength');
+      const enemyAttack = document.getElementById('combatEnemyAttackStrength');
+      const status = document.getElementById('combatResultStatus');
+      const history = document.getElementById('combatHistory');
+
+      if (!combatState) {
+        assaultBtn.disabled = true;
+        heroEndurance.textContent = '—';
+        enemyEndurance.textContent = '—';
+        heroAttack.textContent = '—';
+        enemyAttack.textContent = '—';
+        status.textContent = '';
+        history.innerHTML = '';
+        return;
+      }
+
+      assaultBtn.disabled = !combatState.inProgress;
+      heroEndurance.textContent = combatState.heroEndurance;
+      enemyEndurance.textContent = combatState.enemyEndurance;
+      heroAttack.textContent = combatState.heroAttackStrength ?? '—';
+      enemyAttack.textContent = combatState.enemyAttackStrength ?? '—';
+      status.textContent = combatState.lastResult;
+      history.innerHTML = combatState.history.map((line) => `<li>${line}</li>`).join('');
+    }
+
+    function startCombat() {
+      const heroSkill = parseInt(document.getElementById('habilete').value, 10);
+      const heroEndurance = parseInt(document.getElementById('endurance').value, 10);
+      const enemyName = document.getElementById('combatEnemyName').value.trim() || 'Ennemi';
+      const enemySkill = parseInt(document.getElementById('combatEnemySkill').value, 10);
+      const enemyEndurance = parseInt(document.getElementById('combatEnemyEndurance').value, 10);
+
+      if ([heroSkill, heroEndurance, enemySkill, enemyEndurance].some((v) => Number.isNaN(v))) {
+        setStatus('Combat impossible : renseigne Habileté/Endurance du héros et de l’ennemi.');
+        return;
+      }
+
+      combatState = {
+        enemyName,
+        heroSkill,
+        heroEndurance,
+        enemySkill,
+        enemyEndurance,
+        heroAttackStrength: null,
+        enemyAttackStrength: null,
+        lastResult: 'Combat démarré.',
+        history: [],
+        assaultCount: 0,
+        inProgress: true
+      };
+      refreshCombatUi();
+    }
+
+    function launchAssault() {
+      if (!combatState || !combatState.inProgress) return;
+      const heroRolls = rollDice(2);
+      const enemyRolls = rollDice(2);
+      combatState.heroAttackStrength = sum(heroRolls) + combatState.heroSkill;
+      combatState.enemyAttackStrength = sum(enemyRolls) + combatState.enemySkill;
+      combatState.assaultCount += 1;
+
+      let resultText = 'Égalité, aucun dégât.';
+      if (combatState.heroAttackStrength > combatState.enemyAttackStrength) {
+        combatState.enemyEndurance -= 2;
+        resultText = `${combatState.enemyName} blessé (-2 END).`;
+      } else if (combatState.enemyAttackStrength > combatState.heroAttackStrength) {
+        combatState.heroEndurance -= 2;
+        resultText = 'Héros blessé (-2 END).';
+      }
+
+      combatState.history.push(`Assaut ${combatState.assaultCount} : Héros ${combatState.heroAttackStrength} / Ennemi ${combatState.enemyAttackStrength} → ${resultText}`);
+      if (combatState.history.length > MAX_ASSAULT_HISTORY) {
+        combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
+      }
+
+      document.getElementById('endurance').value = Math.max(0, combatState.heroEndurance);
+
+      if (combatState.enemyEndurance <= 0) {
+        combatState.inProgress = false;
+        combatState.lastResult = 'Ennemi vaincu';
+      } else if (combatState.heroEndurance <= 0) {
+        combatState.inProgress = false;
+        combatState.lastResult = 'Votre personnage est mort';
+      } else {
+        combatState.lastResult = resultText;
+      }
+      save();
+      refreshCombatUi();
+    }
+
+    function endCombat() {
+      combatState = null;
+      refreshCombatUi();
     }
 
     document.getElementById('newGameBtn').addEventListener('click', newGame);
@@ -395,8 +529,12 @@
       applyMetamorphoseValue(event.target.value);
       save();
     });
+    document.getElementById('startCombatBtn').addEventListener('click', startCombat);
+    document.getElementById('assaultBtn').addEventListener('click', launchAssault);
+    document.getElementById('endCombatBtn').addEventListener('click', endCombat);
 
     load();
+    refreshCombatUi();
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add an interactive single-enemy combat mode to the demo app to allow stepwise assaults and short combat history tracking.
- Surface a compact combat UI for the standalone `AssistantJDR` demo and the `compagnon.html` character companion so users can simulate simple fights without the full multi-monster simulator.
- Keep recent assault history bounded to avoid unbounded growth in the UI log.

### Description
- Added a new `Adversaire unique` combat section to `AssistantJDR/index.html` with inputs for enemy name/skill/endurance and buttons `Démarrer le combat`, `Lancer un assaut`, and `Terminer le combat` plus a short-history display. 
- Implemented single-enemy combat state and functions in `AssistantJDR/script.js`: `startSingleEnemyCombat`, `launchAssault`, `endSingleEnemyCombat`, `updateSingleEnemyDisplay`, `roll2d6`, and the `MAX_ASSAULT_HISTORY` limit; these coexist with the existing multi-monster `simulateCombat` logic. 
- Added styling for the new combat panel and history in `style.css` and ensured the existing `#combatLog` styling remains intact. 
- Integrated the same single-enemy combat UI and logic into `compagnon.html` by adding a combat card, corresponding state `combatState`, and functions `startCombat`, `launchAssault`, `endCombat`, `refreshCombatUi`, plus event bindings and persistence update (`save()`) where applicable.

### Testing
- No automated tests were added or run for these UI and script changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0858c20f7883318e83b4d97e88386a)