### PR TITLE
Améliore la lisibilité du journal de combat et simplifie les capacités

### DIFF
--- a/compagnon.html
+++ b/compagnon.html
@@ -136,7 +136,6 @@
             <input id="metamorphose" type="number" min="0" />
             <button type="button" class="secondary" id="metamorphosePlusBtn" aria-label="Augmenter la Métamorphose">+</button>
           </div>
-          <p class="hint">La Métamorphose commence à 0. Dès qu’elle a commencé, elle ne peut plus redescendre sous 1.</p>
         </div>
         <div><label for="alarme">Alarme</label><input id="alarme" type="number" min="0" /></div>
         <div><label for="or">Or</label><input id="or" type="number" min="0" /></div>
@@ -185,7 +184,6 @@
       <div id="selectedMonsterInfo" class="combat-selected-monster hidden">
         <div class="actions" style="justify-content:space-between;align-items:center;">
           <strong id="selectedMonsterName">—</strong>
-          <button class="secondary" id="toggleSelectedMonsterCapsBtn" type="button">Masquer capacités</button>
         </div>
         <div id="selectedMonsterCapsWrap">
                     <ul id="selectedMonsterCaps" class="combat-cap-list"></ul>
@@ -663,9 +661,8 @@
       document.getElementById('selectedMonsterName').textContent = selectedMonsterForCombat.nom || 'Monstre';
             const caps = (selectedMonsterForCombat.capacites || []).map(normalizeCapability);
       document.getElementById('selectedMonsterCaps').innerHTML = caps.length ? caps.map((c) => {
-        const triggerLabel = CAPABILITY_TRIGGER_LABELS[c.trigger] || c.trigger;
         const narrative = formatCapabilityNarrative(c);
-        return `<li><strong>${c.id}</strong> — ${triggerLabel}<br><em>${narrative}</em></li>`;
+        return `<li><em>${narrative}</em></li>`;
       }).join('') : '<li>Aucune capacité spéciale.</li>';
     }
 
@@ -816,9 +813,10 @@
         return;
       }
       const detailsLine = `  🎲 Vous ${heroRolls.join('+')} + HAB ${combatState.heroSkill} = ${heroAttackStrength} | 🎲 ${combatState.enemyName} ${enemyRolls.join('+')} + HAB ${combatState.enemySkill} = ${enemyAttackStrength} ${hitText} · Série ennemie: ${combatState.enemyConsecutiveSuccesses} · Réussites ennemies totales: ${combatState.enemySuccessfulAssaults}`;
