### PR TITLE
Compagnon de lecture: Bestiaire, persistance de combats, capacités et refonte UI

### DIFF
--- a/AssistantJDR/index.html
+++ b/AssistantJDR/index.html
@@ -3,74 +3,116 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Simulation de Combat - La Geste de Gurdill</title>
+    <title>Compagnon de lecture - La Nuit du Loup-Garou</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Simulation de Combat - La Geste de Gurdill</h1>
-    <form id="combatForm">
-        <fieldset>
-            <legend>Héros</legend>
-            <label for="heroAttack">Attaque:</label>
-            <input type="number" id="heroAttack" name="heroAttack" value="12" required><br>
-            <label for="heroDefense">Défense:</label>
-            <input type="number" id="heroDefense" name="heroDefense" value="8" required><br>
-            <label for="heroPR">PR:</label>
-            <input type="number" id="heroPR" name="heroPR" value="7" required><br>
-            <label for="heroPV">PV:</label>
-            <input type="number" id="heroPV" name="heroPV" required><br>
-            <label for="heroDamage">Dégâts:</label>
-            <input type="string" id="heroDamage" name="heroDamage" value="1D+7" required><br>
-        </fieldset>
-        <div id="monsters">
-            <fieldset class="monster">
-                <legend>Monstre 1</legend>
-                <label for="monsterAttack1">Attaque:</label>
-                <input type="number" id="monsterAttack1" name="monsterAttack" value="12" required><br>
-                <label for="monsterDefense1">Défense:</label>
-                <input type="number" id="monsterDefense1" name="monsterDefense" value="8" required><br>
-                <label for="monsterPR1">PR:</label>
-                <input type="number" id="monsterPR1" name="monsterPR" value="5" required><br>
-                <label for="monsterPV1">PV:</label>
-                <input type="number" id="monsterPV1" name="monsterPV" value="20" required><br>
-                <label for="monsterDamage1">Dégâts:</label>
-                <input type="string" id="monsterDamage1" name="monsterDamage" value="1D+6" required><br>
-				<label for="monsterCritDamage1">Si critique, dégâts:</label>
-                <input type="string" id="monsterCritDamage1" name="monsterCritDamage" value="2D+6" required><br>
+    <main class="app-shell">
+        <header class="app-header">
+            <h1>Compagnon de lecture</h1>
+            <p>La Nuit du Loup-Garou — Combat automatique &amp; Bestiaire</p>
+        </header>
+
+        <section id="singleEnemyCombatSection" class="panel">
+            <div class="panel-title-row">
+                <h2>Combat rapide</h2>
+                <button type="button" id="restartLastFightBtn" class="secondary">Relancer dernier combat</button>
+            </div>
+            <fieldset>
+                <legend>Héros</legend>
+                <label for="heroSkill">HABILETÉ</label>
+                <input type="number" id="heroSkill" value="10" min="0" required>
+                <label for="heroEndurance">ENDURANCE</label>
+                <input type="number" id="heroEndurance" value="18" min="1" required>
             </fieldset>
-        </div>
-        <button type="button" onclick="addMonster()">Ajouter un Monstre</button>
-        <button type="button" onclick="simulateCombat()">Simuler le Combat</button>
-    </form>
-    <section id="singleEnemyCombatSection">
-        <h2>Combat</h2>
-        <fieldset>
-            <legend>Adversaire unique</legend>
-            <label for="enemyName">Nom de l’ennemi :</label>
-            <input type="text" id="enemyName" name="enemyName" value="Gobelin" required><br>
-            <label for="enemySkill">Habileté de l’ennemi :</label>
-            <input type="number" id="enemySkill" name="enemySkill" value="8" min="0" required><br>
-            <label for="enemyEndurance">Endurance de l’ennemi :</label>
-            <input type="number" id="enemyEndurance" name="enemyEndurance" value="10" min="1" required><br>
-        </fieldset>
-        <div class="combat-buttons">
-            <button type="button" id="startCombatBtn">Démarrer le combat</button>
-            <button type="button" id="assaultBtn" disabled>Lancer un assaut</button>
-            <button type="button" id="endCombatBtn">Terminer le combat</button>
-        </div>
-        <div id="combatStatus">
-            <p>Endurance actuelle du héros : <strong id="heroCurrentEndurance">-</strong></p>
-            <p>Endurance actuelle de l’ennemi : <strong id="enemyCurrentEndurance">-</strong></p>
-            <p>Force d’attaque du héros : <strong id="heroAttackStrength">-</strong></p>
-            <p>Force d’attaque de l’ennemi : <strong id="enemyAttackStrength">-</strong></p>
-            <p>Résultat du dernier assaut : <strong id="lastAssaultResult">Aucun</strong></p>
-        </div>
-        <div id="assaultHistoryContainer">
-            <h3>Historique court des assauts</h3>
-            <ul id="assaultHistory"></ul>
-        </div>
-    </section>
-    <div id="combatLog"></div>
+            <fieldset>
+                <legend>Adversaire</legend>
+                <label for="enemyName">Nom</label>
+                <input type="text" id="enemyName" value="Gobelin" required>
+                <label for="enemySkill">HABILETÉ</label>
+                <input type="number" id="enemySkill" value="8" min="0" required>
+                <label for="enemyEndurance">ENDURANCE</label>
+                <input type="number" id="enemyEndurance" value="10" min="1" required>
+            </fieldset>
+            <div class="combat-buttons">
+                <button type="button" id="startCombatBtn">Démarrer le combat</button>
+                <button type="button" id="assaultBtn" disabled>Lancer un assaut</button>
+                <button type="button" id="endCombatBtn" class="danger">Terminer le combat</button>
+            </div>
+            <div id="combatStatus" class="status-grid"></div>
+            <div id="assaultHistoryContainer">
+                <h3>Journal de combat</h3>
+                <ul id="assaultHistory"></ul>
+            </div>
+        </section>
+
+        <section id="bestiarySection" class="panel">
+            <div class="panel-title-row">
+                <h2>Bestiaire</h2>
+                <div class="actions-inline">
+                    <button type="button" id="exportBestiaryBtn" class="secondary">Exporter JSON</button>
+                    <label for="importBestiaryInput" class="btn-like secondary">Importer JSON</label>
+                    <input type="file" id="importBestiaryInput" accept="application/json" hidden>
+                    <button type="button" id="addBestiaryBtn">+ Ajouter au bestiaire</button>
+                </div>
+            </div>
+
+            <div class="filters-row">
+                <input type="search" id="searchMonsterInput" placeholder="Rechercher un monstre...">
+                <select id="tagFilterSelect">
+                    <option value="">Tous les tags</option>
+                </select>
+                <select id="sortSelect">
+                    <option value="alpha_asc">A → Z</option>
+                    <option value="alpha_desc">Z → A</option>
+                    <option value="recent">Plus récents</option>
+                </select>
+            </div>
+
+            <div id="bestiaryList" class="cards-grid"></div>
+        </section>
+    </main>
+
+    <dialog id="monsterDialog">
+        <form method="dialog" id="monsterForm" class="dialog-body">
+            <h3 id="dialogTitle">Ajouter un monstre</h3>
+            <input type="hidden" id="monsterId">
+
+            <label for="monsterNom">Nom du monstre</label>
+            <input id="monsterNom" type="text" required>
+
+            <label for="monsterHabilete">HABILETÉ</label>
+            <input id="monsterHabilete" type="number" min="0" required>
+
+            <label for="monsterEndurance">ENDURANCE</label>
+            <input id="monsterEndurance" type="number" min="1" required>
+
+            <label for="monsterDescription">Description courte</label>
+            <textarea id="monsterDescription" rows="2"></textarea>
+
+            <label for="monsterNotes">Notes libres</label>
+            <textarea id="monsterNotes" rows="3"></textarea>
+
+            <label for="monsterTags">Tags (séparés par des virgules)</label>
+            <input id="monsterTags" type="text" placeholder="undead, boss, nocturne">
+
+            <label for="monsterImage">URL/image optionnelle</label>
+            <input id="monsterImage" type="url" placeholder="https://...">
+
+            <div class="panel-sub">
+                <div class="panel-title-row">
+                    <h4>Capacités spéciales</h4>
+                    <button type="button" id="addCapabilityBtn" class="secondary">+ Ajouter une capacité</button>
+                </div>
+                <div id="capabilitiesList"></div>
+            </div>
+
+            <div class="dialog-actions">
+                <button type="button" id="saveMonsterBtn">Enregistrer</button>
+                <button type="button" id="cancelMonsterBtn" class="secondary">Annuler</button>
+            </div>
+        </form>
+    </dialog>
 
     <script src="script.js"></script>
 </body>

