### PR TITLE
Déplace le bloc Gestion de la partie et ajoute triggers/actions de combat (métamorphose)

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -153,29 +153,6 @@
       </div>
     </section>
 
-    <section class="bottom-panel">
-      <div class="card">
-        <div class="actions" style="justify-content:space-between;align-items:center;">
-          <h2 style="margin:0;">Contrôles de partie</h2>
-          <button class="secondary" id="toggleGameControlsBtn" type="button">Déplier</button>
-        </div>
-        <div id="gameControlsBody" class="combat-body hidden">
-          <div class="actions">
-            <button class="primary" id="newGameBtn">Nouvelle partie</button>
-            <button class="primary" id="saveBtn">Enregistrer</button>
-            <button class="danger" id="resetBtn">Réinitialiser</button>
-          </div>
-          <div class="actions" style="margin-top:.5rem;">
-            <button class="secondary" id="testChanceBtn">Tester la Chance</button>
-            <button class="secondary" id="testSkillBtn">Tester l'Habileté</button>
-            <button class="secondary" id="reloadBtn">Recharger</button>
-          </div>
-          <div class="status" id="status"></div>
-          <div class="dice-box" id="diceResult"></div>
-        </div>
-      </div>
-    </section>
-
     <section class="card" id="combatCard">
       <div class="actions" style="justify-content:space-between;align-items:center;">
         <h2 style="margin:0;">Combat</h2>
@@ -289,6 +266,29 @@
       </div>
     </dialog>
 
+    <section class="bottom-panel">
+      <div class="card">
+        <div class="actions" style="justify-content:space-between;align-items:center;">
+          <h2 style="margin:0;">Gestion de la partie</h2>
+          <button class="secondary" id="toggleGameControlsBtn" type="button">Déplier</button>
+        </div>
+        <div id="gameControlsBody" class="combat-body hidden">
+          <div class="actions">
+            <button class="primary" id="newGameBtn">Nouvelle partie</button>
+            <button class="primary" id="saveBtn">Enregistrer</button>
+            <button class="danger" id="resetBtn">Réinitialiser</button>
+          </div>
+          <div class="actions" style="margin-top:.5rem;">
+            <button class="secondary" id="testChanceBtn">Tester la Chance</button>
+            <button class="secondary" id="testSkillBtn">Tester l'Habileté</button>
+            <button class="secondary" id="reloadBtn">Recharger</button>
+          </div>
+          <div class="status" id="status"></div>
+          <div class="dice-box" id="diceResult"></div>
+        </div>
+      </div>
+    </section>
+
   </main>
 
   <script>
@@ -306,8 +306,8 @@
     let combatState = null;
     const BESTIARY_KEY = "compagnon_jdr_bestiary_v1";
     const LAST_FIGHT_KEY = "compagnon_jdr_lastfight_v1";
-    const CAPABILITY_TRIGGERS = ["start_combat","before_assault","hero_hits","enemy_hits","after_assault","end_combat","enemy_consecutive_successes"];
-    const CAPABILITY_ACTIONS = ["message_only","end_combat_message"];
+    const CAPABILITY_TRIGGERS = ["start_combat","before_assault","hero_hits","enemy_hits","after_assault","end_combat","enemy_consecutive_successes","enemy_success_count"];
+    const CAPABILITY_ACTIONS = ["message_only","end_combat_message","increase_metamorphose"];
     const CAPABILITY_TRIGGER_LABELS = {
       start_combat: "Au début du combat",
       before_assault: "Avant un assaut",
@@ -315,11 +315,13 @@
       enemy_hits: "Quand l'ennemi touche",
       after_assault: "Après un assaut",
       end_combat: "À la fin du combat",
-      enemy_consecutive_successes: "Assauts ennemis réussis d'affilée"
+      enemy_consecutive_successes: "Assauts ennemis réussis d'affilée",
+      enemy_success_count: "Nombre d'assauts réussis par l'ennemi"
     };
     const CAPABILITY_ACTION_LABELS = {
       message_only: "Afficher un message",
-      end_combat_message: "Terminer le combat avec message"
+      end_combat_message: "Terminer le combat avec message",
+      increase_metamorphose: "Augmenter la métamorphose de X"
     };
     let bestiary=[]; let editingCapabilities=[];
     let equipementItems = [];
@@ -665,6 +667,7 @@
         details: [],
         assaultCount: 0,
         enemyConsecutiveSuccesses: 0,
+        enemySuccessfulAssaults: 0,
         inProgress: true,
         autoRunning: false,
         monsterId: null,
@@ -682,19 +685,20 @@
       const enemyAttackStrength = sum(enemyRolls) + combatState.enemySkill;
       combatState.assaultCount += 1;
 
