### PR TITLE
Accueil: remplacer le sonomètre par un bloc d'information de classe

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -1,0 +1,146 @@
+(function () {
+    const TROISIEME_CLASSES = new Set(['3E1', '3E2', '3E3', '3E4', '3E5']);
+
+    // Remplacer l'URL par le lien CSV publié du fichier "3E - Techno", onglet "Suivi Eleve 3E".
+    // Format attendu : https://docs.google.com/spreadsheets/d/e/<ID>/pub?gid=<GID_ONGLET>&single=true&output=csv
+    const SHEET_3E_CSV_URL = '';
+
+    const classNameElement = document.getElementById('selected-class-name');
+    const studentsCountElement = document.getElementById('selected-class-students');
+    const statusElement = document.getElementById('class-info-status');
+    const classFilterElement = document.getElementById('progression-class-filter');
+
+    if (!classNameElement || !studentsCountElement || !statusElement) {
+        return;
+    }
+
+    function parseCSV(text) {
+        const rows = [];
+        let current = '';
+        let row = [];
+        let inQuotes = false;
+
+        for (let i = 0; i < text.length; i++) {
+            const char = text[i];
+            if (inQuotes) {
+                if (char === '"') {
+                    if (text[i + 1] === '"') {
+                        current += '"';
+                        i++;
+                    } else {
+                        inQuotes = false;
+                    }
+                } else {
+                    current += char;
+                }
+            } else if (char === '"') {
+                inQuotes = true;
+            } else if (char === ',') {
+                row.push(current);
+                current = '';
+            } else if (char === '\n') {
+                row.push(current);
+                rows.push(row);
+                row = [];
+                current = '';
+            } else if (char !== '\r') {
+                current += char;
+            }
+        }
+
+        if (current || row.length) {
+            row.push(current);
+        }
+        if (row.length) {
+            rows.push(row);
+        }
+
+        return rows;
+    }
+
+    function normalize(value) {
+        return (value || '')
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .trim();
+    }
+
+    function getSelectedClass() {
+        const fromFilter = classFilterElement ? classFilterElement.value.trim() : '';
+        const fromStorage = (localStorage.getItem('userClasse') || '').trim();
+        return fromFilter || fromStorage;
+    }
+
+    async function fetch3EStudentsCount() {
+        if (!SHEET_3E_CSV_URL) {
+            throw new Error('URL CSV du fichier "3E - Techno" non configurée.');
+        }
+
+        const response = await fetch(`${SHEET_3E_CSV_URL}${SHEET_3E_CSV_URL.includes('?') ? '&' : '?'}ts=${Date.now()}`);
+        if (!response.ok) {
+            throw new Error('Impossible de charger les données élèves.');
+        }
+
+        const csvText = await response.text();
+        const rows = parseCSV(csvText).filter((row) => row.some((cell) => (cell || '').trim()));
+        if (!rows.length) {
+            return 0;
+        }
+
+        const header = rows[0].map((cell) => normalize(cell));
+        const nameIdx = header.findIndex((col) => col === 'nom');
+        const statusIdx = header.findIndex((col) => col === 'statut eleve');
+
+        if (nameIdx === -1 || statusIdx === -1) {
+            throw new Error('Colonnes attendues introuvables (nom / statut eleve).');
+        }
+
+        return rows
+            .slice(1)
+            .filter((row) => (row[nameIdx] || '').trim() || (row[statusIdx] || '').trim())
+            .length;
+    }
+
+    async function refreshClassInfo() {
+        const className = getSelectedClass();
+
+        classNameElement.textContent = `Classe sélectionnée : ${className || 'Aucune'}`;
+
+        if (!className) {
+            studentsCountElement.textContent = 'Effectif (3E) : -';
+            statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
+            return;
+        }
+
+        if (!TROISIEME_CLASSES.has(className.toUpperCase())) {
+            studentsCountElement.textContent = 'Effectif (3E) : -';
+            statusElement.textContent = 'Cette classe ne fait pas partie des classes de 3e.';
+            return;
+        }
+
+        studentsCountElement.textContent = 'Effectif (3E) : Chargement...';
+        statusElement.textContent = 'Lecture des données de l\'onglet "Suivi Eleve 3E"...';
+
+        try {
+            const studentsCount = await fetch3EStudentsCount();
+            studentsCountElement.textContent = `Effectif (3E) : ${studentsCount} élèves`;
+            statusElement.textContent = 'Données chargées avec succès.';
+        } catch (error) {
+            studentsCountElement.textContent = 'Effectif (3E) : -';
+            statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
+        }
+    }
+
+    if (classFilterElement) {
+        classFilterElement.addEventListener('change', refreshClassInfo);
+    }
+
+    window.addEventListener('storage', (event) => {
+        if (event.key === 'userClasse') {
+            refreshClassInfo();
+        }
+    });
+
+    refreshClassInfo();
+})();

