### PR TITLE
Améliore l'ergonomie du compagnon et du bloc combat

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -78,6 +78,13 @@
     .combat-selected-monster{margin-top:.6rem;padding:.6rem;border:1px solid #334155;border-radius:8px;background:#0b1220;}
     .combat-selected-monster.hidden{display:none;}
     .combat-cap-list{margin:.45rem 0 0;padding-left:1rem;}
+    .combat-enemy-name{margin-top:.6rem;font-weight:600;color:#cbd5e1;}
+    .combat-stats-table{margin-top:.45rem;width:100%;border-collapse:collapse;background:#0b1220;border:1px solid #334155;border-radius:8px;overflow:hidden;}
+    .combat-stats-table th,.combat-stats-table td{padding:.55rem .65rem;border-bottom:1px solid #1f2937;text-align:center;}
+    .combat-stats-table th{background:#111827;color:#93c5fd;font-size:.9rem;}
+    .combat-stats-table td{font-weight:700;font-size:1.05rem;}
+    .combat-stats-table tr:last-child td{border-bottom:none;}
+
     .popup-dialog{max-width:520px;width:92%;background:#0f172a;color:#f9fafb;border:1px solid #374151;border-radius:12px;padding:0;}
     .popup-inner{padding:1rem;}
      .popup-title{margin:0 0 .45rem;font-size:1.05rem;color:#93c5fd;}
@@ -141,11 +148,13 @@
     <section class="card">
       <div class="actions">
         <button class="primary" id="newGameBtn">Nouvelle partie</button>
+        <button class="primary" id="saveBtn">Enregistrer</button>
+        <button class="danger" id="resetBtn">Réinitialiser</button>
+      </div>
+      <div class="actions" style="margin-top:.5rem;">
         <button class="secondary" id="testChanceBtn">Tester la Chance</button>
         <button class="secondary" id="testSkillBtn">Tester l'Habileté</button>
-        <button class="primary" id="saveBtn">Enregistrer</button>
         <button class="secondary" id="reloadBtn">Recharger</button>
-        <button class="danger" id="resetBtn">Réinitialiser</button>
       </div>
       <div class="status" id="status"></div>
       <div class="dice-box" id="diceResult"></div>
@@ -158,15 +167,15 @@
       </div>
       <div class="grid" style="margin-top:.6rem;">
         <div>
-          <label for="combatEnemyName">Nom de l’ennemi</label>
+          <label for="combatEnemyName">Nom</label>
           <input id="combatEnemyName" type="text" value="Gobelin" />
         </div>
         <div>
-          <label for="combatEnemySkill">Habileté de l’ennemi</label>
+          <label for="combatEnemySkill">Habileté</label>
           <input id="combatEnemySkill" type="number" min="0" value="8" />
         </div>
         <div>
-          <label for="combatEnemyEndurance">Endurance de l’ennemi</label>
+          <label for="combatEnemyEndurance">Endurance</label>
           <input id="combatEnemyEndurance" type="number" min="1" value="10" />
         </div>
       </div>
@@ -176,8 +185,7 @@
           <button class="secondary" id="toggleSelectedMonsterCapsBtn" type="button">Masquer capacités</button>
         </div>
         <div id="selectedMonsterCapsWrap">
-          <div class="hint" id="selectedMonsterStats"></div>
-          <ul id="selectedMonsterCaps" class="combat-cap-list"></ul>
+                    <ul id="selectedMonsterCaps" class="combat-cap-list"></ul>
         </div>
       </div>
       <div id="combatBody" class="combat-body hidden">
@@ -188,11 +196,11 @@
         <button class="danger" id="endCombatBtn">Fuir / Terminer</button>
       </div>
       <div class="status" id="combatResultStatus"></div>
-      <div class="grid" style="margin-top:.6rem;">
-        <div>Nom de l’ennemi : <strong id="combatEnemyNameCurrent">—</strong></div>
-        <div>Endurance actuelle du héros : <strong id="combatHeroEndurance">—</strong></div>
-        <div>Endurance actuelle de l’ennemi : <strong id="combatEnemyEnduranceCurrent">—</strong></div>
-      </div>
+      <div class="combat-enemy-name">Adversaire : <strong id="combatEnemyNameCurrent">—</strong></div>
+      <table class="combat-stats-table" aria-label="Endurance du combat">
+        <thead><tr><th>Endurance du héros</th><th>Endurance de l’ennemi</th></tr></thead>
+        <tbody><tr><td id="combatHeroEndurance">—</td><td id="combatEnemyEnduranceCurrent">—</td></tr></tbody>
+      </table>
       <h3 style="margin-bottom:.5rem;">Journal de combat</h3>
       <ul id="combatHistory"></ul>
       <div class="actions" style="margin-top:.75rem;">
@@ -235,6 +243,17 @@
         <div id="capabilitiesEditor"></div>
         <div class="actions" style="margin-top:.8rem;"><button type="button" class="primary" id="saveMonsterBtn">Enregistrer</button><button type="button" class="secondary" id="cancelMonsterBtn">Annuler</button></div>
       </form>
+    </dialog>
+
+    <dialog id="confirmNewGameDialog" class="popup-dialog">
+      <div class="popup-inner">
+        <h3 class="popup-title">Confirmer la nouvelle partie</h3>
+        <p>Voulez-vous vraiment démarrer une nouvelle partie ? Les données actuelles seront remplacées.</p>
+        <div class="actions" style="margin-top:.8rem;">
+          <button class="primary" id="confirmNewGameYesBtn" type="button">Oui, démarrer</button>
+          <button class="secondary" id="confirmNewGameNoBtn" type="button">Annuler</button>
+        </div>
+      </div>
     </dialog>
 
     <dialog id="combatPopupDialog" class="popup-dialog">
@@ -541,8 +560,7 @@
       if (!selectedMonsterForCombat) { box.classList.add('hidden'); return; }
       box.classList.remove('hidden');
       document.getElementById('selectedMonsterName').textContent = selectedMonsterForCombat.nom || 'Monstre';
-      document.getElementById('selectedMonsterStats').textContent = `HAB ${selectedMonsterForCombat.habilete} • END ${selectedMonsterForCombat.endurance}`;
-      const caps = (selectedMonsterForCombat.capacites || []).map(normalizeCapability);
+            const caps = (selectedMonsterForCombat.capacites || []).map(normalizeCapability);
       document.getElementById('selectedMonsterCaps').innerHTML = caps.length ? caps.map(c => `<li><strong>${c.id}</strong> — ${CAPABILITY_TRIGGER_LABELS[c.trigger] || c.trigger} : ${c.action?.message || 'Sans message'}</li>`).join('') : '<li>Aucune capacité spéciale.</li>';
     }
 
@@ -679,7 +697,8 @@ END héros : ${Math.max(0, combatState.heroEndurance)}
 END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 
 Le ${combatState.enemyName} est vaincu.`;
-        showCombatPopup(`Le ${combatState.enemyName} est vaincu. Combat terminé.`);
+        combatState.history.push(`🏆 ${combatState.enemyName} vaincu.`);
+        showCombatPopup(`🏆 Le ${combatState.enemyName} est vaincu. Combat terminé.`);
         combatExpanded = false;
       } else if (combatState.heroEndurance <= 0) {
         combatState.inProgress = false;
@@ -692,7 +711,8 @@ END héros : ${Math.max(0, combatState.heroEndurance)}
 END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 
 Votre personnage succombe.`;
-        showCombatPopup('Votre héros succombe pendant le combat.');
+        combatState.history.push('💀 Votre héros est vaincu.');
+        showCombatPopup('💀 Votre héros succombe pendant le combat.');
         combatExpanded = false;
       } else {
         combatState.lastResult = `Assaut ${combatState.assaultCount}
@@ -762,13 +782,13 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
     function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
     function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''}};}
-    function applyMonsterCaps(trigger, context = {}){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(message); return;} if(actionType==='message_only'){combatState.history.push(`ℹ ${message}`); showCombatPopup(message); return;} if(trigger==='enemy_consecutive_successes'){combatState.history.push(`ℹ ${c.id} (ennemi: ${context.streak||0} assauts réussis)`);return;} combatState.history.push(`ℹ ${c.id}`); }); }
-    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const defaultMessage=`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; const message=c.action?.message||defaultMessage; const actionType=(c.action?.type||'message_only'); combatState.history.push(`ℹ ${message} (ennemi: ${combatState.enemyConsecutiveSuccesses} assauts réussis)`); if(actionType==='message_only'){showCombatPopup(message);} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(message);}}});}
+    function applyMonsterCaps(trigger, context = {}){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(actionType==='message_only'){combatState.history.push(`ℹ ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(trigger==='enemy_consecutive_successes'){combatState.history.push(`ℹ ${c.id} (ennemi: ${context.streak||0} assauts réussis)`);return;} combatState.history.push(`ℹ ${c.id}`); }); }
+    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const defaultMessage=`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; const message=c.action?.message||defaultMessage; const actionType=(c.action?.type||'message_only'); combatState.history.push(`ℹ ${message} (ennemi: ${combatState.enemyConsecutiveSuccesses} assauts réussis)`); if(actionType==='message_only'){showCombatPopup(`⚔️ ${message}`);} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);}}});}
     function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select><input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
     function renderBestiary(){const q=document.getElementById('bestiarySearch').value.toLowerCase().trim(); const tag=document.getElementById('bestiaryTagFilter').value; const sort=document.getElementById('bestiarySort').value; const tags=[...new Set(bestiary.flatMap(m=>m.tags||[]))].sort((a,b)=>a.localeCompare(b,'fr')); document.getElementById('bestiaryTagFilter').innerHTML='<option value="">Tous</option>'+tags.map(t=>`<option value="${t}" ${t===tag?'selected':''}>${t}</option>`).join(''); let items=bestiary.filter(m=>(!q||`${m.nom} ${m.description} ${(m.tags||[]).join(' ')}`.toLowerCase().includes(q))&&(!tag||(m.tags||[]).includes(tag))); if(sort==='alpha') items.sort((a,b)=>a.nom.localeCompare(b.nom,'fr')); if(sort==='alpha_desc') items.sort((a,b)=>b.nom.localeCompare(a.nom,'fr')); if(sort==='recent') items.sort((a,b)=>b.updatedAt.localeCompare(a.updatedAt)); document.getElementById('bestiaryList').innerHTML=items.map(m=>`<div class="monster-card"><strong>${m.nom}</strong><div class="monster-meta">HAB ${m.habilete} • END ${m.endurance} • ${m.capacites?.length||0} capacité(s) • V:${m.stats?.wins||0}/D:${m.stats?.losses||0}</div><div class="monster-meta">${(m.tags||[]).map(t=>`#${t}`).join(' ')}</div><div class="monster-actions"><button type="button" class="primary" data-a="fight" data-id="${m.id}">Combattre</button><button type="button" class="secondary" data-a="edit" data-id="${m.id}">Modifier</button><button type="button" class="danger" data-a="del" data-id="${m.id}">Supprimer</button><button type="button" class="secondary" data-a="dup" data-id="${m.id}">Dupliquer</button><button type="button" class="secondary" data-a="fav" data-id="${m.id}">${m.favorite?'★':'☆'} Favori</button></div></div>`).join('');}
-    document.getElementById('newGameBtn').addEventListener('click', newGame);
+    document.getElementById('newGameBtn').addEventListener('click', () => document.getElementById('confirmNewGameDialog').showModal());
     document.getElementById('testChanceBtn').addEventListener('click', () => testCharacteristic('chance', 'Chance'));
     document.getElementById('testSkillBtn').addEventListener('click', () => testCharacteristic('habilete', 'Habileté'));
     document.getElementById('saveBtn').addEventListener('click', save);
@@ -798,6 +818,8 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       document.getElementById('toggleSelectedMonsterCapsBtn').textContent = hidden ? 'Masquer capacités' : 'Afficher capacités';
     });
     document.getElementById('combatPopupCloseBtn').addEventListener('click', () => document.getElementById('combatPopupDialog').close());