-      let resultText = 'Égalité';
+      let resultText = 'Les lames se heurtent sans vainqueur';
       let hitText = '→ Aucun dégât';
       if (heroAttackStrength > enemyAttackStrength) {
         combatState.enemyEndurance -= 2;
-        resultText = 'Ennemi touché';
+        resultText = `Vous prenez l'ascendant et blessez ${combatState.enemyName}`;
         hitText = '→ Ennemi blessé (-2 END)';
         combatState.enemyConsecutiveSuccesses = 0;
         applyMonsterCaps('hero_hits');
       } else if (enemyAttackStrength > heroAttackStrength) {
         combatState.heroEndurance -= 2;
-        resultText = 'Vous êtes blessé';
+        resultText = `${combatState.enemyName} trouve une ouverture et vous blesse`;
         hitText = '→ Vous perdez 2 END';
         combatState.enemyConsecutiveSuccesses += 1;
+        combatState.enemySuccessfulAssaults += 1;
         applyMonsterCaps('enemy_hits');
       } else {
         combatState.enemyConsecutiveSuccesses = 0;
@@ -702,15 +706,16 @@
 
       applyMonsterCaps('after_assault');
       handleEnemyConsecutiveTrigger();
+      handleEnemySuccessCountTrigger();
       if (!combatState.inProgress) {
         document.getElementById('endurance').value = Math.max(0, combatState.heroEndurance);
         save();
         refreshCombatUi();
         return;
       }
-      combatState.history.push(`Assaut ${combatState.assaultCount} → ${resultText}`);
-      combatState.details.push(`Assaut ${combatState.assaultCount} · 🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText}`);
-      combatState.history.push(`Série ennemie en cours : ${combatState.enemyConsecutiveSuccesses} assaut(s) réussi(s)`);
+      combatState.history.push(`⚔️ Assaut ${combatState.assaultCount} : ${resultText}.`);
+      combatState.details.push(`Assaut ${combatState.assaultCount} · 🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`);
+      combatState.history.push(`🩸 ${combatState.enemyName} aligne ${combatState.enemyConsecutiveSuccesses} réussite(s) consécutive(s), ${combatState.enemySuccessfulAssaults} au total.`);
       if (combatState.history.length > MAX_ASSAULT_HISTORY) {
         combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
       }
@@ -816,9 +821,10 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
     function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
     function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''}};}