-      combatState.history.push(`⚔️ [Assaut ${combatState.assaultCount}] ${resultText}.`);
-      assaultEvents.forEach((eventLine) => combatState.history.push(eventLine));
-      combatState.pendingHistoryLines.forEach((line) => combatState.history.push(line));
+      combatState.history.push(`🧾 [Assaut ${combatState.assaultCount}]`);
+      combatState.history.push(`⚔️ ${resultText}.`);
+      assaultEvents.forEach((eventLine) => combatState.history.push(`↳ [Assaut ${combatState.assaultCount}] ${eventLine}`));
+      combatState.pendingHistoryLines.forEach((line) => combatState.history.push(`↳ [Assaut ${combatState.assaultCount}] ${line}`));
       combatState.details.push(`──────── Assaut ${combatState.assaultCount} ────────`);
       combatState.details.push(detailsLine);
       if (assaultEvents.length) {
@@ -837,7 +835,7 @@ END héros : ${Math.max(0, combatState.heroEndurance)}
 END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 
 Le ${combatState.enemyName} est vaincu.`;
-        combatState.history.push(`🏆 ${combatState.enemyName} vaincu.`);
+        combatState.history.push(`🏆 [Assaut ${combatState.assaultCount}] ${combatState.enemyName} vaincu.`);
         showCombatPopup(`🏆 Le ${combatState.enemyName} est vaincu. Combat terminé.`);
       } else if (combatState.heroEndurance <= 0) {
         combatState.inProgress = false;
@@ -850,7 +848,7 @@ END héros : ${Math.max(0, combatState.heroEndurance)}
 END ennemi : ${Math.max(0, combatState.enemyEndurance)}
 
 Votre personnage succombe.`;
-        combatState.history.push('💀 Votre héros est vaincu.');
+        combatState.history.push(`💀 [Assaut ${combatState.assaultCount}] Votre héros est vaincu.`);
         showCombatPopup('💀 Votre héros succombe pendant le combat.');
       } else {
         combatState.lastResult = `Assaut ${combatState.assaultCount}
@@ -919,7 +917,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function saveBestiary(){localStorage.setItem(BESTIARY_KEY, JSON.stringify(bestiary));}
     function loadBestiary(){bestiary=JSON.parse(localStorage.getItem(BESTIARY_KEY)||'[]');}
     function saveLastFight(monsterId){localStorage.setItem(LAST_FIGHT_KEY, monsterId||'');}
-    function normalizeCapability(cap){return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger:cap?.trigger||'after_assault',action:cap?.action||{type:'message_only',message:''},oncePerCombat:cap?.oncePerCombat===true};}
+    function normalizeCapability(cap){const trigger=cap?.trigger||'after_assault';return {editorKey:cap?.editorKey||uid(),id:cap?.id||'capacite_sans_nom',trigger,action:cap?.action||{type:'message_only',message:''},oncePerCombat:trigger==='enemy_success_count'?true:cap?.oncePerCombat===true};}
     function executeCapability(capability){
       const c = normalizeCapability(capability);
       const actionType=c.action?.type||'message_only';
@@ -931,7 +929,7 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
     function applyMonsterCaps(trigger){ if(!combatState||!combatState.capacites) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger===trigger).forEach(executeCapability); }
     function handleEnemyConsecutiveTrigger(){ if(!combatState||!combatState.capacites||combatState.enemyConsecutiveSuccesses<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_consecutive_successes').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredConsecutiveAssaults,10)||1); if(combatState.enemyConsecutiveSuccesses===required){combatState.details.push(`  🎯 Trigger ${c.id} : série ennemie ${combatState.enemyConsecutiveSuccesses}/${required}.`); executeCapability(c);}});}
     function handleEnemySuccessCountTrigger(){ if(!combatState||!combatState.capacites||combatState.enemySuccessfulAssaults<=0) return; combatState.capacites.map(normalizeCapability).filter(c=>c.trigger==='enemy_success_count').forEach(c=>{const required=Math.max(1, parseInt(c.action?.requiredSuccessCount,10)||1); const reached=combatState.enemySuccessfulAssaults>=required; if(!reached) return; if(c.oncePerCombat && combatState.enemySuccessCountTriggeredCaps.includes(c.id)) return; if(c.oncePerCombat) combatState.enemySuccessCountTriggeredCaps.push(c.id); combatState.details.push(`  🎯 Trigger ${c.id} : assauts ennemis réussis ${combatState.enemySuccessfulAssaults}/${required}.`); executeCapability(c);});}
-    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div><label style="display:flex;gap:.4rem;align-items:center;"><input data-key="${n.editorKey}" data-k="oncePerCombat" type="checkbox" ${n.oncePerCombat?'checked':''} style="width:auto;">Ne se déclenche qu'une fois par combat</label>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
+    function renderCapabilitiesEditor(){const root=document.getElementById('capabilitiesEditor');root.innerHTML=editingCapabilities.map(c=>{const n=normalizeCapability(c);return `<div class="cap-row"><input data-key="${n.editorKey}" data-k="id" value="${n.id}" placeholder="Nom de la capacité"><select data-key="${n.editorKey}" data-k="trigger">${CAPABILITY_TRIGGERS.map(t=>`<option value="${t}" ${t===n.trigger?'selected':''}>${CAPABILITY_TRIGGER_LABELS[t]||t}</option>`).join('')}</select>${n.trigger==='enemy_consecutive_successes'?`<div><label>Nombre d'assauts consécutifs requis</label><input data-key="${n.editorKey}" data-k="requiredConsecutiveAssaults" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredConsecutiveAssaults,10)||1)}"></div>`:''}${n.trigger==='enemy_success_count'?`<div><label>Nombre total d'assauts ennemis réussis requis</label><input data-key="${n.editorKey}" data-k="requiredSuccessCount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.requiredSuccessCount,10)||1)}"></div>`:''}<select data-key="${n.editorKey}" data-k="actionType">${CAPABILITY_ACTIONS.map(a=>`<option value="${a}" ${a===n.action?.type?'selected':''}>${CAPABILITY_ACTION_LABELS[a]||a}</option>`).join('')}</select>${n.action?.type==='increase_metamorphose'?`<div><label>Augmenter la métamorphose de</label><input data-key="${n.editorKey}" data-k="metamorphoseAmount" type="number" min="1" value="${Math.max(1,parseInt(n.action?.metamorphoseAmount,10)||1)}"></div>`:''}<input data-key="${n.editorKey}" data-k="message" value="${n.action?.message||''}" placeholder="Message"><button type="button" class="danger" data-action="delete-cap" data-key="${n.editorKey}">Supprimer capacité</button></div>`;}).join('');}
     function openMonsterDialog(monster=null){const m=monster?structuredClone(monster):{id:uid(),nom:'',habilete:8,endurance:8,description:'',notes:'',tags:[],image:'',createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:[],favorite:false,stats:{wins:0,losses:0}}; document.getElementById('monsterDialogTitle').textContent=monster?'Modifier un monstre':'Ajouter un monstre'; ['Id','Nom','Habilete','Endurance','Description','Notes','Image'].forEach(()=>{}); document.getElementById('monsterId').value=m.id;document.getElementById('monsterNom').value=m.nom;document.getElementById('monsterHabilete').value=m.habilete;document.getElementById('monsterEndurance').value=m.endurance;document.getElementById('monsterDescription').value=m.description;document.getElementById('monsterNotes').value=m.notes;document.getElementById('monsterTags').value=(m.tags||[]).join(', ');document.getElementById('monsterImage').value=m.image||'';editingCapabilities=(m.capacites||[]).map(normalizeCapability);renderCapabilitiesEditor();document.getElementById('monsterDialog').showModal();}
     function saveMonsterFromDialog(){const id=document.getElementById('monsterId').value;const payload={id,nom:document.getElementById('monsterNom').value.trim(),habilete:parseInt(document.getElementById('monsterHabilete').value,10),endurance:parseInt(document.getElementById('monsterEndurance').value,10),description:document.getElementById('monsterDescription').value.trim(),notes:document.getElementById('monsterNotes').value.trim(),tags:document.getElementById('monsterTags').value.split(',').map(s=>s.trim()).filter(Boolean),image:document.getElementById('monsterImage').value.trim(),createdAt:new Date().toISOString(),updatedAt:new Date().toISOString(),capacites:editingCapabilities,favorite:false,stats:{wins:0,losses:0}};const i=bestiary.findIndex(x=>x.id===id);if(i>=0){payload.createdAt=bestiary[i].createdAt;payload.favorite=bestiary[i].favorite;payload.stats=bestiary[i].stats||payload.stats;bestiary[i]=payload;}else{bestiary.unshift(payload);} saveBestiary(); renderBestiary(); document.getElementById('monsterDialog').close();}
     function renderBestiary(){const q=document.getElementById('bestiarySearch').value.toLowerCase().trim(); const tag=document.getElementById('bestiaryTagFilter').value; const sort=document.getElementById('bestiarySort').value; const tags=[...new Set(bestiary.flatMap(m=>m.tags||[]))].sort((a,b)=>a.localeCompare(b,'fr')); document.getElementById('bestiaryTagFilter').innerHTML='<option value="">Tous</option>'+tags.map(t=>`<option value="${t}" ${t===tag?'selected':''}>${t}</option>`).join(''); let items=bestiary.filter(m=>(!q||`${m.nom} ${m.description} ${(m.tags||[]).join(' ')}`.toLowerCase().includes(q))&&(!tag||(m.tags||[]).includes(tag))); if(sort==='alpha') items.sort((a,b)=>a.nom.localeCompare(b.nom,'fr')); if(sort==='alpha_desc') items.sort((a,b)=>b.nom.localeCompare(a.nom,'fr')); if(sort==='recent') items.sort((a,b)=>b.updatedAt.localeCompare(a.updatedAt)); document.getElementById('bestiaryList').innerHTML=items.map(m=>`<div class="monster-card"><strong>${m.nom}</strong><div class="monster-meta">HAB ${m.habilete} • END ${m.endurance} • ${m.capacites?.length||0} capacité(s) • V:${m.stats?.wins||0}/D:${m.stats?.losses||0}</div><div class="monster-meta">${(m.tags||[]).map(t=>`#${t}`).join(' ')}</div><div class="monster-actions"><button type="button" class="primary" data-a="fight" data-id="${m.id}">Combattre</button><button type="button" class="secondary" data-a="edit" data-id="${m.id}">Modifier</button><button type="button" class="danger" data-a="del" data-id="${m.id}">Supprimer</button><button type="button" class="secondary" data-a="dup" data-id="${m.id}">Dupliquer</button><button type="button" class="secondary" data-a="fav" data-id="${m.id}">${m.favorite?'★':'☆'} Favori</button></div></div>`).join('');}
@@ -982,12 +980,6 @@ END ennemi : ${Math.max(0, combatState.enemyEndurance)}`;
       bestiaryExpanded = !bestiaryExpanded;
       document.getElementById('bestiaryBody').classList.toggle('hidden', !bestiaryExpanded);
       document.getElementById('toggleBestiaryBtn').textContent = bestiaryExpanded ? 'Réduire' : 'Déplier';
-    });
-    document.getElementById('toggleSelectedMonsterCapsBtn').addEventListener('click', () => {
-      const wrap = document.getElementById('selectedMonsterCapsWrap');
-      const hidden = wrap.style.display === 'none';
-      wrap.style.display = hidden ? '' : 'none';
-      document.getElementById('toggleSelectedMonsterCapsBtn').textContent = hidden ? 'Masquer capacités' : 'Afficher capacités';
     });
     document.getElementById('combatPopupCloseBtn').addEventListener('click', () => document.getElementById('combatPopupDialog').close());
     document.getElementById('combatPopupAutoBtn').addEventListener('click', async () => {


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité du journal de combat pour repérer facilement à quel assaut les événements importants (échecs/réussites critiques, effets, fin de combat) se produisent.
- Simplifier l'interface et l'édition des capacités du bestiaire en réduisant les informations techniques affichées et en supprimant une option redondante.

### Description
- Supprime l'aide textuelle sur la Métamorphose dans la fiche personnage (ligne d'aide retirée de la vue minimalisée). 
- Réorganise le journal de combat pour grouper les lignes par assaut en ajoutant une en-tête `🧾 [Assaut X]` et en préfixant les événements/effets/issue du combat avec le numéro d'assaut correspondant. 
- Supprime le bouton « Masquer capacités » dans le panneau de combat et modifie l'affichage des capacités du monstre pour ne montrer que la narration reformulée (plus d'ID ni de trigger technique affiché). 
- Simplifie l'éditeur des capacités pour le trigger `enemy_success_count` en retirant la case « Ne se déclenche qu'une fois par combat » et en forçant `oncePerCombat = true` côté logique via `normalizeCapability`.

### Testing
- Aucuns tests automatisés n'ont été exécutés pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b10a73688331bf36cfaf9ac82f67)