### PR TITLE
Améliore le journal de combat, les critiques et le trigger « une seule fois »

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -336,6 +336,10 @@
     function rollDice(count) {
       return Array.from({ length: count }, rollDie);
     }
+    function pickRandom(array) {
+      if (!Array.isArray(array) || array.length === 0) return '';
+      return array[Math.floor(Math.random() * array.length)];
+    }
 
     function sum(values) {
       return values.reduce((total, value) => total + value, 0);
@@ -673,6 +677,7 @@
         assaultCount: 0,
         enemyConsecutiveSuccesses: 0,
         enemySuccessfulAssaults: 0,
+        enemySuccessCountTriggeredCaps: [],
         inProgress: true,
         autoRunning: false,
         monsterId: null,
@@ -690,17 +695,38 @@
       const enemyAttackStrength = sum(enemyRolls) + combatState.enemySkill;
       combatState.assaultCount += 1;
 
-      let resultText = 'Les lames se heurtent sans vainqueur';
+      let resultText = pickRandom([
+        'Les lames se heurtent sans vainqueur',
+        'Vous tournez l’un autour de l’autre sans trouver l’ouverture',
+        'Le choc est brutal, mais aucun des deux ne cède'
+      ]);
       let hitText = '→ Aucun dégât';
+      const assaultEvents = [];
+      const heroCriticalFail = heroRolls[0] === 1 && heroRolls[1] === 1;
+      const enemyCriticalFail = enemyRolls[0] === 1 && enemyRolls[1] === 1;
+      const heroCriticalSuccess = heroRolls[0] === 6 && heroRolls[1] === 6;
+      const enemyCriticalSuccess = enemyRolls[0] === 6 && enemyRolls[1] === 6;
+      if (heroCriticalFail) assaultEvents.push('💥 Échec critique du héros (double 1) : votre arme glisse des mains dans un faux mouvement.');
+      if (enemyCriticalFail) assaultEvents.push(`💥 Échec critique de ${combatState.enemyName} (double 1) : son attaque s’écrase dans le vide.`);
+      if (heroCriticalSuccess) assaultEvents.push('✨ Réussite critique du héros (double 6) : vous frappez avec une précision fulgurante.');
+      if (enemyCriticalSuccess) assaultEvents.push(`✨ Réussite critique de ${combatState.enemyName} (double 6) : son assaut fend votre garde avec violence.`);
       if (heroAttackStrength > enemyAttackStrength) {
         combatState.enemyEndurance -= 2;
-        resultText = `Vous prenez l'ascendant et blessez ${combatState.enemyName}`;
+        resultText = pickRandom([
+          `Vous prenez l'ascendant et blessez ${combatState.enemyName}`,
+          `Votre attaque transperce la défense de ${combatState.enemyName}`,
+          `Vous forcez ${combatState.enemyName} à reculer sous vos coups`
+        ]);
         hitText = '→ Ennemi blessé (-2 END)';
         combatState.enemyConsecutiveSuccesses = 0;
         applyMonsterCaps('hero_hits');
       } else if (enemyAttackStrength > heroAttackStrength) {
         combatState.heroEndurance -= 2;
-        resultText = `${combatState.enemyName} trouve une ouverture et vous blesse`;
+        resultText = pickRandom([
+          `${combatState.enemyName} trouve une ouverture et vous blesse`,
+          `${combatState.enemyName} vous surprend et vous arrache l’initiative`,
+          `Vous perdez le rythme, ${combatState.enemyName} vous touche de plein fouet`
+        ]);
         hitText = '→ Vous perdez 2 END';
         combatState.enemyConsecutiveSuccesses += 1;
         combatState.enemySuccessfulAssaults += 1;
@@ -718,8 +744,14 @@
         refreshCombatUi();
         return;
       }
-      combatState.history.push(`⚔️ Assaut ${combatState.assaultCount} : ${resultText}.`);
-      combatState.details.push(`Assaut ${combatState.assaultCount} · 🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`);
+      const detailsLine = `🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`;
+      const eventsText = assaultEvents.length ? `\n${assaultEvents.join('\n')}` : '';
+      combatState.history.push(`⚔️ [Assaut ${combatState.assaultCount}] ${resultText}.${eventsText}`);
+      combatState.details.push(`──────── Assaut ${combatState.assaultCount} ────────`);
+      combatState.details.push(detailsLine);
+      if (assaultEvents.length) {
+        assaultEvents.forEach((eventLine) => combatState.details.push(`↳ ${eventLine}`));
+      }
       if (combatState.history.length > MAX_ASSAULT_HISTORY) {
         combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
       }
@@ -742,7 +774,6 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 Le ${combatState.enemyName} est vaincu.`;
         combatState.history.push(`🏆 ${combatState.enemyName} vaincu.`);
         showCombatPopup(`🏆 Le ${combatState.enemyName} est vaincu. Combat terminé.`);
-        combatExpanded = false;
       } else if (combatState.heroEndurance <= 0) {
         combatState.inProgress = false;
         combatState.lastResult = `Assaut ${combatState.assaultCount}
@@ -756,7 +787,6 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 Votre personnage succombe.`;
         combatState.history.push('💀 Votre héros est vaincu.');
         showCombatPopup('💀 Votre héros succombe pendant le combat.');
-        combatExpanded = false;
       } else {
         combatState.lastResult = `Assaut ${combatState.assaultCount}
 Vous : ${heroAttackStrength}
@@ -824,11 +854,11 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function saveBestiary(){localStorage.setItem(BESTIARY_KEY, JSON.stringify(bestiary));}
     function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
     function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
-    function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''}};}
+    function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''},oncePerCombat:cap?.oncePerCombat===true};}
     function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.history.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(actionType==='message_only'){combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} }); }
     function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const message=c.action?.message||`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; combatState.details.push(`🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_consecutive_successes');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