+    document.getElementById('confirmNewGameYesBtn').addEventListener('click', () => { document.getElementById('confirmNewGameDialog').close(); newGame(); });
+    document.getElementById('confirmNewGameNoBtn').addEventListener('click', () => document.getElementById('confirmNewGameDialog').close());
     document.getElementById('addMonsterBtn').addEventListener('click',()=>openMonsterDialog());
     document.getElementById('saveMonsterBtn').addEventListener('click', saveMonsterFromDialog);
     document.getElementById('cancelMonsterBtn').addEventListener('click', ()=>document.getElementById('monsterDialog').close());
@@ -805,7 +827,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='id'){cap.id=t.value;} else {cap.action=cap.action||{type:'message_only',message:''}; if(k==='requiredConsecutiveAssaults') cap.action.requiredConsecutiveAssaults=parseInt(t.value||'1',10); if(k==='message') cap.action.message=t.value;}});
     document.getElementById('capabilitiesEditor').addEventListener('change',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='trigger'){cap.trigger=t.value;renderCapabilitiesEditor();return;} cap.action=cap.action||{type:'message_only',message:''}; if(k==='actionType'){cap.action.type=t.value;renderCapabilitiesEditor();}});
     document.getElementById('capabilitiesEditor').addEventListener('click',(e)=>{const b=e.target.closest('button[data-action="delete-cap"]');if(!b)return;editingCapabilities=editingCapabilities.filter(c=>c.editorKey!==b.dataset.key);renderCapabilitiesEditor();});
