### PR TITLE
Accueil: rendre le bloc gestion équipe plus discret

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -191,7 +191,7 @@
             const detailsButton = document.createElement('button');
             detailsButton.type = 'button';
             detailsButton.className = 'team-details-button';
-            detailsButton.textContent = 'Afficher voyants';
+            detailsButton.textContent = '+';
             detailsButton.setAttribute('aria-pressed', 'false');
 
             const detailsPanel = document.createElement('div');
@@ -220,7 +220,7 @@
             detailsButton.addEventListener('click', () => {
                 const showIndicators = detailsPanel.classList.toggle('indicators-hidden') === false;
                 detailsButton.setAttribute('aria-pressed', String(showIndicators));
-                detailsButton.textContent = showIndicators ? 'Masquer voyants' : 'Afficher voyants';
+                detailsButton.textContent = showIndicators ? '−' : '+';
             });
 
             card.appendChild(title);
@@ -383,8 +383,8 @@
             const teams = buildTeams(lastClassStudents);
             const allSizesValid = teams.every((team) => team.length >= 4 && team.length <= 6);
             teamsPopupStatusElement.textContent = allSizesValid
-                ? 'Équipes générées avec répartition B / T / A.'
-                : 'Équipes générées mais certaines tailles sortent de la plage 4-6.';
+                ? ''
+                : 'Certaines équipes sortent de la plage 4-6 élèves.';
             renderTeams(teams);
             teamsPopupElement.hidden = false;
         });

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
         <div class="teams-popup-panel">
             <button id="close-teams-popup" type="button" class="teams-popup-close">Fermer</button>
             <h3>Équipes générées</h3>
-            <p id="teams-popup-status">Aucune équipe générée.</p>
+            <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1774,13 +1774,19 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .team-details-button {
-    border: 1px solid rgba(255, 255, 255, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.25);
     border-radius: 999px;
-    padding: 6px 10px;
-    background: rgba(255, 255, 255, 0.1);
-    color: #fff;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.85);
     cursor: pointer;
-    font-size: 0.8rem;
+    font-size: 0.95rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .team-details-panel {


### PR DESCRIPTION
### Motivation
- Rendre le contrôle d'affichage des voyants d'équipe moins intrusif sur la page d'accueil.
- Éviter l'affichage inutile d'un message «équipes générées…» quand la génération se passe normalement.

### Description
- `class-info.js`: remplace le libellé textuel du bouton de détails par un bouton compact `+` qui bascule en `−` lors de l'ouverture des voyants, et ajuste le message de statut après génération d'équipes pour n'afficher du texte qu'en cas d'anomalie de taille.
- `styles.css`: adapte `.team-details-button` pour un rendu plus discret (petit bouton rond 22×22px, contraste allégé, centrage du symbole).
- `index.html`: supprime le texte initial `Aucune équipe générée.` dans `#teams-popup-status` pour éviter l'affichage par défaut.

### Testing
- Recherche et inspection du code affecté avec `rg` et `sed` pour vérifier les remplacements (succès).
- Visual vérification du diff avec `git diff -- class-info.js styles.css index.html` (succès).
- Validation des changements enregistrés avec `git add` et `git commit` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f1895e08331843a068cc0d38f24)