### PR TITLE
Améliore l’ergonomie des panneaux et fiabilise les triggers de combat

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -87,11 +87,12 @@
     .combat-details-wrap{margin-top:.8rem;border:1px solid #1d4ed8;border-radius:10px;background:#0b1220;}
     .combat-details-head{display:flex;justify-content:space-between;align-items:center;padding:.55rem .7rem;border-bottom:1px solid #1e3a8a;}
     .combat-details-title{margin:0;color:#93c5fd;font-size:.95rem;font-weight:700;}
-    .combat-details{list-style:none;margin:0;padding:.65rem .9rem;max-height:210px;overflow:auto;color:#60a5fa;font-family:monospace;font-size:.9rem;}
+    .combat-details{list-style:none;margin:0;padding:.65rem .9rem;max-height:320px;overflow:auto;color:#60a5fa;font-family:monospace;font-size:.9rem;}
     .combat-details.hidden{display:none;}
     .combat-details li{margin-bottom:.35rem;}
-    .bottom-panel{position:sticky;bottom:0;z-index:9;background:#111827cc;backdrop-filter:blur(4px);border-top:1px solid #374151;margin-top:1rem;}
+    .bottom-panel{position:relative;background:#111827cc;border-top:1px solid #374151;margin-top:1rem;}
     .bottom-panel .card{margin-bottom:0;border-radius:12px 12px 0 0;}
+    .hidden{display:none !important;}
 
     .popup-dialog{max-width:520px;width:92%;background:#0f172a;color:#f9fafb;border:1px solid #374151;border-radius:12px;padding:0;}
     .popup-inner{padding:1rem;}
@@ -120,7 +121,10 @@
     </section>
 
     <section class="card">
-      <h2>Fiche de personnage</h2>
+      <div class="actions" style="justify-content:space-between;align-items:center;">
+        <h2 style="margin:0;">Fiche de personnage</h2>
+        <button class="secondary" id="toggleCharacterDetailsBtn" type="button">Mode minimal</button>
+      </div>
       <div class="grid">
         <div><label for="habilete">Habileté <span class="max-info" id="habileteMaxDisplay">(max: —)</span></label><input id="habilete" type="number" min="0" /></div>
         <div><label for="endurance">Endurance <span class="max-info" id="enduranceMaxDisplay">(max: —)</span></label><input id="endurance" type="number" min="0" /></div>
@@ -139,6 +143,11 @@
         <div><label for="provisions">Provisions</label><input id="provisions" type="number" min="0" /></div>
       </div>
       <div style="margin-top:.75rem;">
+        <div class="actions" style="justify-content:space-between;align-items:center;">
+          <label for="equipementInput" style="margin:0;">Équipement</label>
+          <button class="secondary" id="toggleEquipementBtn" type="button">Masquer</button>
+        </div>
+        <div id="equipementBlock">
         <label for="equipementInput">Équipement</label>
         <div class="actions">
           <input id="equipementInput" type="text" placeholder="Ex: épée, corde, potion..." />
@@ -146,8 +155,9 @@
         </div>
         <ul id="equipementList" class="equipement-list"></ul>
         <textarea id="equipement" style="display:none;"></textarea>
+        </div>
       </div>
-      <div style="margin-top:.75rem;">
+      <div id="characterDetailsBlock" style="margin-top:.75rem;">
         <label for="notes">Notes / rencontres</label>
         <textarea id="notes" placeholder="Notes utiles pour la suite..."></textarea>
       </div>
@@ -210,7 +220,11 @@
     </section>
 
     <section class="card">
-      <h2>Bestiaire</h2>
+      <div class="actions" style="justify-content:space-between;align-items:center;">
+        <h2 style="margin:0;">Bestiaire</h2>
+        <button class="secondary" id="toggleBestiaryBtn" type="button">Déplier</button>
+      </div>
+      <div id="bestiaryBody" class="hidden">
       <div class="actions" style="margin-bottom:.6rem;">
         <button class="primary" id="addMonsterBtn">+ Ajouter au bestiaire</button>
         <button class="secondary" id="restartLastMonsterFightBtn">Relancer dernier combat</button>
@@ -223,6 +237,7 @@
         <div><label for="bestiarySort">Tri</label><select id="bestiarySort"><option value="alpha">A→Z</option><option value="alpha_desc">Z→A</option><option value="recent">Récents</option></select></div>
       </div>
       <div id="bestiaryList" style="margin-top:.8rem;"></div>
+      </div>
     </section>
 
     <dialog id="monsterDialog" style="max-width:760px;width:95%;background:#111827;color:#f9fafb;border:1px solid #374151;border-radius:12px;">
@@ -301,7 +316,6 @@
 
     const maxFields = ['habileteMax', 'enduranceMax', 'chanceMax'];
     let metamorphoseActive = false;
-    const MAX_ASSAULT_HISTORY = 15;
     const AUTO_ASSAULT_DELAY_MS = 280;
     let combatState = null;
     const BESTIARY_KEY = "compagnon_jdr_bestiary_v1";
@@ -328,6 +342,9 @@
     let combatExpanded = false;
     let gameControlsExpanded = false;
     let combatDetailsExpanded = false;
+    let characterDetailed = true;
+    let equipementExpanded = true;
+    let bestiaryExpanded = false;
 
     function rollDie() {
       return Math.floor(Math.random() * 6) + 1;
@@ -752,13 +769,6 @@
       if (assaultEvents.length) {
         assaultEvents.forEach((eventLine) => combatState.details.push(`↳ ${eventLine}`));
       }
-      if (combatState.history.length > MAX_ASSAULT_HISTORY) {
-        combatState.history = combatState.history.slice(-MAX_ASSAULT_HISTORY);
-      }
-      if (combatState.details.length > MAX_ASSAULT_HISTORY) {
-        combatState.details = combatState.details.slice(-MAX_ASSAULT_HISTORY);
-      }
-
       document.getElementById('endurance').value = Math.max(0, combatState.heroEndurance);
 
       if (combatState.enemyEndurance <= 0) {
@@ -855,9 +865,17 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
     function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
     function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''},oncePerCombat:cap?.oncePerCombat===true};}
-    function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(c=>{ const actionType=c.action?.type||'message_only'; const message=c.action?.message||`${c.id} déclenchée.`; if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.history.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;} if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} if(actionType==='message_only'){combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`); return;} }); }
-    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){const message=c.action?.message||`${required} assaut(s) consécutifs réussis de ${combatState.enemyName}.`; combatState.details.push(`🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_consecutive_successes');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
-    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){ if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); const message=c.action?.message||`${combatState.enemyName} a réussi ${required} assaut(s) durant ce combat.`; combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); if(c.action?.type==='increase_metamorphose'){applyMonsterCaps('enemy_success_count');return;} if(c.action?.type==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`);return;} combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);}});}
+    function executeCapability(capability){
+      const c = normalizeCapability(capability);
+      const actionType=c.action?.type||'message_only';
+      const message=c.action?.message||`${c.id} déclenchée.`;
+      if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.history.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;}
+      if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.history.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;}
+      combatState.history.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);
+    }
+    function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(executeCapability); }
+    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){combatState.details.push(`🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); executeCapability(c);}});}
+    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){ if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); executeCapability(c);}});}
     function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div><label style="display:flex;gap:.4rem;align-items:center;"><input data-key="${n.editorKey}" data-k="oncePerCombat" type="checkbox" ${n.oncePerCombat?'checked':''} style="width:auto;">Ne se déclenche qu'une fois par combat</label>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
