### PR TITLE
Améliore la lisibilité du bloc combat dans compagnon.html

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -188,7 +188,7 @@
         <button class="secondary" id="autoCombatBtn" disabled>Combat automatique</button>
         <button class="danger" id="endCombatBtn">Fuir / Terminer</button>
       </div>
-      <div class="status" id="combatResultStatus"></div>
+      <div class="status" id="combatResultStatus" style="display:none;"></div>
       <div class="combat-enemy-name">Adversaire : <strong id="combatEnemyNameCurrent">—</strong></div>
       <table class="combat-stats-table" aria-label="Endurance du combat">
         <thead><tr><th>Endurance du héros</th><th>Endurance de l’ennemi</th></tr></thead>
@@ -588,7 +588,12 @@
       box.classList.remove('hidden');
       document.getElementById('selectedMonsterName').textContent = selectedMonsterForCombat.nom || 'Monstre';
             const caps = (selectedMonsterForCombat.capacites || []).map(normalizeCapability);
-      document.getElementById('selectedMonsterCaps').innerHTML = caps.length ? caps.map(c => `<li><strong>${c.id}</strong> — ${CAPABILITY_TRIGGER_LABELS[c.trigger] || c.trigger} : ${c.action?.message || 'Sans message'}</li>`).join('') : '<li>Aucune capacité spéciale.</li>';
+      document.getElementById('selectedMonsterCaps').innerHTML = caps.length ? caps.map((c) => {
+        const triggerLabel = CAPABILITY_TRIGGER_LABELS[c.trigger] || c.trigger;
+        const message = (c.action?.message || '').trim();
+        const narrative = message || `Effet en attente : précise ce qu'il se passe quand « ${c.id} » se déclenche.`;
+        return `<li><strong>${c.id}</strong> — ${triggerLabel}<br><em>${narrative}</em></li>`;
+      }).join('') : '<li>Aucune capacité spéciale.</li>';
     }
 
     function refreshCombatPanelVisibility() {
@@ -636,7 +641,7 @@
       enemyName.textContent = combatState.enemyName;
       heroEndurance.textContent = combatState.heroEndurance;
       enemyEndurance.textContent = combatState.enemyEndurance;
-      status.textContent = combatState.lastResult;
+      status.textContent = "";
       history.innerHTML = combatState.history.map((line) => `<li>${line}</li>`).join('');
       details.innerHTML = combatState.details.map((line) => `<li>${line}</li>`).join('');
       details.classList.toggle('hidden', !combatDetailsExpanded);
@@ -715,7 +720,6 @@
       }
       combatState.history.push(`⚔️ Assaut ${combatState.assaultCount} : ${resultText}.`);
       combatState.details.push(`Assaut ${combatState.assaultCount} · 🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`);
-      combatState.history.push(`🩸 ${combatState.enemyName} aligne ${combatState.enemyConsecutiveSuccesses} réussite(s) consécutive(s), ${combatState.enemySuccessfulAssaults} au total.`);
       if (combatState.history.length > MAX_ASSAULT_HISTORY) {
         combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
       }


### PR DESCRIPTION
### Motivation
- Rendre le bloc « Combat » plus lisible et immersif en supprimant les répétitions et en clarifiant l’affichage des capacités des monstres.

### Description
- Masque la zone `combatResultStatus` dans l’UI et empêche `refreshCombatUi()` d’y injecter `combatState.lastResult` pour éviter le texte bleu avant le journal. 
- Supprime l’ajout redondant de la ligne résumant les assauts ennemis dans `combatState.history` afin de ne conserver ces informations que dans `combatState.details` (détail du combat). 
- Reformate `renderSelectedMonsterInfo()` pour afficher chaque capacité sur deux lignes avec le label du trigger (`CAPABILITY_TRIGGER_LABELS`) et un texte narratif; si la capacité n’a pas de message, on affiche un fallback immersif explicite. 
- Tous les changements sont dans le fichier `compagnon.html`.

### Testing
- Recherche et inspection du code avec `rg` et `sed` pour localiser les sections modifiées, et toutes les recherches ont retourné les occurrences attendues avec succès. 
- Application des modifications via petits scripts Python pour remplacer les fragments ciblés, puis vérification avec `rg`/`nl` pour confirmer les remplacements, et ces vérifications ont réussi. 
- L’ensemble des commandes automatisées exécutées pendant la validation a terminé sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09729615dc83318abf90f4bab5ff8b)