### PR TITLE
Ajouter voyants B/T/A et bouton Détails dans la popup de génération d'équipes

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -151,6 +151,22 @@
         return teams;
     }
 
+    function createIndicatorsRow(valuesByKey) {
+        const row = document.createElement('div');
+        row.className = 'class-indicators';
+
+        ['b', 't', 'a'].forEach((key) => {
+            const light = document.createElement('span');
+            light.className = 'indicator-light';
+            light.setAttribute('role', 'img');
+            light.setAttribute('aria-label', `Indicateur ${key.toUpperCase()}`);
+            setIndicatorLight(light, valuesByKey[key] ?? null);
+            row.appendChild(light);
+        });
+
+        return row;
+    }
+
     function renderTeams(teams) {
         if (!teamsPopupListElement) {
             return;
@@ -162,14 +178,54 @@
             card.className = 'team-card';
             const title = document.createElement('h4');
             title.textContent = `Équipe ${index + 1} (${team.length} élèves)`;
-            const list = document.createElement('ul');
+
+            const teamIndicators = createIndicatorsRow({
+                b: computeAverage(team.map((student) => student.b).filter((value) => value !== null)),
+                t: computeAverage(team.map((student) => student.t).filter((value) => value !== null)),
+                a: computeAverage(team.map((student) => student.a).filter((value) => value !== null)),
+            });
+            teamIndicators.classList.add('team-indicators');
+
+            const detailsButton = document.createElement('button');
+            detailsButton.type = 'button';
+            detailsButton.className = 'team-details-button';
+            detailsButton.textContent = 'Détails';
+            detailsButton.setAttribute('aria-expanded', 'false');
+
+            const detailsPanel = document.createElement('div');
+            detailsPanel.className = 'team-details-panel';
+            detailsPanel.hidden = true;
+
+            const detailsList = document.createElement('ul');
+            detailsList.className = 'team-students-list';
             team.forEach((student) => {
                 const item = document.createElement('li');
-                item.textContent = student.name;
-                list.appendChild(item);
+                item.className = 'team-student-item';
+
+                const name = document.createElement('span');
+                name.textContent = student.name;
+
+                const studentIndicators = createIndicatorsRow({ b: student.b, t: student.t, a: student.a });
+                studentIndicators.classList.add('team-student-indicators');
+
+                item.appendChild(name);
+                item.appendChild(studentIndicators);
+                detailsList.appendChild(item);
             });
+
+            detailsPanel.appendChild(detailsList);
+
+            detailsButton.addEventListener('click', () => {
+                const nextState = detailsPanel.hidden;
+                detailsPanel.hidden = !nextState;
+                detailsButton.setAttribute('aria-expanded', String(nextState));
+                detailsButton.textContent = nextState ? 'Masquer détails' : 'Détails';
+            });
+
             card.appendChild(title);
-            card.appendChild(list);
+            card.appendChild(teamIndicators);
+            card.appendChild(detailsButton);
+            card.appendChild(detailsPanel);
             teamsPopupListElement.appendChild(card);
         });
     }

--- a/styles.css
+++ b/styles.css
@@ -1767,3 +1767,47 @@ svg.axe { display: block; margin: 0.5em 0; }
     margin: 0;
     padding-left: 18px;
 }
+
+
+.team-indicators {
+    margin: 6px 0 10px;
+}
+
+.team-details-button {
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: 999px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.team-details-panel {
+    margin-top: 10px;
+}
+
+.team-students-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.team-student-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 8px;
+    padding: 8px;
+}
+
+.team-student-indicators {
+    margin: 0;
+    gap: 8px;
+    flex-shrink: 0;
+}


### PR DESCRIPTION
### Motivation
- Permettre de visualiser rapidement la composition des équipes via 3 voyants (B / T / A) calculés à partir des indicateurs élèves. 
- Offrir un accès rapide aux détails de chaque équipe pour inspecter les voyants individuels des élèves sans quitter la popup.

### Description
- Ajout de la fonction `createIndicatorsRow` dans `class-info.js` pour construire une rangée de 3 voyants et réutiliser `setIndicatorLight` pour les colorer. 
- Modification de `renderTeams` dans `class-info.js` pour afficher les voyants d'équipe (moyennes calculées avec `computeAverage`), ajouter un bouton `Détails` et un panneau extensible listant les élèves avec leurs voyants individuels. 
- Gestion de l'accessibilité via `role`, `aria-label` et `aria-expanded`, et utilisation de l'attribut `hidden` pour basculer l'affichage du panneau. 
- Ajout des règles CSS dans `styles.css` pour `.team-indicators`, `.team-details-button`, `.team-details-panel`, `.team-students-list`, `.team-student-item` et `.team-student-indicators` pour présenter proprement les voyants et la liste détaillée.

### Testing
- Vérification syntaxique JavaScript avec `node --check class-info.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a60437c8331ae4b95bd14b4d658)