### PR TITLE
Accueil: T1/T2/T3 sur 20 et bouton "Trop de bruit"

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -116,6 +116,13 @@
         };
     }
 
+    function getIndicatorDisplayConfig(key) {
+        if (['t1', 't2', 't3'].includes(key)) {
+            return { maxValue: 20, suffix: '/20' };
+        }
+        return { maxValue: 100, suffix: '%' };
+    }
+
     function buildTeams(students) {
         const teams = Array.from({ length: 6 }, () => []);
         const remaining = students.slice();
@@ -171,7 +178,7 @@
             light.className = 'indicator-light';
             light.setAttribute('role', 'img');
             light.setAttribute('aria-label', `Indicateur ${key.toUpperCase()}`);
-            setIndicatorLight(light, valuesByKey[key] ?? null);
+            setIndicatorLight(light, valuesByKey[key] ?? null, getIndicatorDisplayConfig(key));
             row.appendChild(light);
         });
 
@@ -255,10 +262,12 @@
         return Math.min(max, Math.max(min, value));
     }
 
-    function setIndicatorLight(indicatorElement, value) {
+    function setIndicatorLight(indicatorElement, value, options = {}) {
         if (!indicatorElement) {
             return;
         }
+        const maxValue = Number.isFinite(options.maxValue) && options.maxValue > 0 ? options.maxValue : 100;
+        const suffix = options.suffix || '%';
 
         if (value === null) {
             indicatorElement.style.setProperty('--indicator-color', '#6b7280');
@@ -267,14 +276,14 @@
             return;
         }
 
-        const percent = clamp(value, 0, 100);
-        const hue = (percent / 100) * 120;
+        const boundedValue = clamp(value, 0, maxValue);
+        const hue = (boundedValue / maxValue) * 120;
         const color = `hsl(${hue} 88% 48%)`;
         const glow = `hsl(${hue} 92% 55% / 0.6)`;
 
         indicatorElement.style.setProperty('--indicator-color', color);
         indicatorElement.style.setProperty('--indicator-glow', glow);
-        indicatorElement.title = `${percent.toFixed(1)} %`;
+        indicatorElement.title = suffix === '%' ? `${boundedValue.toFixed(1)} %` : `${boundedValue.toFixed(1)} ${suffix}`;
     }
 
     function getClassConfig(selectedClass) {
@@ -396,12 +405,12 @@
         try {
             const classData = await fetchClassData(className, classConfig);
             studentsCountElement.textContent = `Effectif (${classConfig.level}) : ${classData.studentsCount} élèves`;
-            setIndicatorLight(indicatorBElement, classData.averageB);
-            setIndicatorLight(indicatorTElement, classData.averageT);
-            setIndicatorLight(indicatorAElement, classData.averageA);
-            setIndicatorLight(indicatorT1Element, classData.averageT1);
-            setIndicatorLight(indicatorT2Element, classData.averageT2);
-            setIndicatorLight(indicatorT3Element, classData.averageT3);
+            setIndicatorLight(indicatorBElement, classData.averageB, getIndicatorDisplayConfig('b'));
+            setIndicatorLight(indicatorTElement, classData.averageT, getIndicatorDisplayConfig('t'));
+            setIndicatorLight(indicatorAElement, classData.averageA, getIndicatorDisplayConfig('a'));
+            setIndicatorLight(indicatorT1Element, classData.averageT1, getIndicatorDisplayConfig('t1'));
+            setIndicatorLight(indicatorT2Element, classData.averageT2, getIndicatorDisplayConfig('t2'));
+            setIndicatorLight(indicatorT3Element, classData.averageT3, getIndicatorDisplayConfig('t3'));
             lastClassStudents = classData.students;
             statusElement.textContent = 'Données chargées avec succès.';
         } catch (error) {

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -133,6 +133,23 @@
         return parsed.length ? parsed : null;
     }
 
+
+    function extractNoiseMessages(text) {
+        const messages = [];
+        const cleanedText = (text || '').replace(/%([^%]+)%/g, (_, message) => {
+            const cleanedMessage = cleanText(message);
+            if (cleanedMessage) {
+                messages.push(cleanedMessage);
+            }
+            return ' ';
+        });
+
+        return {
+            cleanedText: cleanText(cleanedText),
+            messages
+        };
+    }
+
     function formatRemaining(seconds) {
         const safeSeconds = Math.max(0, Math.floor(seconds));
         const minutes = String(Math.floor(safeSeconds / 60)).padStart(2, '0');
@@ -331,7 +348,8 @@
         return {
             element: card,
             start: startTimer,
-            isComplete: () => remainingSeconds <= 0
+            isComplete: () => remainingSeconds <= 0,
+            stop: stopTimer
         };
     }
 
@@ -498,7 +516,8 @@
         tasks.forEach((task) => {
             const item = document.createElement('li');
             const label = document.createElement('strong');
-            const inlineSubtasks = parseInlineSubtasks(task.label);
+            const noiseData = extractNoiseMessages(task.label);
+            const inlineSubtasks = parseInlineSubtasks(noiseData.cleanedText);
 
             if (inlineSubtasks) {
                 const subtaskGrid = document.createElement('div');
@@ -516,8 +535,29 @@
                     subtaskGrid.appendChild(timerCard.element);
                 });
                 item.appendChild(subtaskGrid);
+                if (noiseData.messages.length) {
+                    const noiseButton = document.createElement('button');
+                    noiseButton.type = 'button';
+                    noiseButton.className = 'task-noise-button';
+                    noiseButton.textContent = 'Trop de bruit';
+
+                    let noiseMessageIndex = 0;
+                    noiseButton.addEventListener('click', () => {
+                        timerCards.forEach((timerCard) => timerCard.stop());
+                        const message = noiseData.messages[noiseMessageIndex] || '';
+                        if (message) {
+                            window.alert(message);
+                        }
+                        noiseMessageIndex += 1;
+                        if (noiseMessageIndex >= noiseData.messages.length) {
+                            noiseButton.remove();
+                        }
+                    });
+
+                    item.appendChild(noiseButton);
+                }
             } else {
-                label.textContent = task.label || 'Tâche sans titre';
+                label.textContent = noiseData.cleanedText || 'Tâche sans titre';
                 item.appendChild(label);
             }
 


### PR DESCRIPTION
### Motivation
- Traiter les indicateurs T1/T2/T3 comme des notes sur 20 (affichage et infobulle) tandis que B/T/A restent en pourcentage pour refléter correctement l’échelle des évaluations.
- Permettre d’inclure dans la description d’une tâche des messages d’alerte/instructions encadrés par `%...%` et fournir une action rapide en séance pour les afficher.

### Description
- `class-info.js` : ajout de `getIndicatorDisplayConfig(key)` et extension de `setIndicatorLight` pour prendre en charge une échelle (`maxValue`) et un suffixe (`suffix`), et utilisation de cette config pour afficher T1/T2/T3 sur 20 et B/T/A en `%`.
- `home-progressions.js` : ajout de `extractNoiseMessages(text)` pour extraire et nettoyer les messages `%...%` des libellés de tâches et retour du texte nettoyé pour le parsing des sous-tâches.
- `home-progressions.js` : `createSubtaskTimerCard` expose désormais une méthode `stop()` pour interrompre les minuteurs externément.
- `home-progressions.js` : dans `buildTasksList` ajout conditionnel d’un bouton `Trop de bruit` lorsqu’une tâche contient un ou plusieurs messages `%...%`; au clic le bouton arrête tous les minuteurs de la tâche et affiche le message extrait dans une popup, affiche ensuite les messages suivants à chaque clic et supprime le bouton après le dernier message.

### Testing
- Syntax check avec `node --check home-progressions.js` a réussi.
- Syntax check avec `node --check class-info.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c61c0496083318d3fb6d777842e19)