-    document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat(); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
+    document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();document.getElementById('combatCard').scrollIntoView({behavior:'smooth',block:'start'});showCombatPopup('⚔️ Lancement du combat'); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
     document.getElementById('bestiarySearch').addEventListener('input',renderBestiary);
     document.getElementById('bestiaryTagFilter').addEventListener('change',renderBestiary);
     document.getElementById('bestiarySort').addEventListener('change',renderBestiary);


### PR DESCRIPTION
### Motivation
- Rendre l’interface du compagnon plus lisible et cohérente pour les phases de combat et d’action.
- Offrir des retours visuels clairs (confirmations, emoji) pour les événements de combat afin d’améliorer l’expérience utilisateur.

### Description
- Réorganise les boutons d’action pour afficher en priorité `Nouvelle partie / Enregistrer / Réinitialiser` et place les tests (`Tester la Chance`, `Tester l'Habileté`, `Recharger`) sur une deuxième ligne.
- Ajoute une boîte de confirmation stylée `#confirmNewGameDialog` déclenchée depuis `#newGameBtn` et raccordée aux actions Oui/Annuler qui appellent `newGame()`.
- Simplifie les libellés du bloc combat en `Nom`, `Habileté`, `Endurance` et supprime la redondance HAB/END dans le panneau des capacités (`selectedMonsterStats` retiré).
- Remplace la ligne d’état d’endurance par un tableau lisible (`.combat-stats-table` et `.combat-enemy-name`) affichant côté à côte l’`Endurance du héros` et l’`Endurance de l’ennemi`.
- Enrichit le journal et les popups de combat : ajout de l’entrée de journal avec emoji `🏆` quand l’ennemi est vaincu et `💀` quand le héros est vaincu, et préfixe les popups de messages de combat avec `⚔️` (modifs dans `applyMonsterCaps`, `handleEnemyConsecutiveTrigger`, `launchAssault` et `showCombatPopup`).
- Depuis le bestiaire, le bouton `Combattre` recentre la vue sur le bloc combat (`document.getElementById('combatCard').scrollIntoView(...)`) et affiche la popup `⚔️ Lancement du combat` avant de démarrer.

### Testing
- Aucun test automatisé exécuté pour cette page HTML/JS statique.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0956a95d5c8331adecf8bba94d64cc)