### PR TITLE
Ajouter voyants T1/T2/T3 et intégrer dans la répartition des équipes

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -12,6 +12,9 @@
     const indicatorBElement = document.getElementById('selected-class-indicator-b');
     const indicatorTElement = document.getElementById('selected-class-indicator-t');
     const indicatorAElement = document.getElementById('selected-class-indicator-a');
+    const indicatorT1Element = document.getElementById('selected-class-indicator-t1');
+    const indicatorT2Element = document.getElementById('selected-class-indicator-t2');
+    const indicatorT3Element = document.getElementById('selected-class-indicator-t3');
     const statusElement = document.getElementById('class-info-status');
     const classFilterElement = document.getElementById('progression-class-filter');
     const generateTeamsButton = document.getElementById('generate-teams-button');
@@ -22,7 +25,7 @@
 
     let lastClassStudents = [];
 
-    if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !statusElement) {
+    if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element || !statusElement) {
         return;
     }
 
@@ -107,6 +110,9 @@
             b: parsePercentage(row[idxMap.indicatorBIdx]),
             t: parsePercentage(row[idxMap.indicatorTIdx]),
             a: parsePercentage(row[idxMap.indicatorAIdx]),
+            t1: parsePercentage(row[idxMap.indicatorT1Idx]),
+            t2: parsePercentage(row[idxMap.indicatorT2Idx]),
+            t3: parsePercentage(row[idxMap.indicatorT3Idx]),
         };
     }
 
@@ -132,6 +138,9 @@
         pickTopPerTeam('b', (student) => (student.b === null ? -1 : 100 - student.b));
         pickTopPerTeam('t');
         pickTopPerTeam('a');
