### PR TITLE
Corriger comportements UI et triggers de combat dans compagnon.html

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -91,7 +91,7 @@
     .combat-details.hidden{display:none;}
     .combat-details li{margin-bottom:.35rem;}
     .bottom-panel{position:relative;background:#111827cc;border-top:1px solid #374151;margin-top:1rem;}
-    .bottom-panel .card{margin-bottom:0;border-radius:12px 12px 0 0;}
+    .bottom-panel .card{margin-bottom:0;border-radius:12px;}
     .hidden{display:none !important;}
 
     .popup-dialog{max-width:520px;width:92%;background:#0f172a;color:#f9fafb;border:1px solid #374151;border-radius:12px;padding:0;}
@@ -276,6 +276,7 @@
         <h3 class="popup-title">Événement de combat</h3>
         <p id="combatPopupMessage"></p>
         <div class="actions" style="margin-top:.8rem;">
+          <button class="secondary" id="combatPopupAutoBtn" type="button" style="display:none;">Combat automatique</button>
           <button class="primary" id="combatPopupCloseBtn" type="button">Compris</button>
         </div>
       </div>
@@ -342,7 +343,7 @@
     let combatExpanded = false;
     let gameControlsExpanded = false;
     let combatDetailsExpanded = false;
-    let characterDetailed = true;
+    let characterDetailed = false;
     let equipementExpanded = true;
     let bestiaryExpanded = false;
 
@@ -438,9 +439,11 @@
       el.textContent = message;
     }
 
-    function showCombatPopup(message) {
+    function showCombatPopup(message, options = {}) {
       const popup = document.getElementById('combatPopupDialog');
       document.getElementById('combatPopupMessage').textContent = message;
+      const autoBtn = document.getElementById('combatPopupAutoBtn');
+      autoBtn.style.display = options.showAuto ? '' : 'none';
       if (!popup.open) popup.showModal();
     }
 
@@ -496,6 +499,21 @@
 
     function newGame() {
       endCombat();
+      combatExpanded = false;
+      bestiaryExpanded = false;
+      gameControlsExpanded = false;
+      characterDetailed = false;
+      equipementExpanded = false;
+      combatDetailsExpanded = false;
+      document.getElementById('toggleCombatDetailsBtn').textContent = 'Voir détails du combat';
+      document.getElementById('toggleBestiaryBtn').textContent = 'Déplier';
+      document.getElementById('toggleGameControlsBtn').textContent = 'Déplier';
+      document.getElementById('toggleCharacterDetailsBtn').textContent = 'Mode détaillé';
+      document.getElementById('toggleEquipementBtn').textContent = 'Afficher';
+      refreshCharacterMode();
+      refreshCombatPanelVisibility();
+      document.getElementById('bestiaryBody').classList.add('hidden');
+      document.getElementById('gameControlsBody').classList.add('hidden');
       startDiceAnimation(() => {
         const habileteRoll = rollDice(1);
         const enduranceRoll = rollDice(2);
@@ -797,7 +815,7 @@
         refreshCombatUi();
         return;
       }
-      const detailsLine = `🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`;
+      const detailsLine = `  🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`;
       combatState.history.push(`⚔️ [Assaut ${combatState.assaultCount}] ${resultText}.`);
       assaultEvents.forEach((eventLine) => combatState.history.push(eventLine));
       combatState.pendingHistoryLines.forEach((line) => combatState.history.push(line));
@@ -906,13 +924,13 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       const c = normalizeCapability(capability);
       const actionType=c.action?.type||'message_only';
       const message=c.action?.message||`${c.id} déclenchée.`;
-      if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.pendingHistoryLines.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;}
+      if(actionType==='increase_metamorphose'){const amount=Math.max(1, parseInt(c.action?.metamorphoseAmount,10)||1);const current=parseInt(document.getElementById('metamorphose').value,10);const base=Number.isNaN(current)?0:current;applyMetamorphoseValue(base+amount);const now=parseInt(document.getElementById('metamorphose').value,10);combatState.details.push(`  🧬 ${c.id} : Métamorphose +${amount} (nouvelle valeur: ${now}).`);combatState.pendingHistoryLines.push(`🌕 ${combatState.enemyName} réveille la bête en vous : votre métamorphose grimpe de ${amount}.`);save();return;}
       if(actionType==='end_combat_message'){combatState.inProgress=false;combatState.lastResult=message;combatState.pendingHistoryLines.push(`🛑 ${message}`); showCombatPopup(`⚔️ ${message}`); return;}
       combatState.pendingHistoryLines.push(`📜 ${message}`); showCombatPopup(`⚔️ ${message}`);
     }
     function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(executeCapability); }
-    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){combatState.details.push(`🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); executeCapability(c);}});}
-    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); if(combatState.enemySuccessfulAssaults===required){ if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); combatState.details.push(`🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); executeCapability(c);}});}
+    function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){combatState.details.push(`  🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); executeCapability(c);}});}
+    function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); const reached=combatState.enemySuccessfulAssaults>=required; if(!reached) return; if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); combatState.details.push(`  🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); executeCapability(c);});}
     function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div><label style="display:flex;gap:.4rem;align-items:center;"><input data-key="${n.editorKey}" data-k="oncePerCombat" type="checkbox" ${n.oncePerCombat?'checked':''} style="width:auto;">Ne se déclenche qu'une fois par combat</label>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
