### PR TITLE
Accueil: garder la liste des élèves visible et faire du bouton 'détail' un contrôle des voyants

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -191,12 +191,12 @@
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'team-details-button';
-            detailsButton.textContent = 'Détails';
-            detailsButton.setAttribute('aria-expanded', 'false');
+            detailsButton.textContent = 'Afficher voyants';
+            detailsButton.setAttribute('aria-pressed', 'false');
 
             const detailsPanel = document.createElement('div');
             detailsPanel.className = 'team-details-panel';
-            detailsPanel.hidden = true;
+            detailsPanel.classList.add('indicators-hidden');
 
             const detailsList = document.createElement('ul');
             detailsList.className = 'team-students-list';
@@ -218,10 +218,9 @@
             detailsPanel.appendChild(detailsList);
 
             detailsButton.addEventListener('click', () => {
-                const nextState = detailsPanel.hidden;
-                detailsPanel.hidden = !nextState;
-                detailsButton.setAttribute('aria-expanded', String(nextState));
-                detailsButton.textContent = nextState ? 'Masquer détails' : 'Détails';
+                const showIndicators = detailsPanel.classList.toggle('indicators-hidden') === false;
+                detailsButton.setAttribute('aria-pressed', String(showIndicators));
+                detailsButton.textContent = showIndicators ? 'Masquer voyants' : 'Afficher voyants';
             });
 
             card.appendChild(title);

--- a/styles.css
+++ b/styles.css
@@ -1811,3 +1811,7 @@ svg.axe { display: block; margin: 0.5em 0; }
     gap: 8px;
     flex-shrink: 0;
 }
+
+.team-details-panel.indicators-hidden .team-student-indicators {
+    display: none;
+}


### PR DESCRIPTION
### Motivation
- Afficher en permanence la liste des élèves pour chaque équipe sur la page d'accueil et faire en sorte que le bouton « détail » n'affecte que l'affichage des voyants individuels.

### Description
- Dans `class-info.js` le bouton de détail a été renommé en `Afficher voyants` / `Masquer voyants`, il utilise maintenant l'attribut `aria-pressed` et bascule une classe `indicators-hidden` au lieu de cacher le panneau complet, de sorte que les noms d'élèves restent toujours visibles.
- Dans `styles.css` une règle `.team-details-panel.indicators-hidden .team-student-indicators { display: none; }` a été ajoutée pour masquer uniquement les voyants des élèves quand la classe `indicators-hidden` est présente.

### Testing
- Commandes automatiques exécutées et réussies : `git status --short`, `git add class-info.js styles.css && git commit -m "Accueil: toujours afficher les élèves des équipes"`, et vérification des modifications avec `nl -ba class-info.js | sed -n '180,240p'` et `nl -ba styles.css | sed -n '1800,1835p'`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4d48234c83318eea99cd11ae0939)