-    function applyMonsterCaps(trigger, context = {}){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(actionType==='message_only'){combatState.history.push(`ℹ ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(trigger==='enemy_consecutive_successes'){combatState.history.push(`ℹ ${c.id} (ennemi: ${context.streak||0} assauts réussis)`);return;} combatState.history.push(`ℹ ${c.id}`); }); }
-    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const defaultMessage=`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; const message=c.action?.message||defaultMessage; const actionType=(c.action?.type||'message_only'); combatState.history.push(`ℹ ${message} (ennemi: ${combatState.enemyConsecutiveSuccesses} assauts réussis)`); if(actionType==='message_only'){showCombatPopup(`⚔️ ${message}`);} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);}}});}
-    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select><input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
+    function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.history.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(actionType==='message_only'){combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} }); }
+    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const message=c.action?.message||`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; combatState.details.push(`🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_consecutive_successes');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
+    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){const message=c.action?.message||`${combatState.enemyName} a réussi ${required} assaut(s) durant ce combat.`; combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_success_count');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
+    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
     function renderBestiary(){const q=document.getElementById('bestiarySearch').value.toLowerCase().trim(); const tag=document.getElementById('bestiaryTagFilter').value; const sort=document.getElementById('bestiarySort').value; const tags=[...new Set(bestiary.flatMap(m=>m.tags||[]))].sort((a,b)=>a.localeCompare(b,'fr')); document.getElementById('bestiaryTagFilter').innerHTML='<option value="">Tous</option>'+tags.map(t=>`<option value="${t}" ${t===tag?'selected':''}>${t}</option>`).join(''); let items=bestiary.filter(m=>(!q||`${m.nom} ${m.description} ${(m.tags||[]).join(' ')}`.toLowerCase().includes(q))&&(!tag||(m.tags||[]).includes(tag))); if(sort==='alpha') items.sort((a,b)=>a.nom.localeCompare(b.nom,'fr')); if(sort==='alpha_desc') items.sort((a,b)=>b.nom.localeCompare(a.nom,'fr')); if(sort==='recent') items.sort((a,b)=>b.updatedAt.localeCompare(a.updatedAt)); document.getElementById('bestiaryList').innerHTML=items.map(m=>`<div class="monster-card"><strong>${m.nom}</strong><div class="monster-meta">HAB ${m.habilete} • END ${m.endurance} • ${m.capacites?.length||0} capacité(s) • V:${m.stats?.wins||0}/D:${m.stats?.losses||0}</div><div class="monster-meta">${(m.tags||[]).map(t=>`#${t}`).join(' ')}</div><div class="monster-actions"><button type="button" class="primary" data-a="fight" data-id="${m.id}">Combattre</button><button type="button" class="secondary" data-a="edit" data-id="${m.id}">Modifier</button><button type="button" class="danger" data-a="del" data-id="${m.id}">Supprimer</button><button type="button" class="secondary" data-a="dup" data-id="${m.id}">Dupliquer</button><button type="button" class="secondary" data-a="fav" data-id="${m.id}">${m.favorite?'★':'☆'} Favori</button></div></div>`).join('');}
@@ -868,7 +874,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     document.getElementById('saveMonsterBtn').addEventListener('click', saveMonsterFromDialog);
     document.getElementById('cancelMonsterBtn').addEventListener('click', ()=>document.getElementById('monsterDialog').close());
     document.getElementById('addCapabilityBtn').addEventListener('click', ()=>{editingCapabilities.push(normalizeCapability({id:`capacite_${editingCapabilities.length+1}`,trigger:'after_assault',action:{type:'message_only',message:''}}));renderCapabilitiesEditor();});
-    document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='id'){cap.id=t.value;} else {cap.action=cap.action||{type:'message_only',message:''}; if(k==='requiredConsecutiveAssaults') cap.action.requiredConsecutiveAssaults=parseInt(t.value||'1',10); if(k==='message') cap.action.message=t.value;}});
+    document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='id'){cap.id=t.value;} else {cap.action=cap.action||{type:'message_only',message:''}; if(k==='requiredConsecutiveAssaults') cap.action.requiredConsecutiveAssaults=parseInt(t.value||'1',10); if(k==='requiredSuccessCount') cap.action.requiredSuccessCount=parseInt(t.value||'1',10); if(k==='metamorphoseAmount') cap.action.metamorphoseAmount=parseInt(t.value||'1',10); if(k==='message') cap.action.message=t.value;}});
     document.getElementById('capabilitiesEditor').addEventListener('change',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='trigger'){cap.trigger=t.value;renderCapabilitiesEditor();return;} cap.action=cap.action||{type:'message_only',message:''}; if(k==='actionType'){cap.action.type=t.value;renderCapabilitiesEditor();}});
     document.getElementById('capabilitiesEditor').addEventListener('click',(e)=>{const b=e.target.closest('button[data-action="delete-cap"]');if(!b)return;editingCapabilities=editingCapabilities.filter(c=>c.editorKey!==b.dataset.key);renderCapabilitiesEditor();});
     document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();document.getElementById('combatCard').scrollIntoView({behavior:'smooth',block:'start'});showCombatPopup('⚔️ Lancement du combat'); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});


### PR DESCRIPTION
### Motivation
- Rendre le panneau de contrôle de la partie plus visible et le placer en dernier bloc pour l'ergonomie. 
- Rendre le journal de combat plus littéraire et fournir des détails exploitables pour les capacités de monstres. 
- Permettre aux monstres de déclencher des effets basés sur le nombre d'assauts réussis (non nécessairement consécutifs) et d'augmenter la métamorphose du héros.

### Description
- Renomme le bloc `Contrôles de partie` en `Gestion de la partie` et le déplace en dernier bloc du `main` (fichier modifié : `compagnon.html`).
- Améliore le texte du journal et du détail de combat pour une narration plus littéraire et ajoute le compteur total `enemySuccessfulAssaults` dans `combatState`, visible dans `combatDetails` et `combatHistory`.
- Étend le système de capacités : ajoute le trigger `enemy_success_count` et l'action `increase_metamorphose`, et prolonge les labels/constants correspondants (`CAPABILITY_TRIGGERS`, `CAPABILITY_ACTIONS`, `CAPABILITY_TRIGGER_LABELS`, `CAPABILITY_ACTION_LABELS`).
- Intègre la logique d'exécution : la nouvelle action `increase_metamorphose` est gérée dans `applyMonsterCaps` (applique l'augmentation, sauvegarde et écrit dans `combatState.details` et `combatState.history`), plus le nouveau handler `handleEnemySuccessCountTrigger` déclenché après chaque assaut; l'éditeur de capacités (`renderCapabilitiesEditor`) accepte maintenant les champs `requiredSuccessCount` et `metamorphoseAmount`.

### Testing
- Exécution du JavaScript embarqué pour vérification de base via `node -e "...new Function(js)"` qui a retourné `ok` (succès).
- Recherches automatiques (`rg`) pour vérifier la présence des nouveaux identifiants et fonctions (`Gestion de la partie`, `enemy_success_count`, `increase_metamorphose`, `enemySuccessfulAssaults`, `handleEnemySuccessCountTrigger`) ont trouvé les modifications attendues (succès).
- Le changement a été commité localement (message de commit produit), prêt pour revue et test en navigateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0967548b4083318936d522fc27e1d5)