@@ -972,6 +990,10 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       document.getElementById('toggleSelectedMonsterCapsBtn').textContent = hidden ? 'Masquer capacités' : 'Afficher capacités';
     });
     document.getElementById('combatPopupCloseBtn').addEventListener('click', () => document.getElementById('combatPopupDialog').close());
+    document.getElementById('combatPopupAutoBtn').addEventListener('click', async () => {
+      document.getElementById('combatPopupDialog').close();
+      await runAutoCombat();
+    });
     document.getElementById('confirmNewGameYesBtn').addEventListener('click', () => { document.getElementById('confirmNewGameDialog').close(); newGame(); });
     document.getElementById('confirmNewGameNoBtn').addEventListener('click', () => document.getElementById('confirmNewGameDialog').close());
     document.getElementById('addMonsterBtn').addEventListener('click',()=>openMonsterDialog());
@@ -981,7 +1003,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     document.getElementById('capabilitiesEditor').addEventListener('input',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='id'){cap.id=t.value;} else {cap.action=cap.action||{type:'message_only',message:''}; if(k==='requiredConsecutiveAssaults') cap.action.requiredConsecutiveAssaults=parseInt(t.value||'1',10); if(k==='requiredSuccessCount') cap.action.requiredSuccessCount=parseInt(t.value||'1',10); if(k==='metamorphoseAmount') cap.action.metamorphoseAmount=parseInt(t.value||'1',10); if(k==='message') cap.action.message=t.value;}});
     document.getElementById('capabilitiesEditor').addEventListener('change',(e)=>{const t=e.target;const cap=editingCapabilities.find(c=>c.editorKey===t.dataset.key);if(!cap)return;const k=t.dataset.k;if(k==='trigger'){cap.trigger=t.value;renderCapabilitiesEditor();return;} if(k==='oncePerCombat'){cap.oncePerCombat=Boolean(t.checked);return;} cap.action=cap.action||{type:'message_only',message:''}; if(k==='actionType'){cap.action.type=t.value;renderCapabilitiesEditor();}});
     document.getElementById('capabilitiesEditor').addEventListener('click',(e)=>{const b=e.target.closest('button[data-action="delete-cap"]');if(!b)return;editingCapabilities=editingCapabilities.filter(c=>c.editorKey!==b.dataset.key);renderCapabilitiesEditor();});