@@ -894,6 +912,21 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       gameControlsExpanded = !gameControlsExpanded;
       document.getElementById('gameControlsBody').classList.toggle('hidden', !gameControlsExpanded);
       document.getElementById('toggleGameControlsBtn').textContent = gameControlsExpanded ? 'Réduire' : 'Déplier';
+    });
+    document.getElementById('toggleCharacterDetailsBtn').addEventListener('click', () => {
+      characterDetailed = !characterDetailed;
+      document.getElementById('characterDetailsBlock').classList.toggle('hidden', !characterDetailed);
+      document.getElementById('toggleCharacterDetailsBtn').textContent = characterDetailed ? 'Mode minimal' : 'Mode détaillé';
+    });
+    document.getElementById('toggleEquipementBtn').addEventListener('click', () => {
+      equipementExpanded = !equipementExpanded;
+      document.getElementById('equipementBlock').classList.toggle('hidden', !equipementExpanded);
+      document.getElementById('toggleEquipementBtn').textContent = equipementExpanded ? 'Masquer' : 'Afficher';
+    });
+    document.getElementById('toggleBestiaryBtn').addEventListener('click', () => {
+      bestiaryExpanded = !bestiaryExpanded;
+      document.getElementById('bestiaryBody').classList.toggle('hidden', !bestiaryExpanded);
+      document.getElementById('toggleBestiaryBtn').textContent = bestiaryExpanded ? 'Réduire' : 'Déplier';
     });
     document.getElementById('toggleSelectedMonsterCapsBtn').addEventListener('click', () => {
       const wrap = document.getElementById('selectedMonsterCapsWrap');
@@ -943,6 +976,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     renderBestiary();
     renderSelectedMonsterInfo();
     refreshCombatUi();
+    document.getElementById('bestiaryBody').classList.toggle('hidden', !bestiaryExpanded);
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Afficher l’historique complet du combat et corriger des déclenchements de capacités incorrects ou anticipés pendant les assauts.
- Proposer un affichage minimal/détaillé de la fiche personnage et permettre de réduire l’équipement et le bestiaire pour alléger l’interface.
- Faire en sorte que le panneau de gestion de la partie ne reste plus collé au premier plan en permanence.

### Description
- Augmente la hauteur du panneau de détails de combat et supprime la troncature agressive de l’historique afin d’afficher tout le journal de combat.
- Introduit `executeCapability(capability)` et refactore `applyMonsterCaps`, `handleEnemyConsecutiveTrigger` et `handleEnemySuccessCountTrigger` pour exécuter uniquement la capacité ciblée au bon moment (évite les déclenchements indirects/anticipés).
- Ajoute des états UI (`characterDetailed`, `equipementExpanded`, `bestiaryExpanded`), boutons et handlers pour basculer entre mode détaillé/minimal de la fiche, masquer/afficher l’équipement et rendre le bestiaire réductible (fermé par défaut).
- Ajuste le CSS pour la nouvelle UX : `.combat-details` (max-height augmenté), `.bottom-panel` (plus `sticky`) et ajout d’une règle globale `.hidden` pour masquer proprement les blocs.

### Testing
- Aucun test automatisé disponible dans le dépôt; aucun test automatique n'a été exécuté pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097fd1b2c08331bd0e30bc869c564f)