-    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){const message=c.action?.message||`${combatState.enemyName} a réussi ${required} assaut(s) durant ce combat.`; combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_success_count');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
-    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
+    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){ if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); const message=c.action?.message||`${combatState.enemyName} a réussi ${required} assaut(s) durant ce combat.`; combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_success_count');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
+    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div><label style="display:flex;gap:.4rem;align-items:center;"><input data-key="${n.editorKey}" data-k="oncePerCombat" type="checkbox" ${n.oncePerCombat?'checked':''} style="width:auto;">Ne se déclenche qu'une fois par combat</label>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
     function renderBestiary(){const q=document.getElementById('bestiarySearch').value.toLowerCase().trim(); const tag=document.getElementById('bestiaryTagFilter').value; const sort=document.getElementById('bestiarySort').value; const tags=[...new Set(bestiary.flatMap(m=>m.tags||[]))].sort((a,b)=>a.localeCompare(b,'fr')); document.getElementById('bestiaryTagFilter').innerHTML='<option value="">Tous</option>'+tags.map(t=>`<option value="${t}" ${t===tag?'selected':''}>${t}</option>`).join(''); let items=bestiary.filter(m=>(!q||`${m.nom} ${m.description} ${(m.tags||[]).join(' ')}`.toLowerCase().includes(q))&&(!tag||(m.tags||[]).includes(tag))); if(sort==='alpha') items.sort((a,b)=>a.nom.localeCompare(b.nom,'fr')); if(sort==='alpha_desc') items.sort((a,b)=>b.nom.localeCompare(a.nom,'fr')); if(sort==='recent') items.sort((a,b)=>b.updatedAt.localeCompare(a.updatedAt)); document.getElementById('bestiaryList').innerHTML=items.map(m=>`<div class="monster-card"><strong>${m.nom}</strong><div class="monster-meta">HAB ${m.habilete} • END ${m.endurance} • ${m.capacites?.length||0} capacité(s) • V:${m.stats?.wins||0}/D:${m.stats?.losses||0}</div><div class="monster-meta">${(m.tags||[]).map(t=>`#${t}`).join(' ')}</div><div class="monster-actions"><button type="button" class="primary" data-a="fight" data-id="${m.id}">Combattre</button><button type="button" class="secondary" data-a="edit" data-id="${m.id}">Modifier</button><button type="button" class="danger" data-a="del" data-id="${m.id}">Supprimer</button><button type="button" class="secondary" data-a="dup" data-id="${m.id}">Dupliquer</button><button type="button" class="secondary" data-a="fav" data-id="${m.id}">${m.favorite?'★':'☆'} Favori</button></div></div>`).join('');}
@@ -879,7 +909,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     document.getElementById('cancelMonsterBtn').addEventListener('click', ()=>document.getElementById('monsterDialog').close());
     document.getElementById('addCapabilityBtn').addEventListener('click', ()=>{editingCapabilities.push(normalizeCapability({id:`capacite_${editingCapabilities.length+1}`,trigger:'after_assault',action:{type:'message_only',message:''}}));renderCapabilitiesEditor();});
     document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='id'){cap.id=t.value;} else {cap.action=cap.action||{type:'message_only',message:''}; if(k==='requiredConsecutiveAssaults') cap.action.requiredConsecutiveAssaults=parseInt(t.value||'1',10); if(k==='requiredSuccessCount') cap.action.requiredSuccessCount=parseInt(t.value||'1',10); if(k==='metamorphoseAmount') cap.action.metamorphoseAmount=parseInt(t.value||'1',10); if(k==='message') cap.action.message=t.value;}});