-    document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();document.getElementById('combatCard').scrollIntoView({behavior:'smooth',block:'start'});showCombatPopup('⚔️ Lancement du combat'); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
+    document.getElementById('bestiaryList').addEventListener('click',(e)=>{const b=e.target.closest('button[data-a]');if(!b)return;const m=bestiary.find(x=>x.id===b.dataset.id);if(!m)return; if(b.dataset.a==='fight'){selectedMonsterForCombat=structuredClone(m);renderSelectedMonsterInfo();document.getElementById('combatEnemyName').value=m.nom;document.getElementById('combatEnemySkill').value=m.habilete;document.getElementById('combatEnemyEndurance').value=m.endurance;startCombat();bestiaryExpanded=false;document.getElementById('bestiaryBody').classList.add('hidden');document.getElementById('toggleBestiaryBtn').textContent='Déplier';document.getElementById('combatCard').scrollIntoView({behavior:'smooth',block:'start'});showCombatPopup('⚔️ Lancement du combat', { showAuto: true }); if(combatState){combatState.monsterId=m.id;combatState.capacites=m.capacites||[];applyMonsterCaps('start_combat'); refreshCombatUi(); saveLastFight(m.id);} } if(b.dataset.a==='edit') openMonsterDialog(m); if(b.dataset.a==='del' && confirm(`Supprimer ${m.nom} ?`)){bestiary=bestiary.filter(x=>x.id!==m.id);saveBestiary();renderBestiary();} if(b.dataset.a==='dup'){const c=structuredClone(m);c.id=uid();c.nom=`${m.nom} (copie)`;c.createdAt=new Date().toISOString();c.updatedAt=c.createdAt;bestiary.unshift(c);saveBestiary();renderBestiary();} if(b.dataset.a==='fav'){m.favorite=!m.favorite;m.updatedAt=new Date().toISOString();saveBestiary();renderBestiary();}});
     document.getElementById('bestiarySearch').addEventListener('input',renderBestiary);
     document.getElementById('bestiaryTagFilter').addEventListener('change',renderBestiary);
     document.getElementById('bestiarySort').addEventListener('change',renderBestiary);
@@ -1013,6 +1035,8 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     renderBestiary();
     renderSelectedMonsterInfo();
     refreshCombatUi();
+    document.getElementById('toggleCharacterDetailsBtn').textContent = characterDetailed ? 'Mode minimal' : 'Mode détaillé';
+    document.getElementById('toggleEquipementBtn').textContent = equipementExpanded ? 'Masquer' : 'Afficher';
     refreshCharacterMode();
     document.getElementById('bestiaryBody').classList.toggle('hidden', !bestiaryExpanded);
   </script>


### PR DESCRIPTION
### Motivation
- Améliorer l’ergonomie mobile et corriger des comportements attendus lors du lancement d’une nouvelle partie et des combats depuis le bestiaire.
- Réparer la logique des capacités de monstres qui doivent déclencher l’augmentation de métamorphose quand le nombre total de réussites ennemies est atteint ou dépassé.

### Description
- Rendu homogène du style du panneau « Gestion de la partie » en corrigeant le `border-radius` pour avoir 4 coins arrondis.
- Mise en mode minimal par défaut la fiche de personnage (`characterDetailed = false`) et synchronisation des libellés/bloques (cacher équipement et hint métamorphose quand minimalisé).
- À `Nouvelle partie` : repli automatique des blocs principaux (combat, bestiaire, gestion de partie, équipement/détails) et mise à jour des boutons d’état.
- Depuis le bestiaire, le bouton « Combattre » replie le bestiaire, affiche une popup de lancement avec option `Combat automatique` et peut lancer l’auto-combat automatiquement; ajout du bouton et du handler associé.
- Amélioration du journal détaillé du combat en indentant les lignes d’événements sous le titre `Assaut X` pour une meilleure lisibilité.
- Correction de la logique du trigger `enemy_success_count` pour se déclencher quand `enemySuccessfulAssaults >= required` (plutôt que `===`), et petits ajustements pour que les triggers et les effets (notamment `increase_metamorphose`) ajoutent des lignes indentées dans `combatState.details`.

### Testing
- Aucun test automatisé n’a été exécuté pour cette modification.
- Les changements ont été vérifiés en revue de diff et commit local du fichier `compagnon.html` (commit réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ad09a1c483318a77f5f3cc686306)