+        pickTopPerTeam('t1');
+        pickTopPerTeam('t2');
+        pickTopPerTeam('t3');
 
         const sortByLowestTeamSize = () => teams.map((team, index) => ({ team, index })).sort((lhs, rhs) => lhs.team.length - rhs.team.length);
         for (const student of remaining) {
@@ -157,7 +166,7 @@
         const row = document.createElement('div');
         row.className = 'class-indicators';
 
-        ['b', 't', 'a'].forEach((key) => {
+        ['b', 't', 'a', 't1', 't2', 't3'].forEach((key) => {
             const light = document.createElement('span');
             light.className = 'indicator-light';
             light.setAttribute('role', 'img');
@@ -185,6 +194,9 @@
                 b: computeAverage(team.map((student) => student.b).filter((value) => value !== null)),
                 t: computeAverage(team.map((student) => student.t).filter((value) => value !== null)),
                 a: computeAverage(team.map((student) => student.a).filter((value) => value !== null)),
+                t1: computeAverage(team.map((student) => student.t1).filter((value) => value !== null)),
+                t2: computeAverage(team.map((student) => student.t2).filter((value) => value !== null)),
+                t3: computeAverage(team.map((student) => student.t3).filter((value) => value !== null)),
             });
             teamIndicators.classList.add('team-indicators');
 
@@ -207,7 +219,14 @@
                 const name = document.createElement('span');
                 name.textContent = student.name;
 
-                const studentIndicators = createIndicatorsRow({ b: student.b, t: student.t, a: student.a });
+                const studentIndicators = createIndicatorsRow({
+                    b: student.b,
+                    t: student.t,
+                    a: student.a,
+                    t1: student.t1,
+                    t2: student.t2,
+                    t3: student.t3
+                });
                 studentIndicators.classList.add('team-student-indicators');
 
                 item.appendChild(name);
@@ -284,7 +303,7 @@
         const csvText = await response.text();
         const rows = parseCSV(csvText).filter((row) => row.some((cell) => (cell || '').trim()));
         if (!rows.length) {
-            return { studentsCount: 0, averageB: null, averageT: null, averageA: null, students: [] };
+            return { studentsCount: 0, averageB: null, averageT: null, averageA: null, averageT1: null, averageT2: null, averageT3: null, students: [] };
         }
 
         const header = rows[0].map((cell) => normalize(cell));
@@ -293,9 +312,12 @@
         const indicatorBIdx = header.findIndex((col) => col === 'b');
         const indicatorTIdx = header.findIndex((col) => col === 't');
         const indicatorAIdx = header.findIndex((col) => col === 'a');
+        const indicatorT1Idx = header.findIndex((col) => col === 't1');
+        const indicatorT2Idx = header.findIndex((col) => col === 't2');
+        const indicatorT3Idx = header.findIndex((col) => col === 't3');
 
-        if (classIdx === -1 || nameIdx === -1 || indicatorBIdx === -1 || indicatorTIdx === -1 || indicatorAIdx === -1) {
-            throw new Error('Colonnes attendues introuvables (classe / nom / B / T / A).');
+        if (classIdx === -1 || nameIdx === -1 || indicatorBIdx === -1 || indicatorTIdx === -1 || indicatorAIdx === -1 || indicatorT1Idx === -1 || indicatorT2Idx === -1 || indicatorT3Idx === -1) {
+            throw new Error('Colonnes attendues introuvables (classe / nom / B / T / A / T1 / T2 / T3).');
         }
 
         const normalizedSelectedClass = normalize(selectedClass);
@@ -306,12 +328,18 @@
         const bValues = classRows.map((row) => parsePercentage(row[indicatorBIdx])).filter((value) => value !== null);
         const tValues = classRows.map((row) => parsePercentage(row[indicatorTIdx])).filter((value) => value !== null);
         const aValues = classRows.map((row) => parsePercentage(row[indicatorAIdx])).filter((value) => value !== null);
+        const t1Values = classRows.map((row) => parsePercentage(row[indicatorT1Idx])).filter((value) => value !== null);
+        const t2Values = classRows.map((row) => parsePercentage(row[indicatorT2Idx])).filter((value) => value !== null);
+        const t3Values = classRows.map((row) => parsePercentage(row[indicatorT3Idx])).filter((value) => value !== null);
 
         const students = classRows.map((row) => parseStudentData(row, {
             nameIdx,
             indicatorBIdx,
             indicatorTIdx,
             indicatorAIdx,
+            indicatorT1Idx,
+            indicatorT2Idx,
+            indicatorT3Idx,
         }));
 
         return {
@@ -319,6 +347,9 @@
             averageB: computeAverage(bValues),
             averageT: computeAverage(tValues),
             averageA: computeAverage(aValues),
+            averageT1: computeAverage(t1Values),
+            averageT2: computeAverage(t2Values),
+            averageT3: computeAverage(t3Values),
             students,
         };
     }
@@ -334,6 +365,9 @@
             setIndicatorLight(indicatorBElement, null);
             setIndicatorLight(indicatorTElement, null);
             setIndicatorLight(indicatorAElement, null);
+            setIndicatorLight(indicatorT1Element, null);
+            setIndicatorLight(indicatorT2Element, null);
+            setIndicatorLight(indicatorT3Element, null);
             statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
             return;
         }
@@ -343,6 +377,9 @@
             setIndicatorLight(indicatorBElement, null);
             setIndicatorLight(indicatorTElement, null);
             setIndicatorLight(indicatorAElement, null);
+            setIndicatorLight(indicatorT1Element, null);
+            setIndicatorLight(indicatorT2Element, null);
+            setIndicatorLight(indicatorT3Element, null);
             statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
             return;
         }
@@ -351,6 +388,9 @@
         setIndicatorLight(indicatorBElement, null);
         setIndicatorLight(indicatorTElement, null);
         setIndicatorLight(indicatorAElement, null);
+        setIndicatorLight(indicatorT1Element, null);
+        setIndicatorLight(indicatorT2Element, null);
+        setIndicatorLight(indicatorT3Element, null);
         statusElement.textContent = `Lecture des données de l'onglet "${classConfig.sheetLabel}"...`;
 
         try {
@@ -359,6 +399,9 @@
             setIndicatorLight(indicatorBElement, classData.averageB);
             setIndicatorLight(indicatorTElement, classData.averageT);
             setIndicatorLight(indicatorAElement, classData.averageA);
+            setIndicatorLight(indicatorT1Element, classData.averageT1);
+            setIndicatorLight(indicatorT2Element, classData.averageT2);
+            setIndicatorLight(indicatorT3Element, classData.averageT3);
             lastClassStudents = classData.students;
             statusElement.textContent = 'Données chargées avec succès.';
         } catch (error) {
@@ -366,6 +409,9 @@
             setIndicatorLight(indicatorBElement, null);
             setIndicatorLight(indicatorTElement, null);
             setIndicatorLight(indicatorAElement, null);
+            setIndicatorLight(indicatorT1Element, null);
+            setIndicatorLight(indicatorT2Element, null);
+            setIndicatorLight(indicatorT3Element, null);
             lastClassStudents = [];
             statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
         }
@@ -383,7 +429,7 @@
             const teams = buildTeams(lastClassStudents);
             const allSizesValid = teams.every((team) => team.length >= 4 && team.length <= 6);
             teamsPopupStatusElement.textContent = allSizesValid
-                ? 'Équipes générées avec répartition B / T / A.'
+                ? 'Équipes générées avec répartition B / T / A / T1 / T2 / T3.'
                 : 'Équipes générées mais certaines tailles sortent de la plage 4-6.';
             renderTeams(teams);
             teamsPopupElement.hidden = false;

--- a/index.html
+++ b/index.html
@@ -27,10 +27,13 @@
                     </div>
                     <p id="selected-class-name">Classe sélectionnée : Aucune</p>
                     <p id="selected-class-students">Effectif (3E) : -</p>
-                    <div class="class-indicators" aria-label="Indicateurs B, T et A">
+                    <div class="class-indicators" aria-label="Indicateurs B, T, A, T1, T2 et T3">
                         <span id="selected-class-indicator-b" class="indicator-light" role="img" aria-label="Indicateur B"></span>
                         <span id="selected-class-indicator-t" class="indicator-light" role="img" aria-label="Indicateur T"></span>
                         <span id="selected-class-indicator-a" class="indicator-light" role="img" aria-label="Indicateur A"></span>
+                        <span id="selected-class-indicator-t1" class="indicator-light" role="img" aria-label="Indicateur T1"></span>
+                        <span id="selected-class-indicator-t2" class="indicator-light" role="img" aria-label="Indicateur T2"></span>
+                        <span id="selected-class-indicator-t3" class="indicator-light" role="img" aria-label="Indicateur T3"></span>
                     </div>
                     <button id="generate-teams-button" type="button" class="generate-teams-button">Générer les équipes</button>
                     <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>

--- a/styles.css
+++ b/styles.css
@@ -1675,6 +1675,7 @@ svg.axe { display: block; margin: 0.5em 0; }
 .class-indicators {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 12px;
     margin: 10px 0 6px;
 }


### PR DESCRIPTION
### Motivation
- Le CSV des classes contient maintenant trois colonnes additionnelles `T1`, `T2` et `T3` pour les classes 3E/5E et l'interface doit afficher ces moyennes en plus de B/T/A et les prendre en compte lors de la génération des équipes.
- Garder l'affichage lisible quand il y a six voyants côte à côte nécessite un ajustement CSS pour permettre le retour à la ligne.

### Description
- `index.html` : ajout de trois spans pour les voyants de classe `selected-class-indicator-t1`, `-t2` et `-t3` dans le bloc « Informations classe ». 
- `class-info.js` : lecture des colonnes `t1`, `t2`, `t3` depuis le CSV, stockage par élève (`t1`, `t2`, `t3`), calcul des moyennes de classe (`averageT1`, `averageT2`, `averageT3`) et affichage des voyants correspondants; message d'erreur mis à jour quand les colonnes attendues sont absentes.
- `class-info.js` : l'algorithme de répartition des équipes inclut désormais `t1`, `t2`, `t3` dans les phases de sélection (`pickTopPerTeam`) et les moyennes d'équipe, et les voyants individuels et d'équipe affichés dans la popup prennent en charge les 6 métriques.
- `styles.css` : ajout de `flex-wrap: wrap` à `.class-indicators` pour permettre plusieurs lignes de voyants lorsque nécessaire.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check class-info.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4fea8e788331b667e670fe85a2c1)