-    document.getElementById('capabilitiesEditor').addEventListener('change',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='trigger'){cap.trigger=t.value;renderCapabilitiesEditor();return;} cap.action=cap.action||{type:'message_only',message:''}; if(k==='actionType'){cap.action.type=t.value;renderCapabilitiesEditor();}});
+    document.getElementById('capabilitiesEditor').addEventListener('change',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='trigger'){cap.trigger=t.value;renderCapabilitiesEditor();return;} if(k==='oncePerCombat'){cap.oncePerCombat=Boolean(t.checked);return;} cap.action=cap.action||{type:'message_only',message:''}; if(k==='actionType'){cap.action.type=t.value;renderCapabilitiesEditor();}});
     document.getElementById('capabilitiesEditor').addEventListener('click',(e)=>{const b=e.target.closest('button[data-action="delete-cap"]');if(!b)return;editingCapabilities=editingCapabilities.filter(c=>c.editorKey!==b.dataset.key);renderCapabilitiesEditor();});
     document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();document.getElementById('combatCard').scrollIntoView({behavior:'smooth',block:'start'});showCombatPopup('⚔️ Lancement du combat'); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
     document.getElementById('bestiarySearch').addEventListener('input',renderBestiary);


### PR DESCRIPTION
### Motivation
- Rendre le journal et les détails de combat plus lisibles et narratifs par assaut.  
- Permettre qu'une capacité déclenchée sur le comptage d'assauts ennemis (`enemy_success_count`) puisse être configurée pour ne se produire qu'une fois par combat.  
- Ajouter de la variété textuelle et des descriptions immersives pour les jets extrêmes (double 1 / double 6).  
- Ne plus réduire automatiquement la box de combat à la fin d’un affrontement pour préserver le contexte visuel.

### Description
- Ajout de la fonction utilitaire `pickRandom` et usage pour varier les formulations de résultat d'assaut (`resultText`) et éviter les répétitions.  
- Détection des critiques `double 1` et `double 6` pour le héros et l'ennemi, avec insertion d'événements narratifs (`assaultEvents`) affichés dans le `history` et dans `details`.  
- Reformattage du journal : chaque assaut ajoute maintenant une entrée `⚔️ [Assaut X] ...` et le panneau de détails reçoit un bloc séparateur `──────── Assaut X ────────` suivi des lignes de détail et des événements de l'assaut.  
- Capacité « une seule fois par combat » : `normalizeCapability` inclut maintenant `oncePerCombat`, l'éditeur de capacités propose une case à cocher, l'état de combat (`combatState.enemySuccessCountTriggeredCaps`) enregistre les capacités déjà déclenchées, et `handleEnemySuccessCountTrigger` bloque les ré-déclenchements si demandé.  
- Suppression de la fermeture automatique du panneau de combat en fin de combat (la variable `combatExpanded` n'est plus forcée à `false` lors de la fin), laissant la box ouverte pour consultation.

### Testing
- Vérification du diff avec `git diff -- compagnon.html` pour inspecter les modifications et confirmer les lignes modifiées ; commande exécutée avec succès.  
- Validation de l'indexation des changements via `git add` et `git commit -m "Améliore le journal d'assaut et les triggers de capacités"`, qui a réussi.  
- Génération du contenu de la PR (outil `make_pr`) pour résumer les changements appliqués ; exécution réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0978e9d3ec8331ba889465eeb3ae15)