### PR TITLE
Ajout du bouton « Générer les équipes » et popup pour répartir les élèves (B/T/A)

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -12,6 +12,13 @@
     const indicatorAElement = document.getElementById('selected-class-indicator-a');
     const statusElement = document.getElementById('class-info-status');
     const classFilterElement = document.getElementById('progression-class-filter');
+    const generateTeamsButton = document.getElementById('generate-teams-button');
+    const teamsPopupElement = document.getElementById('teams-popup');
+    const closeTeamsPopupButton = document.getElementById('close-teams-popup');
+    const teamsPopupListElement = document.getElementById('teams-popup-list');
+    const teamsPopupStatusElement = document.getElementById('teams-popup-status');
+
+    let lastClassStudents = [];
 
     if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !statusElement) {
         return;
@@ -91,6 +98,82 @@
         return values.reduce((sum, value) => sum + value, 0) / values.length;
     }
 
+    function parseStudentData(row, idxMap) {
+        const name = (row[idxMap.nameIdx] || '').trim();
+        return {
+            name,
+            b: parsePercentage(row[idxMap.indicatorBIdx]),
+            t: parsePercentage(row[idxMap.indicatorTIdx]),
+            a: parsePercentage(row[idxMap.indicatorAIdx]),
+        };
+    }
+
+    function buildTeams(students) {
+        const teams = Array.from({ length: 6 }, () => []);
+        const remaining = students.slice();
+
+        const pickTopPerTeam = (key, scoreFn = (student) => student[key] ?? -1) => {
+            const sorted = remaining
+                .filter((student) => scoreFn(student) !== -1)
+                .sort((lhs, rhs) => scoreFn(rhs) - scoreFn(lhs));
+
+            for (let i = 0; i < teams.length && i < sorted.length; i++) {
+                const selected = sorted[i];
+                const index = remaining.indexOf(selected);
+                if (index !== -1) {
+                    teams[i].push(selected);
+                    remaining.splice(index, 1);
+                }
+            }
+        };
+
+        pickTopPerTeam('b', (student) => (student.b === null ? -1 : 100 - student.b));
+        pickTopPerTeam('t');
+        pickTopPerTeam('a');
+
+        const sortByLowestTeamSize = () => teams.map((team, index) => ({ team, index })).sort((lhs, rhs) => lhs.team.length - rhs.team.length);
+        for (const student of remaining) {
+            const teamEntry = sortByLowestTeamSize()[0];
+            teamEntry.team.push(student);
+        }
+
+        let changed = true;
+        while (changed) {
+            changed = false;
+            const maxTeam = teams.reduce((prev, curr) => (curr.length > prev.length ? curr : prev), teams[0]);
+            const minTeam = teams.reduce((prev, curr) => (curr.length < prev.length ? curr : prev), teams[0]);
+            if (maxTeam.length > 6 && minTeam.length < 4) {
+                minTeam.push(maxTeam.pop());
+                changed = true;
+            }
+        }
+
+        return teams;
+    }
+
+    function renderTeams(teams) {
+        if (!teamsPopupListElement) {
+            return;
+        }
+
+        teamsPopupListElement.innerHTML = '';
+        teams.forEach((team, index) => {
+            const card = document.createElement('article');
+            card.className = 'team-card';
+            const title = document.createElement('h4');
+            title.textContent = `Équipe ${index + 1} (${team.length} élèves)`;
+            const list = document.createElement('ul');
+            team.forEach((student) => {
+                const item = document.createElement('li');
+                item.textContent = student.name;
+                list.appendChild(item);
+            });
+            card.appendChild(title);
+            card.appendChild(list);
+            teamsPopupListElement.appendChild(card);
+        });
+    }
+
 
     function clamp(value, min, max) {
         return Math.min(max, Math.max(min, value));
@@ -131,7 +214,7 @@
         const csvText = await response.text();
         const rows = parseCSV(csvText).filter((row) => row.some((cell) => (cell || '').trim()));
         if (!rows.length) {
-            return { studentsCount: 0, averageB: null, averageT: null, averageA: null };
+            return { studentsCount: 0, averageB: null, averageT: null, averageA: null, students: [] };
         }
 
         const header = rows[0].map((cell) => normalize(cell));
@@ -154,11 +237,19 @@
         const tValues = classRows.map((row) => parsePercentage(row[indicatorTIdx])).filter((value) => value !== null);
         const aValues = classRows.map((row) => parsePercentage(row[indicatorAIdx])).filter((value) => value !== null);
 
+        const students = classRows.map((row) => parseStudentData(row, {
+            nameIdx,
+            indicatorBIdx,
+            indicatorTIdx,
+            indicatorAIdx,
+        }));
+
         return {
             studentsCount: classRows.length,
             averageB: computeAverage(bValues),
             averageT: computeAverage(tValues),
             averageA: computeAverage(aValues),
+            students,
         };
     }
 
@@ -197,14 +288,45 @@
             setIndicatorLight(indicatorBElement, classData.averageB);
             setIndicatorLight(indicatorTElement, classData.averageT);
             setIndicatorLight(indicatorAElement, classData.averageA);