--- a/AssistantJDR/script.js
+++ b/AssistantJDR/script.js
@@ -1,218 +1,118 @@
-let monsterCount = 1;
-const MAX_ASSAULT_HISTORY = 10;
+const MAX_ASSAULT_HISTORY = 20;
+const STORAGE_KEYS = {
+    bestiary: 'lnlg_bestiary_v1',
+    history: 'lnlg_combat_history_v1',
+    lastFight: 'lnlg_last_fight_v1'
+};
+
+const CAPABILITY_TYPES = [
+    'text_note', 'enemy_damage_modifier', 'hero_damage_modifier', 'enemy_regeneration', 'hero_regeneration',
+    'metamorphosis_change', 'luck_change', 'skill_change', 'conditional_immunity',
+    'start_of_combat_effect', 'end_of_combat_effect'
+];
+const CAPABILITY_TRIGGERS = ['start_combat', 'before_assault', 'hero_hits', 'enemy_hits', 'after_assault', 'end_combat'];
+
+let bestiary = [];
+let combatHistory = [];
 let singleEnemyCombat = null;
+let editingCapabilities = [];
 
-function addMonster() {
-    monsterCount++;
-    const monstersDiv = document.getElementById('monsters');
-    const newMonster = document.createElement('fieldset');
-    newMonster.className = 'monster';
-    newMonster.innerHTML = `
-        <legend>Monstre ${monsterCount}</legend>
-        <label for="monsterAttack${monsterCount}">Attaque:</label>
-        <input type="number" id="monsterAttack${monsterCount}" name="monsterAttack" value="12" required><br>
-        <label for="monsterDefense${monsterCount}">Défense:</label>
-        <input type="number" id="monsterDefense${monsterCount}" name="monsterDefense" value="8" required><br>
-        <label for="monsterPR${monsterCount}">PR:</label>
-        <input type="number" id="monsterPR${monsterCount}" name="monsterPR" value="5" required><br>
-        <label for="monsterPV${monsterCount}">PV:</label>
-        <input type="number" id="monsterPV${monsterCount}" name="monsterPV" value="20" required><br>
-        <label for="monsterDamage${monsterCount}">Dégâts:</label>
-        <input type="string" id="monsterDamage${monsterCount}" name="monsterDamage" value="1D+6" required><br>
-        <label for="monsterCritDamage${monsterCount}">Si critique, dégâts:</label>
-        <input type="string" id="monsterCritDamage${monsterCount}" name="monsterCritDamage" value="2D+6" required><br>
-    `;
-    monstersDiv.appendChild(newMonster);
+const uid = () => `${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+const nowIso = () => new Date().toISOString();
+
+function loadState() {
+    bestiary = JSON.parse(localStorage.getItem(STORAGE_KEYS.bestiary) || '[]');
+    combatHistory = JSON.parse(localStorage.getItem(STORAGE_KEYS.history) || '[]');
 }
 
-// Fonction pour lancer un dé de 6
-function rollDice(number) {
-	let total = 0;
-	for (let i = 0; i < number; i++) {
-		total += Math.floor(Math.random() * 6) + 1;
-	}
-	return total;
+function persistState() {
+    localStorage.setItem(STORAGE_KEYS.bestiary, JSON.stringify(bestiary));
+    localStorage.setItem(STORAGE_KEYS.history, JSON.stringify(combatHistory.slice(-200)));
 }
 
-// Fonction pour calculer les dégâts à partir de la formule xD + y
-function calculateDamage(formula) {
-	const match = formula.match(/(\d+)D\s*\+\s*(\d+)/);
-	const numberOfDice = parseInt(match[1]);
-	const additionalValue = parseInt(match[2]);
-	return rollDice(numberOfDice) + additionalValue;
-}
-	
-function simulateCombat() {
-
-
-    // Récupérer les valeurs du formulaire
-    const hero = {
-        attack: parseInt(document.getElementById('heroAttack').value),
-        defense: parseInt(document.getElementById('heroDefense').value),
-        pr: parseInt(document.getElementById('heroPR').value),
-        pv: parseInt(document.getElementById('heroPV').value),
-        damageFormula: document.getElementById('heroDamage').value
-    };
-
-    let monsters = [];
-    for (let i = 1; i <= monsterCount; i++) {
-        monsters.push({
-            attack: parseInt(document.getElementById(`monsterAttack${i}`).value),
-            defense: parseInt(document.getElementById(`monsterDefense${i}`).value),
-            pr: parseInt(document.getElementById(`monsterPR${i}`).value),
-            pv: parseInt(document.getElementById(`monsterPV${i}`).value),
-            damageFormula: document.getElementById(`monsterDamage${i}`).value,
-			critDamageFormula: document.getElementById(`monsterCritDamage${i}`).value
-        });
-    }
-
-    // Initialisation du journal de combat
-    let combatLog = [];
-    let logLimit = 200; // Limiter le journal à 100 entrées
-	let unMonstreEncoreEnVie = true
-
-    while (hero.pv > 0 && unMonstreEncoreEnVie) {
-		
-        // Tour du héros
-		// --- choix d'un monstre à combattre: le premier encore en vie
-		let iMonstre=0;
-		for (let monster of monsters) {
-            if (monster.pv <= 0) continue;
-			iMonstre++;
-			
-			if (Math.random() * 20 <= hero.attack) {
-				if (Math.random() * 20 > monster.defense) {
-					const damageDealt = Math.max(calculateDamage(hero.damageFormula) - monster.pr, 0);
-					monster.pv -= damageDealt;
-					combatLog.push(`Le héros attaque et inflige ${damageDealt} dégâts. PV du monstre ${iMonstre}: ${monster.pv}`);
-				} else {
-					combatLog.push(`Le héros attaque mais le monstre ${iMonstre} se defend.`);
-				}
-			} else {
-				combatLog.push(`Le héros attaque le monstre ${iMonstre} mais rate.`);
-			}
-			break;
-		}
-
-        // Tour des monstres
-		unMonstreEncoreEnVie = false
-		iMonstre=0;
-		for (let monster of monsters) {
-            if (monster.pv <= 0) continue;
-			iMonstre++;
-			unMonstreEncoreEnVie = true
-			let jetAttaque = Math.random() * 20
-			// coup critique
-			if ( jetAttaque < 5) {
-				if (Math.random() * 20 > hero.defense) {
-					const damageDealt = Math.max(calculateDamage(monster.critDamageFormula) - hero.pr, 0);
-					hero.pv -= damageDealt;
-					combatLog.push(`Le monstre ${iMonstre} attaque (critique) et inflige ${damageDealt} dégâts. PV du héros: ${hero.pv}`);
-				} else {
-					combatLog.push(`Le monstre ${iMonstre} attaque (critique)  mais le héros se défend.`);
-				}
-			} else {
-				// coup normal
-				if ( jetAttaque <= monster.attack) {
-					if (Math.random() * 20 > hero.defense) {
-						const damageDealt = Math.max(calculateDamage(monster.damageFormula) - hero.pr, 0);
-						hero.pv -= damageDealt;
-						combatLog.push(`Le monstre ${iMonstre} attaque et inflige ${damageDealt} dégâts. PV du héros: ${hero.pv}`);
-					} else {
-						combatLog.push(`Le monstre ${iMonstre} attaque mais le héros se défend.`);
-					}
-				} else {
-					combatLog.push(`Le monstre ${iMonstre} attaque mais rate.`);
-				}
-			}
-			
-			// Limiter la longueur du journal
-			if (combatLog.length > logLimit) {
-				combatLog = combatLog.slice(combatLog.length - logLimit);
-			}
-		}
-    }
-
-    // Affichage du résultat final
-    if (hero.pv > 0) {
-        combatLog.push(`<strong>Le héros a vaincu le monstre ! il lui reste ${hero.pv} PV....</strong>`);
-    } else {
-        combatLog.push(`<strong>Le monstre a vaincu le héros...</strong>`);
-    }
-
-    // Afficher le journal de combat
-    document.getElementById('combatLog').innerHTML = combatLog.join('<br>');
+function saveLastFight(payload) {
+    localStorage.setItem(STORAGE_KEYS.lastFight, JSON.stringify(payload));
 }
 
-function roll2d6() {
-    return rollDice(2);
+function getLastFight() {
+    return JSON.parse(localStorage.getItem(STORAGE_KEYS.lastFight) || 'null');
 }
 
-function updateSingleEnemyDisplay() {
-    const heroEnduranceEl = document.getElementById('heroCurrentEndurance');
-    const enemyEnduranceEl = document.getElementById('enemyCurrentEndurance');
-    const heroAttackStrengthEl = document.getElementById('heroAttackStrength');
-    const enemyAttackStrengthEl = document.getElementById('enemyAttackStrength');
-    const lastAssaultResultEl = document.getElementById('lastAssaultResult');
-    const assaultBtn = document.getElementById('assaultBtn');
+function roll2d6() { return (1 + Math.floor(Math.random() * 6)) + (1 + Math.floor(Math.random() * 6)); }
+
+function renderStatus() {
+    const el = document.getElementById('combatStatus');
+    if (!singleEnemyCombat) { el.innerHTML = '<p>Combat inactif.</p>'; return; }
+    el.innerHTML = `
+        <p>Héros END: <strong>${singleEnemyCombat.heroEndurance}</strong></p>
+        <p>Ennemi END: <strong>${singleEnemyCombat.enemyEndurance}</strong></p>
+        <p>FA héros: <strong>${singleEnemyCombat.heroAttackStrength ?? '-'}</strong></p>
+        <p>FA ennemi: <strong>${singleEnemyCombat.enemyAttackStrength ?? '-'}</strong></p>
+        <p>Statut: <strong>${singleEnemyCombat.lastResult || 'Aucun'}</strong></p>`;
+}
+
+function renderHistory() {
     const historyEl = document.getElementById('assaultHistory');
-
-    if (!singleEnemyCombat) {
-        heroEnduranceEl.textContent = '-';
-        enemyEnduranceEl.textContent = '-';
-        heroAttackStrengthEl.textContent = '-';
-        enemyAttackStrengthEl.textContent = '-';
-        lastAssaultResultEl.textContent = 'Aucun';
-        assaultBtn.disabled = true;
-        historyEl.innerHTML = '';
-        return;
-    }
-
-    heroEnduranceEl.textContent = singleEnemyCombat.heroEndurance;
-    enemyEnduranceEl.textContent = singleEnemyCombat.enemyEndurance;
-    heroAttackStrengthEl.textContent = singleEnemyCombat.heroAttackStrength ?? '-';
-    enemyAttackStrengthEl.textContent = singleEnemyCombat.enemyAttackStrength ?? '-';
-    lastAssaultResultEl.textContent = singleEnemyCombat.lastResult || 'Aucun';
-    assaultBtn.disabled = !singleEnemyCombat.inProgress;
-
-    historyEl.innerHTML = singleEnemyCombat.history
-        .map((entry) => `<li>${entry}</li>`)
-        .join('');
+    historyEl.innerHTML = (singleEnemyCombat?.history || []).map((entry) => `<li>${entry}</li>`).join('');
 }
 
-function startSingleEnemyCombat() {
-    const enemyName = document.getElementById('enemyName').value.trim() || 'Ennemi';
-    const enemySkill = parseInt(document.getElementById('enemySkill').value, 10);
-    const enemyEndurance = parseInt(document.getElementById('enemyEndurance').value, 10);
-    const heroSkill = parseInt(document.getElementById('heroAttack').value, 10);
-    const heroEndurance = parseInt(document.getElementById('heroPV').value, 10);
+function applyCapabilities(trigger) {
+    if (!singleEnemyCombat) return;
+    const caps = singleEnemyCombat.capacites.filter((c) => c.trigger === trigger);
+    caps.forEach((cap) => {
+        if (!cap.automatic) {
+            singleEnemyCombat.history.push(`⚠ Rappel capacité manuelle: ${cap.description || cap.type}`);
+            return;
+        }
+        switch (cap.type) {
+            case 'enemy_regeneration':
+                singleEnemyCombat.enemyEndurance += Number(cap.value || 0);
+                singleEnemyCombat.history.push(`→ Régénération ennemi: +${cap.value} END`);
+                break;
+            case 'hero_regeneration':
+                singleEnemyCombat.heroEndurance += Number(cap.value || 0);
+                singleEnemyCombat.history.push(`→ Régénération héros: +${cap.value} END`);
+                break;
+            case 'enemy_damage_modifier':
+            case 'hero_damage_modifier':
+            case 'skill_change':
+            case 'luck_change':
+            case 'metamorphosis_change':
+            case 'conditional_immunity':
+            case 'start_of_combat_effect':
+            case 'end_of_combat_effect':
+            case 'text_note':
+            default:
+                singleEnemyCombat.history.push(`ℹ ${cap.type}: ${cap.description || 'effet appliqué selon règle spéciale'}`);
+        }
+    });
+}
 
-    if ([enemySkill, enemyEndurance, heroSkill, heroEndurance].some((value) => Number.isNaN(value))) {
-        return;
-    }
+function startSingleEnemyCombat(monsterOverride = null) {
+    const enemyName = monsterOverride?.nom || document.getElementById('enemyName').value.trim() || 'Ennemi';
+    const enemySkill = Number(monsterOverride?.habilete ?? document.getElementById('enemySkill').value);
+    const enemyEndurance = Number(monsterOverride?.endurance ?? document.getElementById('enemyEndurance').value);
+    const heroSkill = Number(document.getElementById('heroSkill').value);
+    const heroEndurance = Number(document.getElementById('heroEndurance').value);
+
+    if ([enemySkill, enemyEndurance, heroSkill, heroEndurance].some(Number.isNaN)) return;
 
     singleEnemyCombat = {
-        enemyName,
-        heroSkill,
-        heroEndurance,
-        enemySkill,
-        enemyEndurance,
-        heroAttackStrength: null,
-        enemyAttackStrength: null,
-        lastResult: 'Combat démarré.',
-        history: [],
-        assaultCount: 0,
-        inProgress: true
+        monsterId: monsterOverride?.id || null,
+        enemyName, heroSkill, heroEndurance, enemySkill, enemyEndurance,
+        heroAttackStrength: null, enemyAttackStrength: null,
+        lastResult: 'Combat démarré.', history: [], assaultCount: 0, inProgress: true,
+        capacites: monsterOverride?.capacites || []
     };
 
-    updateSingleEnemyDisplay();
+    applyCapabilities('start_combat');
+    renderStatus(); renderHistory();
 }
 
 function launchAssault() {
-    if (!singleEnemyCombat || !singleEnemyCombat.inProgress) {
-        return;
-    }
+    if (!singleEnemyCombat?.inProgress) return;
 
+    applyCapabilities('before_assault');
     const enemyRoll = roll2d6();
     const heroRoll = roll2d6();
     singleEnemyCombat.enemyAttackStrength = enemyRoll + singleEnemyCombat.enemySkill;
@@ -222,40 +122,214 @@ function launchAssault() {
     let resultText = '';
     if (singleEnemyCombat.heroAttackStrength > singleEnemyCombat.enemyAttackStrength) {
         singleEnemyCombat.enemyEndurance -= 2;
-        resultText = `${singleEnemyCombat.enemyName} blessé (-2 END).`;
+        resultText = `${singleEnemyCombat.enemyName} blessé (-2 END)`;
+        applyCapabilities('hero_hits');
     } else if (singleEnemyCombat.enemyAttackStrength > singleEnemyCombat.heroAttackStrength) {
         singleEnemyCombat.heroEndurance -= 2;
-        resultText = `Héros blessé (-2 END).`;
+        resultText = 'Héros blessé (-2 END)';
+        applyCapabilities('enemy_hits');
     } else {
-        resultText = 'Égalité, aucun dégât.';
+        resultText = 'Égalité, aucun dégât';
     }
 
-    const line = `Assaut ${singleEnemyCombat.assaultCount} : Héros ${singleEnemyCombat.heroAttackStrength} / Ennemi ${singleEnemyCombat.enemyAttackStrength} → ${resultText}`;
+    applyCapabilities('after_assault');
+
+    const line = `Assaut ${singleEnemyCombat.assaultCount} — Vous: ${singleEnemyCombat.heroAttackStrength}, ${singleEnemyCombat.enemyName}: ${singleEnemyCombat.enemyAttackStrength} → ${resultText}`;
     singleEnemyCombat.history.push(line);
-    if (singleEnemyCombat.history.length > MAX_ASSAULT_HISTORY) {
-        singleEnemyCombat.history = singleEnemyCombat.history.slice(-MAX_ASSAULT_HISTORY);
-    }
+    singleEnemyCombat.history = singleEnemyCombat.history.slice(-MAX_ASSAULT_HISTORY);
 
     if (singleEnemyCombat.enemyEndurance <= 0) {
         singleEnemyCombat.inProgress = false;
         singleEnemyCombat.lastResult = 'Ennemi vaincu';
+        applyCapabilities('end_combat');
+        trackResult(true);
     } else if (singleEnemyCombat.heroEndurance <= 0) {
         singleEnemyCombat.inProgress = false;
         singleEnemyCombat.lastResult = 'Votre personnage est mort';
+        applyCapabilities('end_combat');
+        trackResult(false);
     } else {
         singleEnemyCombat.lastResult = resultText;
     }
 
-    updateSingleEnemyDisplay();
+    renderStatus(); renderHistory();
 }
 
-function endSingleEnemyCombat() {
-    singleEnemyCombat = null;
-    updateSingleEnemyDisplay();
+function trackResult(victory) {
+    if (!singleEnemyCombat?.monsterId) return;
+    const m = bestiary.find((x) => x.id === singleEnemyCombat.monsterId);
+    if (!m) return;
+    m.stats = m.stats || { wins: 0, losses: 0 };
+    if (victory) m.stats.wins += 1; else m.stats.losses += 1;
+    m.updatedAt = nowIso();
+    combatHistory.push({ at: nowIso(), monsterId: m.id, victory });
+    persistState();
 }
 
-document.getElementById('startCombatBtn').addEventListener('click', startSingleEnemyCombat);
-document.getElementById('assaultBtn').addEventListener('click', launchAssault);
-document.getElementById('endCombatBtn').addEventListener('click', endSingleEnemyCombat);
+function endSingleEnemyCombat() { singleEnemyCombat = null; renderStatus(); renderHistory(); }
 
-updateSingleEnemyDisplay();
+function monsterTemplate() {
+    return { id: uid(), nom: '', habilete: 8, endurance: 8, description: '', notes: '', tags: [], image: '', createdAt: nowIso(), updatedAt: nowIso(), favorite: false, capacites: [], stats: { wins: 0, losses: 0 } };
+}
+
+function openMonsterDialog(monster = null) {
+    const m = monster ? structuredClone(monster) : monsterTemplate();
+    document.getElementById('dialogTitle').textContent = monster ? 'Modifier un monstre' : 'Ajouter un monstre';
+    document.getElementById('monsterId').value = m.id;
+    document.getElementById('monsterNom').value = m.nom;
+    document.getElementById('monsterHabilete').value = m.habilete;
+    document.getElementById('monsterEndurance').value = m.endurance;
+    document.getElementById('monsterDescription').value = m.description;
+    document.getElementById('monsterNotes').value = m.notes;
+    document.getElementById('monsterTags').value = m.tags.join(', ');
+    document.getElementById('monsterImage').value = m.image || '';
+    editingCapabilities = m.capacites || [];
+    renderCapabilityEditor();
+    document.getElementById('monsterDialog').showModal();
+}
+
+function renderCapabilityEditor() {
+    const root = document.getElementById('capabilitiesList');
+    root.innerHTML = editingCapabilities.map((cap) => `
+        <article class="cap-row">
+            <select data-k="type" data-id="${cap.id}">${CAPABILITY_TYPES.map((t) => `<option value="${t}" ${t === cap.type ? 'selected' : ''}>${t}</option>`).join('')}</select>
+            <select data-k="trigger" data-id="${cap.id}">${CAPABILITY_TRIGGERS.map((t) => `<option value="${t}" ${t === cap.trigger ? 'selected' : ''}>${t}</option>`).join('')}</select>
+            <input data-k="value" data-id="${cap.id}" type="number" value="${cap.value ?? 0}" placeholder="Valeur">
+            <input data-k="description" data-id="${cap.id}" type="text" value="${cap.description || ''}" placeholder="Description">
+            <label><input data-k="automatic" data-id="${cap.id}" type="checkbox" ${cap.automatic ? 'checked' : ''}> Auto</label>
+            <button type="button" data-action="delete-cap" data-id="${cap.id}" class="danger">✕</button>
+        </article>`).join('');
+}
+
+function addCapability() {
+    editingCapabilities.push({ id: uid(), type: 'text_note', trigger: 'after_assault', value: 0, description: '', automatic: false });
+    renderCapabilityEditor();
+}
+
+function saveMonster() {
+    const id = document.getElementById('monsterId').value;
+    const payload = {
+        id,
+        nom: document.getElementById('monsterNom').value.trim(),
+        habilete: Number(document.getElementById('monsterHabilete').value),
+        endurance: Number(document.getElementById('monsterEndurance').value),
+        description: document.getElementById('monsterDescription').value.trim(),
+        notes: document.getElementById('monsterNotes').value.trim(),
+        tags: document.getElementById('monsterTags').value.split(',').map((x) => x.trim()).filter(Boolean),
+        image: document.getElementById('monsterImage').value.trim(),
+        createdAt: nowIso(), updatedAt: nowIso(), capacites: editingCapabilities,
+        favorite: false, stats: { wins: 0, losses: 0 }
+    };
+
+    const index = bestiary.findIndex((m) => m.id === id);
+    if (index >= 0) {
+        payload.createdAt = bestiary[index].createdAt;
+        payload.favorite = bestiary[index].favorite;
+        payload.stats = bestiary[index].stats || payload.stats;
+        bestiary[index] = payload;
+    } else {
+        bestiary.unshift(payload);
+    }
+
+    persistState();
+    renderBestiary();
+    document.getElementById('monsterDialog').close();
+}
+
+function renderBestiary() {
+    const query = document.getElementById('searchMonsterInput').value.trim().toLowerCase();
+    const tag = document.getElementById('tagFilterSelect').value;
+    const sort = document.getElementById('sortSelect').value;
+
+    const tags = [...new Set(bestiary.flatMap((m) => m.tags || []))].sort((a, b) => a.localeCompare(b, 'fr'));
+    document.getElementById('tagFilterSelect').innerHTML = `<option value="">Tous les tags</option>${tags.map((t) => `<option value="${t}" ${t === tag ? 'selected' : ''}>${t}</option>`).join('')}`;
+
+    let items = bestiary.filter((m) => (!query || `${m.nom} ${m.description} ${(m.tags || []).join(' ')}`.toLowerCase().includes(query)) && (!tag || (m.tags || []).includes(tag)));
+    if (sort === 'alpha_asc') items.sort((a, b) => a.nom.localeCompare(b.nom, 'fr'));
+    if (sort === 'alpha_desc') items.sort((a, b) => b.nom.localeCompare(a.nom, 'fr'));
+    if (sort === 'recent') items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+    document.getElementById('bestiaryList').innerHTML = items.map((m) => `
+        <article class="monster-card ${m.favorite ? 'favorite' : ''}">
+            <div>
+                <h3>${m.nom}</h3>
+                <p><strong>HAB:</strong> ${m.habilete} • <strong>END:</strong> ${m.endurance}</p>
+                <p>${m.capacites?.length || 0} capacité(s) • V:${m.stats?.wins || 0} / D:${m.stats?.losses || 0}</p>
+                <p class="tags">${(m.tags || []).map((t) => `#${t}`).join(' ')}</p>
+            </div>
+            <div class="card-actions">
+                <button type="button" data-action="fight" data-id="${m.id}">Combattre</button>
+                <button type="button" data-action="edit" data-id="${m.id}" class="secondary">Modifier</button>
+                <button type="button" data-action="duplicate" data-id="${m.id}" class="secondary">Dupliquer</button>
+                <button type="button" data-action="favorite" data-id="${m.id}" class="secondary">${m.favorite ? '★ Favori' : '☆ Favori'}</button>
+                <button type="button" data-action="delete" data-id="${m.id}" class="danger">Supprimer</button>
+            </div>
+        </article>`).join('');
+}
+
+function handleBestiaryClick(event) {
+    const btn = event.target.closest('button[data-action]'); if (!btn) return;
+    const id = btn.dataset.id;
+    const monster = bestiary.find((m) => m.id === id); if (!monster) return;
+
+    if (btn.dataset.action === 'fight') {
+        document.getElementById('enemyName').value = monster.nom;
+        document.getElementById('enemySkill').value = monster.habilete;
+        document.getElementById('enemyEndurance').value = monster.endurance;
+        saveLastFight({ monsterId: monster.id });
+        startSingleEnemyCombat(monster);
+    }
+    if (btn.dataset.action === 'edit') openMonsterDialog(monster);
+    if (btn.dataset.action === 'duplicate') {
+        const clone = structuredClone(monster); clone.id = uid(); clone.nom = `${monster.nom} (copie)`; clone.createdAt = nowIso(); clone.updatedAt = nowIso();
+        bestiary.unshift(clone); persistState(); renderBestiary();
+    }
+    if (btn.dataset.action === 'favorite') { monster.favorite = !monster.favorite; monster.updatedAt = nowIso(); persistState(); renderBestiary(); }
+    if (btn.dataset.action === 'delete' && confirm(`Supprimer ${monster.nom} ?`)) { bestiary = bestiary.filter((m) => m.id !== id); persistState(); renderBestiary(); }
+}
+
+function bootEvents() {
+    document.getElementById('startCombatBtn').addEventListener('click', () => startSingleEnemyCombat());
+    document.getElementById('assaultBtn').addEventListener('click', launchAssault);
+    document.getElementById('endCombatBtn').addEventListener('click', endSingleEnemyCombat);
+    document.getElementById('addBestiaryBtn').addEventListener('click', () => openMonsterDialog());
+    document.getElementById('saveMonsterBtn').addEventListener('click', saveMonster);
+    document.getElementById('cancelMonsterBtn').addEventListener('click', () => document.getElementById('monsterDialog').close());
+    document.getElementById('addCapabilityBtn').addEventListener('click', addCapability);
+    document.getElementById('bestiaryList').addEventListener('click', handleBestiaryClick);
+    document.getElementById('searchMonsterInput').addEventListener('input', renderBestiary);
+    document.getElementById('tagFilterSelect').addEventListener('change', renderBestiary);
+    document.getElementById('sortSelect').addEventListener('change', renderBestiary);
+    document.getElementById('restartLastFightBtn').addEventListener('click', () => {
+        const last = getLastFight();
+        if (!last?.monsterId) return;
+        const monster = bestiary.find((m) => m.id === last.monsterId);
+        if (monster) startSingleEnemyCombat(monster);
+    });
+    document.getElementById('exportBestiaryBtn').addEventListener('click', () => {
+        const blob = new Blob([JSON.stringify(bestiary, null, 2)], { type: 'application/json' });
+        const a = document.createElement('a'); a.href = URL.createObjectURL(blob); a.download = 'bestiary.json'; a.click();
+    });
+    document.getElementById('importBestiaryInput').addEventListener('change', async (e) => {
+        const file = e.target.files?.[0]; if (!file) return;
+        const parsed = JSON.parse(await file.text());
+        if (Array.isArray(parsed)) { bestiary = parsed; persistState(); renderBestiary(); }
+    });
+    document.getElementById('capabilitiesList').addEventListener('input', (e) => {
+        const t = e.target;
+        const id = t.dataset.id; const key = t.dataset.k;
+        const cap = editingCapabilities.find((c) => c.id === id); if (!cap) return;
+        cap[key] = key === 'automatic' ? t.checked : (key === 'value' ? Number(t.value) : t.value);
+    });
+    document.getElementById('capabilitiesList').addEventListener('click', (e) => {
+        const btn = e.target.closest('button[data-action="delete-cap"]'); if (!btn) return;
+        editingCapabilities = editingCapabilities.filter((c) => c.id !== btn.dataset.id);
+        renderCapabilityEditor();
+    });
+}
+
+loadState();
+bootEvents();
+renderBestiary();
+renderStatus();
+renderHistory();

--- a/AssistantJDR/style.css
+++ b/AssistantJDR/style.css
@@ -1,78 +1,45 @@
-body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 20px;
-    background-color: #f0f0f0;
+:root {
+  --bg: #121019;
+  --panel: #1d1a27;
+  --text: #f3edf7;
+  --muted: #b2a8c2;
+  --primary: #9b6dff;
+  --secondary: #3a334a;
+  --danger: #d45757;
+  --ok: #65c18c;
 }
-
-h1 {
-    text-align: center;
-}
-
-form {
-    max-width: 600px;
-    margin: 0 auto;
-    padding: 20px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-
-fieldset {
-    margin-bottom: 20px;
-}
-
-label {
-    display: block;
-    margin-bottom: 5px;
-}
-
-input {
-    width: calc(100% - 20px);
-    padding: 10px;
-    margin-bottom: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-}
-
-button {
-    width: 100%;
-    padding: 10px;
-    background-color: #007BFF;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-}
-
-button:hover {
-    background-color: #0056b3;
-}
-
-#combatLog {
-    max-width: 600px;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-
-#singleEnemyCombatSection {
-    max-width: 600px;
-    margin: 20px auto;
-    padding: 20px;
-    background-color: #fff;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-}
-
-.combat-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-#assaultHistoryContainer ul {
-    padding-left: 20px;
+* { box-sizing: border-box; }
+body { margin: 0; font-family: Inter, Arial, sans-serif; background: radial-gradient(circle at top, #251f33, var(--bg)); color: var(--text); }
+.app-shell { max-width: 860px; margin: 0 auto; padding: 14px; }
+.app-header { text-align: center; margin-bottom: 10px; }
+.app-header p { color: var(--muted); }
+.panel { background: var(--panel); border: 1px solid #2f2940; border-radius: 14px; padding: 12px; margin-bottom: 12px; }
+.panel-title-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; flex-wrap: wrap; }
+.panel-sub { margin-top: 10px; border-top: 1px solid #342d45; padding-top: 10px; }
+label { display: block; font-size: 0.9rem; margin-top: 8px; color: var(--muted); }
+input, textarea, select, button { width: 100%; border-radius: 10px; border: 1px solid #3a334a; padding: 10px; font-size: 1rem; background: #171420; color: var(--text); }
+button, .btn-like { background: var(--primary); border: 0; color: white; font-weight: 700; cursor: pointer; text-align: center; }
+button.secondary, .btn-like.secondary { background: var(--secondary); }
+button.danger { background: var(--danger); }
+fieldset { border: 1px solid #342d45; border-radius: 12px; margin-top: 8px; }
+legend { color: var(--muted); }
+.combat-buttons { display: grid; gap: 8px; margin-top: 10px; }
+.status-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 8px; }
+#assaultHistory { padding-left: 20px; max-height: 240px; overflow: auto; }
+.filters-row, .actions-inline, .card-actions { display: grid; gap: 8px; }
+.filters-row { grid-template-columns: 1fr; margin: 10px 0; }
+.cards-grid { display: grid; gap: 8px; }
+.monster-card { background: #171420; border: 1px solid #312943; border-radius: 12px; padding: 10px; display: grid; gap: 8px; }
+.monster-card.favorite { border-color: #c79b2f; box-shadow: 0 0 0 1px #c79b2f inset; }
+.tags { color: #8de0ff; font-size: 0.9rem; }
+.card-actions button { padding: 8px; }
+.cap-row { display: grid; grid-template-columns: 1fr; gap: 6px; margin-bottom: 8px; padding: 8px; background: #14111d; border-radius: 10px; }
+dialog { width: min(96vw, 800px); border: 1px solid #3f3658; border-radius: 14px; background: #201b2e; color: var(--text); }
+.dialog-actions { display: grid; gap: 8px; margin-top: 8px; }
+@media (min-width: 720px) {
+  .filters-row { grid-template-columns: 2fr 1fr 1fr; }
+  .actions-inline { grid-template-columns: repeat(3, minmax(140px, 1fr)); }
+  .card-actions { grid-template-columns: repeat(5, minmax(100px, 1fr)); }
+  .cap-row { grid-template-columns: repeat(6, minmax(80px, 1fr)); align-items: center; }
+  .dialog-actions { grid-template-columns: 1fr 1fr; }
 }

--- a/compagnon.html
+++ b/compagnon.html
@@ -40,7 +40,7 @@
       margin-bottom: .25rem;
       color: #d1d5db;
     }
-    input, textarea {
+    input, textarea, select {
       width: 100%;
       border: 1px solid #4b5563;
       background: #111827;
@@ -69,6 +69,10 @@
     .metamorphose-controls input { text-align: center; }
     .metamorphose-controls button { padding: .55rem .7rem; min-width: 2.2rem; }
     .rolling { animation: pulseDice .5s ease-in-out 4; }
+    .monster-card{background:#0f172a;border:1px solid #334155;border-radius:10px;padding:.7rem;margin-bottom:.6rem;}
+    .monster-actions{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.4rem;margin-top:.5rem;}
+    .monster-meta{color:#93c5fd;font-size:.86rem;}
+    .cap-row{display:grid;gap:.35rem;margin:.45rem 0;padding:.5rem;border:1px solid #374151;border-radius:8px;background:#0b1220;}
     @keyframes pulseDice { 0%,100%{opacity:1;transform:translateY(0)} 50%{opacity:.45;transform:translateY(-2px)} }
   </style>
 </head>
@@ -170,6 +174,43 @@
         <button class="secondary" id="closeCombatBtn" style="display:none;">Fermer le combat</button>
       </div>
     </section>
+
+    <section class="card">
+      <h2>Bestiaire</h2>
+      <div class="actions" style="margin-bottom:.6rem;">
+        <button class="primary" id="addMonsterBtn">+ Ajouter au bestiaire</button>
+        <button class="secondary" id="restartLastMonsterFightBtn">Relancer dernier combat</button>
+        <button class="secondary" id="exportBestiaryBtn">Exporter JSON</button>
+        <label class="secondary" style="padding:.7rem .9rem;border-radius:8px;display:inline-block;cursor:pointer;">Importer JSON<input id="importBestiaryInput" type="file" accept="application/json" style="display:none;"></label>
+      </div>
+      <div class="grid">
+        <div><label for="bestiarySearch">Recherche</label><input id="bestiarySearch" type="search" placeholder="Nom, description, tags"></div>
+        <div><label for="bestiaryTagFilter">Tag</label><select id="bestiaryTagFilter"><option value="">Tous</option></select></div>
+        <div><label for="bestiarySort">Tri</label><select id="bestiarySort"><option value="alpha">A→Z</option><option value="alpha_desc">Z→A</option><option value="recent">Récents</option></select></div>
+      </div>
+      <div id="bestiaryList" style="margin-top:.8rem;"></div>
+    </section>
+
+    <dialog id="monsterDialog" style="max-width:760px;width:95%;background:#111827;color:#f9fafb;border:1px solid #374151;border-radius:12px;">
+      <form method="dialog" style="padding:1rem;">
+        <h3 id="monsterDialogTitle">Ajouter un monstre</h3>
+        <input id="monsterId" type="hidden">
+        <div class="grid">
+          <div><label>Nom du monstre</label><input id="monsterNom" required></div>
+          <div><label>HABILETÉ</label><input id="monsterHabilete" type="number" min="0" required></div>
+          <div><label>ENDURANCE</label><input id="monsterEndurance" type="number" min="1" required></div>
+          <div><label>Tags (virgules)</label><input id="monsterTags"></div>
+        </div>
+        <label>Description courte</label><textarea id="monsterDescription"></textarea>
+        <label>Notes libres</label><textarea id="monsterNotes"></textarea>
+        <label>URL/image optionnelle</label><input id="monsterImage" type="url">
+        <h4>Capacités spéciales</h4>
+        <button type="button" class="secondary" id="addCapabilityBtn">+ Ajouter une capacité</button>
+        <div id="capabilitiesEditor"></div>
+        <div class="actions" style="margin-top:.8rem;"><button type="button" class="primary" id="saveMonsterBtn">Enregistrer</button><button type="button" class="secondary" id="cancelMonsterBtn">Annuler</button></div>
+      </form>
+    </dialog>
+
   </main>
 
   <script>
@@ -185,6 +226,11 @@
     const MAX_ASSAULT_HISTORY = 15;
     const AUTO_ASSAULT_DELAY_MS = 280;
     let combatState = null;
+    const BESTIARY_KEY = "compagnon_jdr_bestiary_v1";
+    const LAST_FIGHT_KEY = "compagnon_jdr_lastfight_v1";
+    const CAPABILITY_TYPES = ["text_note","enemy_damage_modifier","hero_damage_modifier","enemy_regeneration","hero_regeneration","metamorphosis_change","luck_change","skill_change","conditional_immunity","start_of_combat_effect","end_of_combat_effect"];
+    const CAPABILITY_TRIGGERS = ["start_combat","before_assault","hero_hits","enemy_hits","after_assault","end_combat"];
+    let bestiary=[]; let editingCapabilities=[];
 
     function rollDie() {
       return Math.floor(Math.random() * 6) + 1;
@@ -480,13 +526,16 @@
         history: [],
         assaultCount: 0,
         inProgress: true,
-        autoRunning: false
+        autoRunning: false,
+        monsterId: null,
+        capacites: []
       };
       refreshCombatUi();
     }
 
     function launchAssault() {
       if (!combatState || !combatState.inProgress) return;
+      applyMonsterCaps('before_assault');
       const heroRolls = rollDice(2);
       const enemyRolls = rollDice(2);
       const heroAttackStrength = sum(heroRolls) + combatState.heroSkill;
@@ -499,12 +548,15 @@
         combatState.enemyEndurance -= 2;
         resultText = 'Ennemi touché';
         hitText = '→ Ennemi blessé (-2 END)';
+        applyMonsterCaps('hero_hits');
       } else if (enemyAttackStrength > heroAttackStrength) {
         combatState.heroEndurance -= 2;
         resultText = 'Vous êtes blessé';
         hitText = '→ Vous perdez 2 END';
+        applyMonsterCaps('enemy_hits');
       }
 
+      applyMonsterCaps('after_assault');
       combatState.history.push(`Assaut ${combatState.assaultCount} → ${resultText}`);
       if (combatState.history.length > MAX_ASSAULT_HISTORY) {
         combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
@@ -570,6 +622,16 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       refreshCombatUi();
     }
 
+
+    function uid(){return `${Date.now()}_${Math.random().toString(36).slice(2,8)}`;}
+    function saveBestiary(){localStorage.setItem(BESTIARY_KEY, JSON.stringify(bestiary));}
+    function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
+    function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
+    function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.filter(c=>c.trigger===trigger).forEach(c=>{ if(!c.automatic){combatState.history.push(`⚠ Rappel: ${c.description||c.type}`);return;} if(c.type==='enemy_regeneration'){combatState.enemyEndurance += Number(c.value||0); combatState.history.push(`→ Régénération ennemi: +${c.value} END`);} else if(c.type==='hero_regeneration'){combatState.heroEndurance += Number(c.value||0); combatState.history.push(`→ Régénération héros: +${c.value} END`);} else {combatState.history.push(`ℹ ${c.type}: ${c.description||'règle spéciale'}`);} }); }
+    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>`<div class="cap-row"><select data-id="${c.id}" data-k="type">${CAPABILITY_TYPES.map(t=>`<option value="${t}" ${t===c.type?'selected':''}>${t}</option>`).join('')}</select><select data-id="${c.id}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===c.trigger?'selected':''}>${t}</option>`).join('')}</select><input data-id="${c.id}" data-k="value" type="number" value="${c.value??0}" placeholder="Valeur"><input data-id="${c.id}" data-k="description" value="${c.description||''}" placeholder="Description"><label><input data-id="${c.id}" data-k="automatic" type="checkbox" ${c.automatic?'checked':''}> Appliquer automatiquement</label><button type="button" class="danger" data-action="delete-cap" data-id="${c.id}">Supprimer capacité</button></div>`).join('');}
+    function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=m.capacites||[];renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
+    function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
+    function renderBestiary(){const q=document.getElementById('bestiarySearch').value.toLowerCase().trim(); const tag=document.getElementById('bestiaryTagFilter').value; const sort=document.getElementById('bestiarySort').value; const tags=[...new Set(bestiary.flatMap(m=>m.tags||[]))].sort((a,b)=>a.localeCompare(b,'fr')); document.getElementById('bestiaryTagFilter').innerHTML='<option value="">Tous</option>'+tags.map(t=>`<option value="${t}" ${t===tag?'selected':''}>${t}</option>`).join(''); let items=bestiary.filter(m=>(!q||`${m.nom} ${m.description} ${(m.tags||[]).join(' ')}`.toLowerCase().includes(q))&&(!tag||(m.tags||[]).includes(tag))); if(sort==='alpha') items.sort((a,b)=>a.nom.localeCompare(b.nom,'fr')); if(sort==='alpha_desc') items.sort((a,b)=>b.nom.localeCompare(a.nom,'fr')); if(sort==='recent') items.sort((a,b)=>b.updatedAt.localeCompare(a.updatedAt)); document.getElementById('bestiaryList').innerHTML=items.map(m=>`<div class="monster-card"><strong>${m.nom}</strong><div class="monster-meta">HAB ${m.habilete} • END ${m.endurance} • ${m.capacites?.length||0} capacité(s) • V:${m.stats?.wins||0}/D:${m.stats?.losses||0}</div><div class="monster-meta">${(m.tags||[]).map(t=>`#${t}`).join(' ')}</div><div class="monster-actions"><button type="button" class="primary" data-a="fight" data-id="${m.id}">Combattre</button><button type="button" class="secondary" data-a="edit" data-id="${m.id}">Modifier</button><button type="button" class="danger" data-a="del" data-id="${m.id}">Supprimer</button><button type="button" class="secondary" data-a="dup" data-id="${m.id}">Dupliquer</button><button type="button" class="secondary" data-a="fav" data-id="${m.id}">${m.favorite?'★':'☆'} Favori</button></div></div>`).join('');}
     document.getElementById('newGameBtn').addEventListener('click', newGame);
     document.getElementById('testChanceBtn').addEventListener('click', () => testCharacteristic('chance', 'Chance'));
     document.getElementById('testSkillBtn').addEventListener('click', () => testCharacteristic('habilete', 'Habileté'));
@@ -587,8 +649,23 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     document.getElementById('autoCombatBtn').addEventListener('click', runAutoCombat);
     document.getElementById('endCombatBtn').addEventListener('click', endCombat);
     document.getElementById('closeCombatBtn').addEventListener('click', endCombat);
+    document.getElementById('addMonsterBtn').addEventListener('click',()=>openMonsterDialog());
+    document.getElementById('saveMonsterBtn').addEventListener('click', saveMonsterFromDialog);
+    document.getElementById('cancelMonsterBtn').addEventListener('click', ()=>document.getElementById('monsterDialog').close());
+    document.getElementById('addCapabilityBtn').addEventListener('click', ()=>{editingCapabilities.push({id:uid(),type:'text_note',trigger:'after_assault',value:0,description:'',automatic:false});renderCapabilitiesEditor();});
+    document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.id===t.dataset.id);if(!cap)return;const k=t.dataset.k;cap[k]=k==='automatic'?t.checked:(k==='value'?parseInt(t.value||'0',10):t.value);});
+    document.getElementById('capabilitiesEditor').addEventListener('click',(e)=>{const b=e.target.closest('button[data-action="delete-cap"]');if(!b)return;editingCapabilities=editingCapabilities.filter(c=>c.id!==b.dataset.id);renderCapabilitiesEditor();});
+    document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat(); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
+    document.getElementById('bestiarySearch').addEventListener('input',renderBestiary);
+    document.getElementById('bestiaryTagFilter').addEventListener('change',renderBestiary);
+    document.getElementById('bestiarySort').addEventListener('change',renderBestiary);
+    document.getElementById('exportBestiaryBtn').addEventListener('click',()=>{const blob=new Blob([JSON.stringify(bestiary,null,2)],{type:'application/json'});const a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download='bestiary.json';a.click();});
+    document.getElementById('importBestiaryInput').addEventListener('change',async(e)=>{const f=e.target.files?.[0];if(!f)return;const arr=JSON.parse(await f.text());if(Array.isArray(arr)){bestiary=arr;saveBestiary();renderBestiary();}});
+    document.getElementById('restartLastMonsterFightBtn').addEventListener('click',()=>{const id=localStorage.getItem(LAST_FIGHT_KEY);const m=bestiary.find(x=>x.id===id);if(!m)return;document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat');refreshCombatUi();}});
 
     load();
+    loadBestiary();
+    renderBestiary();
     refreshCombatUi();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Moderniser le simulateur initial pour en faire un «Compagnon de lecture» dédié à «La Nuit du Loup-Garou» avec suivi de combat et bestiaire intégré. 
- Permettre la création/édition/duplication/suppression de monstres, inclure des capacités spéciales et suivre les statistiques des affrontements. 
- Améliorer l'ergonomie et la lisibilité avec une interface responsive, thème sombre et un journal d'assauts plus riche.

### Description
- Remplacé et restructuré `AssistantJDR/index.html` pour exposer un shell applicatif, panneaux «Combat rapide» et «Bestiaire», le `dialog` de création/édition de monstre et boutons d'import/export JSON. 
- Refondu `AssistantJDR/script.js` avec persistance via `localStorage` (`lnlg_bestiary_v1`, `lnlg_combat_history_v1`, `lnlg_last_fight_v1`), helpers `uid`/`nowIso`, fonctions de rendu (`renderBestiary`, `renderStatus`, `renderHistory`), gestionnaire de capacités (`applyCapabilities`) et CRUD complet du bestiaire (import/export, dupliquer, favori, supprimer). 
- Refactorisé la logique de combat pour 2d6 (`roll2d6`), séparation des étapes `startSingleEnemyCombat`/`launchAssault`/`endSingleEnemyCombat`, tracking des résultats vers le bestiaire via `trackResult`, et augmentation de l'historique (`MAX_ASSAULT_HISTORY`). 
- Remanié le style (`AssistantJDR/style.css`) vers un design sombre, responsive et composantisé, et mis à jour `compagnon.html` pour intégrer les mêmes capacités de bestiaire, dialogue d'édition et persistance côté compagnon. 

### Testing
- Aucun test automatisé n'a été ajouté ni exécuté pour ces changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a088f49e7108331b54d1fcc57ea7d72)