--- a/index.html
+++ b/index.html
@@ -23,39 +23,11 @@
             <article class="atelier sonometre-card home-card-sonometre">
                 <div class="atelier-content">
                     <div class="card-header-with-toggle">
-                        <h2>Régulation du bruit</h2>
-                        <button id="toggle-sonometre-compact" type="button" class="panel-toggle-button" aria-expanded="true">Masquer</button>
+                        <h2>Informations classe</h2>
                     </div>
-
-                    <div class="sonometre-controls">
-                        <label for="seuil">Seuil de bruit (%) :</label>
-                        <input id="seuil" type="range" min="10" max="90" value="55">
-                        <span id="seuil-valeur">55%</span>
-                    </div>
-
-                    <div class="sonometre-controls sonometre-bruit-mode" role="group" aria-label="Niveau de bruit ambiant">
-                        <span>Ambiance actuelle :</span>
-                        <button id="mode-calme" type="button" class="sonometre-mode-btn is-active" data-sensibilite="115">Calme</button>
-                        <button id="mode-bruyant" type="button" class="sonometre-mode-btn" data-sensibilite="80">Bruyant</button>
-                    </div>
-
-                    <div class="barre-wrapper" aria-label="Niveau sonore en direct">
-                        <div id="barre-niveau" class="barre-niveau"></div>
-                        <div id="seuil-marker" class="seuil-marker" aria-hidden="true">
-                            <span id="seuil-marker-label" class="seuil-marker-label">55%</span>
-                        </div>
-                    </div>
-
-                    <p id="niveau-live">Niveau actuel : 0%</p>
-                    <p id="depassements">Dépassements : 0</p>
-
-                    <div class="sonometre-actions">
-                        <button id="start-sonometre" type="button">Démarrer le sonomètre</button>
-                        <button id="pause-sonometre" type="button">Mettre en pause</button>
-                        <button id="decrement-compteur" type="button">-1 dépassement</button>
-                        <button id="increment-compteur" type="button">+1 dépassement</button>
-                        <button id="reset-compteur" type="button">Réinitialiser le compteur</button>
-                    </div>
+                    <p id="selected-class-name">Classe sélectionnée : Aucune</p>
+                    <p id="selected-class-students">Effectif (3E) : -</p>
+                    <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>
             <article class="atelier datetime-card home-card-datetime">
@@ -133,7 +105,7 @@
         </div>
     </div>
 
-    <script src="sonometre.js"></script>
+    <script src="class-info.js"></script>
     <script src="home-progressions.js"></script>
     <script src="home-datetime.js"></script>
 </body>


### PR DESCRIPTION
### Motivation

- Remplacer le bloc « Régulation du bruit » de la page d'accueil par un bloc affichant des informations liées à la classe sélectionnée, et fournir l'effectif pour les classes de 3e (3E1..3E5) en lisant l'onglet Google Sheets correspondant.

### Description

- Modifie `index.html` pour supprimer les contrôles du sonomètre et ajouter trois éléments d'affichage : `#selected-class-name`, `#selected-class-students` et `#class-info-status`, puis inclut `class-info.js` à la place de `sonometre.js`.
- Ajoute `class-info.js` qui détermine la classe active (priorité au filtre `#progression-class-filter`, sinon `localStorage.userClasse`), vérifie si la classe fait partie de `new Set(['3E1','3E2','3E3','3E4','3E5'])`, et pour les 3E charge un CSV Google Sheets, parse le CSV, vérifie la présence des en-têtes `nom` et `statut eleve` et comptabilise les lignes élèves pour afficher l'effectif.
- Le fichier `class-info.js` expose une constante de configuration `SHEET_3E_CSV_URL` à renseigner avec l'URL publiée du Google Sheet (format attendu : `.../pub?gid=<GID>&single=true&output=csv`).
- Rappel pour accéder aux données comme ailleurs sur le site : publier l'onglet `Suivi Eleve 3E` en CSV depuis Google Sheets, copier l'URL publique (`.../pub?gid=...&single=true&output=csv`) et la coller dans `SHEET_3E_CSV_URL` dans `class-info.js`.

### Testing

- Vérification git locale : `git status --short` exécuté et affiché avec les fichiers modifiés, résultat OK.
- Commit automatique : `git commit` a été exécuté et a réussi (message : "Remplace le bloc sonomètre par les infos de classe").
- Aucune suite de tests unitaires automatisés n'a été lancée sur ce changement; comportement à valider en chargeant la page et en configurant `SHEET_3E_CSV_URL` pour tester la récupération réelle des données.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c36defb1c8331b82c4c71b4495fe5)