+            lastClassStudents = classData.students;
             statusElement.textContent = 'Données chargées avec succès.';
         } catch (error) {
             studentsCountElement.textContent = 'Effectif (3E) : -';
             setIndicatorLight(indicatorBElement, null);
             setIndicatorLight(indicatorTElement, null);
             setIndicatorLight(indicatorAElement, null);
+            lastClassStudents = [];
             statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
         }
+    }
+
+    if (generateTeamsButton && teamsPopupElement && closeTeamsPopupButton) {
+        generateTeamsButton.addEventListener('click', () => {
+            if (lastClassStudents.length < 24) {
+                teamsPopupStatusElement.textContent = 'Impossible de générer 6 équipes de 4 à 6 élèves avec cet effectif.';
+                teamsPopupListElement.innerHTML = '';
+                teamsPopupElement.hidden = false;
+                return;
+            }
+
+            const teams = buildTeams(lastClassStudents);
+            const allSizesValid = teams.every((team) => team.length >= 4 && team.length <= 6);
+            teamsPopupStatusElement.textContent = allSizesValid
+                ? 'Équipes générées avec répartition B / T / A.'
+                : 'Équipes générées mais certaines tailles sortent de la plage 4-6.';
+            renderTeams(teams);
+            teamsPopupElement.hidden = false;
+        });
+
+        closeTeamsPopupButton.addEventListener('click', () => {
+            teamsPopupElement.hidden = true;
+        });
+
+        teamsPopupElement.addEventListener('click', (event) => {
+            if (event.target === teamsPopupElement) {
+                teamsPopupElement.hidden = true;
+            }
+        });
     }
 
     if (classFilterElement) {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                         <span id="selected-class-indicator-t" class="indicator-light" role="img" aria-label="Indicateur T"></span>
                         <span id="selected-class-indicator-a" class="indicator-light" role="img" aria-label="Indicateur A"></span>
                     </div>
+                    <button id="generate-teams-button" type="button" class="generate-teams-button">Générer les équipes</button>
                     <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>
@@ -107,6 +108,15 @@
     <div id="datetime-popup" class="datetime-popup" hidden>
         <div class="datetime-popup-panel">
             <button id="close-datetime-popup" type="button" class="datetime-popup-close">Fermer</button>
+        </div>
+    </div>
+
+    <div id="teams-popup" class="teams-popup" hidden>
+        <div class="teams-popup-panel">
+            <button id="close-teams-popup" type="button" class="teams-popup-close">Fermer</button>
+            <h3>Équipes générées</h3>
+            <p id="teams-popup-status">Aucune équipe générée.</p>
+            <div id="teams-popup-list" class="teams-popup-list"></div>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1691,3 +1691,79 @@ svg.axe { display: block; margin: 0.5em 0; }
         0 0 10px var(--indicator-glow),
         0 0 20px color-mix(in srgb, var(--indicator-glow) 75%, transparent 25%);
 }
+
+.generate-teams-button {
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    padding: 8px 14px;
+    font-size: 0.88rem;
+    cursor: pointer;
+    margin: 6px 0;
+}
+
+.generate-teams-button:hover {
+    background: rgba(255, 255, 255, 0.24);
+}
+
+.teams-popup {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5000;
+}
+
+.teams-popup[hidden] {
+    display: none;
+}
+
+.teams-popup-panel {
+    width: min(920px, 95vw);
+    max-height: 88vh;
+    overflow-y: auto;
+    background: #0f172a;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 14px;
+    padding: 18px;
+    color: #fff;
+    position: relative;
+}
+
+.teams-popup-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    cursor: pointer;
+}
+
+.teams-popup-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 10px;
+    margin-top: 12px;
+}
+
+.team-card {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 10px;
+    padding: 10px;
+}
+
+.team-card h4 {
+    margin: 0 0 8px;
+}
+
+.team-card ul {
+    margin: 0;
+    padding-left: 18px;
+}


### PR DESCRIPTION
### Motivation
- Permettre à l'enseignant de générer rapidement 6 équipes équilibrées depuis le bloc « Informations classe » sur la page d'accueil.
- Respecter les contraintes pédagogiques : chaque équipe doit contenir entre 4 et 6 élèves et répartir équitablement les profils B / T / A (dont les élèves les plus marquants).

### Description
- Ajout d'un bouton et de la structure HTML du popup dans `index.html` pour déclencher et afficher les équipes générées.
- Ajout des styles du bouton, du popup et des cartes d'équipe dans `styles.css` pour un affichage clair et réactif.
- Extension de `class-info.js` pour conserver la liste des élèves chargés, parser les indicateurs par élève et exposer la fonction de génération de groupes.
- Implémentation d'un algorithme qui crée 6 équipes, tente d'équilibrer les profils B / T / A (sélection des meilleurs répartis par équipe), distribue le reste pour lisser les tailles et vise la contrainte 4–6 élèves par équipe, puis rend les équipes dans le popup avec gestion d'ouverture/fermeture.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check class-info.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c470f15f4833185ac9916dfb34748)