### PR TITLE
Accueil : afficher B/T/A en voyants lumineux

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -91,11 +91,31 @@
         return values.reduce((sum, value) => sum + value, 0) / values.length;
     }
 
-    function formatPercentage(value) {
-        if (value === null) {
-            return '-';
+
+    function clamp(value, min, max) {
+        return Math.min(max, Math.max(min, value));
+    }
+
+    function setIndicatorLight(indicatorElement, value) {
+        if (!indicatorElement) {
+            return;
         }
-        return `${value.toFixed(1)} %`;
+
+        if (value === null) {
+            indicatorElement.style.setProperty('--indicator-color', '#6b7280');
+            indicatorElement.style.setProperty('--indicator-glow', 'rgba(107, 114, 128, 0.45)');
+            indicatorElement.title = 'Donnée indisponible';
+            return;
+        }
+
+        const percent = clamp(value, 0, 100);
+        const hue = (percent / 100) * 120;
+        const color = `hsl(${hue} 88% 48%)`;
+        const glow = `hsl(${hue} 92% 55% / 0.6)`;
+
+        indicatorElement.style.setProperty('--indicator-color', color);
+        indicatorElement.style.setProperty('--indicator-glow', glow);
+        indicatorElement.title = `${percent.toFixed(1)} %`;
     }
 
     async function fetch3EClassData(selectedClass) {
@@ -149,40 +169,40 @@
 
         if (!className) {
             studentsCountElement.textContent = 'Effectif (3E) : -';
-            indicatorBElement.textContent = 'Sérieux (B) : -';
-            indicatorTElement.textContent = 'Travail (T) : -';
-            indicatorAElement.textContent = 'Autonomie (A) : -';
+            setIndicatorLight(indicatorBElement, null);
+            setIndicatorLight(indicatorTElement, null);
+            setIndicatorLight(indicatorAElement, null);
             statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
             return;
         }
 
         if (!TROISIEME_CLASSES.has(className.toUpperCase())) {
             studentsCountElement.textContent = 'Effectif (3E) : -';
-            indicatorBElement.textContent = 'Sérieux (B) : -';
-            indicatorTElement.textContent = 'Travail (T) : -';
-            indicatorAElement.textContent = 'Autonomie (A) : -';
+            setIndicatorLight(indicatorBElement, null);
+            setIndicatorLight(indicatorTElement, null);
+            setIndicatorLight(indicatorAElement, null);
             statusElement.textContent = 'Cette classe ne fait pas partie des classes de 3e.';
             return;
         }
 
         studentsCountElement.textContent = 'Effectif (3E) : Chargement...';
-        indicatorBElement.textContent = 'Sérieux (B) : Chargement...';
-        indicatorTElement.textContent = 'Travail (T) : Chargement...';
-        indicatorAElement.textContent = 'Autonomie (A) : Chargement...';
+        setIndicatorLight(indicatorBElement, null);
+        setIndicatorLight(indicatorTElement, null);
+        setIndicatorLight(indicatorAElement, null);
         statusElement.textContent = 'Lecture des données de l\'onglet "Suivi Eleve 3E"...';
 
         try {
             const classData = await fetch3EClassData(className);
             studentsCountElement.textContent = `Effectif (3E) : ${classData.studentsCount} élèves`;
-            indicatorBElement.textContent = `Sérieux (B) : ${formatPercentage(classData.averageB)}`;
-            indicatorTElement.textContent = `Travail (T) : ${formatPercentage(classData.averageT)}`;
-            indicatorAElement.textContent = `Autonomie (A) : ${formatPercentage(classData.averageA)}`;
+            setIndicatorLight(indicatorBElement, classData.averageB);
+            setIndicatorLight(indicatorTElement, classData.averageT);
+            setIndicatorLight(indicatorAElement, classData.averageA);
             statusElement.textContent = 'Données chargées avec succès.';
         } catch (error) {
             studentsCountElement.textContent = 'Effectif (3E) : -';
-            indicatorBElement.textContent = 'Sérieux (B) : -';
-            indicatorTElement.textContent = 'Travail (T) : -';
-            indicatorAElement.textContent = 'Autonomie (A) : -';
+            setIndicatorLight(indicatorBElement, null);
+            setIndicatorLight(indicatorTElement, null);
+            setIndicatorLight(indicatorAElement, null);
             statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
         }
     }

--- a/index.html
+++ b/index.html
@@ -27,9 +27,11 @@
                     </div>
                     <p id="selected-class-name">Classe sélectionnée : Aucune</p>
                     <p id="selected-class-students">Effectif (3E) : -</p>
-                    <p id="selected-class-indicator-b">Sérieux (B) : -</p>
-                    <p id="selected-class-indicator-t">Travail (T) : -</p>
-                    <p id="selected-class-indicator-a">Autonomie (A) : -</p>
+                    <div class="class-indicators" aria-label="Indicateurs B, T et A">
+                        <span id="selected-class-indicator-b" class="indicator-light" role="img" aria-label="Indicateur B"></span>
+                        <span id="selected-class-indicator-t" class="indicator-light" role="img" aria-label="Indicateur T"></span>
+                        <span id="selected-class-indicator-a" class="indicator-light" role="img" aria-label="Indicateur A"></span>
+                    </div>
                     <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>

--- a/styles.css
+++ b/styles.css
@@ -1671,3 +1671,23 @@ svg.axe { display: block; margin: 0.5em 0; }
             rgb(calc(5 + (250 * var(--timer-progress))), 20, calc(70 - (55 * var(--timer-progress)))) 100%);
     transition: background 0.35s linear;
 }
+
+.class-indicators {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 10px 0 6px;
+}
+
+.indicator-light {
+    --indicator-color: #6b7280;
+    --indicator-glow: rgba(107, 114, 128, 0.45);
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, #ffffff 0%, var(--indicator-color) 45%, color-mix(in srgb, var(--indicator-color) 72%, #000000 28%) 100%);
+    box-shadow:
+        0 0 0 1px rgba(255, 255, 255, 0.35) inset,
+        0 0 10px var(--indicator-glow),
+        0 0 20px color-mix(in srgb, var(--indicator-glow) 75%, transparent 25%);
+}


### PR DESCRIPTION
### Motivation
- Remplacer les libellés texte des indicateurs B/T/A par des voyants visuels alignés sur une seule ligne pour un rendu plus compact et agréable visuellement.
- Représenter la valeur de chaque indicateur par une couleur allant du rouge (0%) au vert (100%) et gérer proprement l'absence de données.

### Description
- Remplacement des trois paragraphes textuels B/T/A par un conteneur `<div class="class-indicators">` contenant trois `<span class="indicator-light" id="selected-class-indicator-{b,t,a}">` gardant l'ordre B/T/A et des attributs d'accessibilité (`role`/`aria-label`).
- Ajout de styles dans `styles.css` pour afficher des voyants ronds avec glow et espacement (`.class-indicators`, `.indicator-light`).
- Ajout des fonctions `clamp` et `setIndicatorLight` dans `class-info.js` et modification de `refreshClassInfo` pour piloter dynamiquement la couleur des voyants (hue de 0→120) et afficher un état neutre gris quand la donnée est absente, au lieu d'insérer du texte.

### Testing
- Vérification statique du script JavaScript avec `node --check class-info.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c44af00948331b65547ca5ea447b0)