### PR TITLE
Ajouter bouton «Trop de bruit» global, popup rouge et bouton DING

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -3,6 +3,7 @@
     const dateElement = document.getElementById('live-date');
     const openPopupButton = document.getElementById('open-datetime-popup');
     const rollDiceButton = document.getElementById('roll-dice-button');
+    const dingButton = document.getElementById('ding-button');
     const closePopupButton = document.getElementById('close-datetime-popup');
     const datetimePopup = document.getElementById('datetime-popup');
     const diceResultElement = document.getElementById('dice-result');
@@ -73,5 +74,33 @@
         if (diceResultElement) {
             diceResultElement.textContent = `Résultat (${numberOfDice}d${facesPerDie}) : [${rolls.join(', ')}] → Total ${total}`;
         }
+    });
+
+    dingButton?.addEventListener('click', () => {
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) return;
+        const audioContext = new AudioContextClass();
+        const now = audioContext.currentTime;
+        const oscillator = audioContext.createOscillator();
+        const gainNode = audioContext.createGain();
+
+        oscillator.type = 'triangle';
+        oscillator.frequency.setValueAtTime(1120, now);
+        oscillator.frequency.exponentialRampToValueAtTime(1680, now + 0.08);
+        oscillator.frequency.exponentialRampToValueAtTime(900, now + 1.1);
+
+        gainNode.gain.setValueAtTime(0.0001, now);
+        gainNode.gain.exponentialRampToValueAtTime(1, now + 0.02);
+        gainNode.gain.exponentialRampToValueAtTime(0.5, now + 0.2);
+        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.start(now);
+        oscillator.stop(now + 1.15);
+
+        setTimeout(() => {
+            audioContext.close();
+        }, 1400);
     });
 })();

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -11,6 +11,10 @@
     const planningToggleCountButton = document.getElementById('progression-toggle-count');
     const importantMessagesPanelElement = document.getElementById('important-messages-panel');
     const importantMessageTextElement = document.getElementById('important-message-text');
+    const noiseAlertButtonElement = document.getElementById('noise-alert-button');
+    const noiseAlertPopupElement = document.getElementById('noise-alert-popup');
+    const closeNoiseAlertPopupButton = document.getElementById('close-noise-alert-popup');
+    const noiseAlertPopupMessageElement = document.getElementById('noise-alert-popup-message');
 
     if (!statusElement || !listElement || !classFilterElement || !showPastElement) {
         return;
@@ -27,6 +31,8 @@
     let importantMessagesIntervalId = null;
     let importantMessageTransitionTimeoutId = null;
     let currentImportantMessageIndex = 0;
+    let currentNoiseAlertMessages = [];
+    let currentNoiseMessageIndex = 0;
 
     function normalize(value) {
         return (value || '')
@@ -189,6 +195,38 @@
         window.setTimeout(() => {
             audioContext.close();
         }, Math.ceil((notes.length * 220) + 250));
+    }
+
+    function playLoudDing(options = {}) {
+        const { duration = 1.2, baseFrequency = 950, gainLevel = 0.95 } = options;
+        const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) {
+            return;
+        }
+
+        const audioContext = new AudioContextClass();
+        const now = audioContext.currentTime;
+        const oscillator = audioContext.createOscillator();
+        const gainNode = audioContext.createGain();
+
+        oscillator.type = 'triangle';
+        oscillator.frequency.setValueAtTime(baseFrequency, now);
+        oscillator.frequency.exponentialRampToValueAtTime(baseFrequency * 1.45, now + 0.14);
+        oscillator.frequency.exponentialRampToValueAtTime(baseFrequency * 0.8, now + duration);
+
+        gainNode.gain.setValueAtTime(0.0001, now);
+        gainNode.gain.exponentialRampToValueAtTime(gainLevel, now + 0.03);
+        gainNode.gain.exponentialRampToValueAtTime(0.55, now + 0.18);
+        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.start(now);
+        oscillator.stop(now + duration + 0.05);
+
+        window.setTimeout(() => {
+            audioContext.close();
+        }, Math.ceil((duration * 1000) + 200));
     }
 
     function createSubtaskTimerCard(subtask, options = {}) {
@@ -419,10 +457,18 @@
     function parseSessionDetails(detailsText) {
         const sourceText = detailsText || '';
         const importantMessages = [];
-        const textWithoutMessages = sourceText.replace(/\$([^$]+)\$/g, (_, message) => {
+        const noiseMessages = [];
+        const textWithoutImportantMessages = sourceText.replace(/\$([^$]+)\$/g, (_, message) => {
             const cleanedMessage = cleanText(message);
             if (cleanedMessage) {
                 importantMessages.push(cleanedMessage);
+            }
+            return ' ';
+        });
+        const textWithoutMessages = textWithoutImportantMessages.replace(/%([^%]+)%/g, (_, message) => {
+            const cleanedMessage = cleanText(message);
+            if (cleanedMessage) {
+                noiseMessages.push(cleanedMessage);
             }
             return ' ';
         });
@@ -442,8 +488,34 @@
         return {
             content,
             tasks: normalizeTasks(parsed.tasks || []),
-            importantMessages
+            importantMessages,
+            noiseMessages
         };
+    }
+
+    function closeNoiseAlertPopup() {
+        if (noiseAlertPopupElement) {
+            noiseAlertPopupElement.hidden = true;
+        }
+    }
+
+    function handleNoiseAlertButtonClick() {
+        if (!currentNoiseAlertMessages.length) {
+            return;
+        }
+        const message = currentNoiseAlertMessages[currentNoiseMessageIndex] || '';
+        if (noiseAlertPopupMessageElement) {
+            noiseAlertPopupMessageElement.textContent = message;
+        }
+        if (noiseAlertPopupElement) {
+            noiseAlertPopupElement.hidden = false;
+        }
+        playLoudDing({ duration: 1.4, baseFrequency: 1050, gainLevel: 1 });
+
+        currentNoiseMessageIndex += 1;
+        if (currentNoiseMessageIndex >= currentNoiseAlertMessages.length) {
+            currentNoiseMessageIndex = 0;
+        }
     }
 
     function stopImportantMessagesRotation() {
@@ -535,27 +607,6 @@
                     subtaskGrid.appendChild(timerCard.element);
                 });
                 item.appendChild(subtaskGrid);
-                if (noiseData.messages.length) {
-                    const noiseButton = document.createElement('button');
-                    noiseButton.type = 'button';
-                    noiseButton.className = 'task-noise-button';
-                    noiseButton.textContent = 'Trop de bruit';
-
-                    let noiseMessageIndex = 0;
-                    noiseButton.addEventListener('click', () => {
-                        timerCards.forEach((timerCard) => timerCard.stop());
-                        const message = noiseData.messages[noiseMessageIndex] || '';
-                        if (message) {
-                            window.alert(message);
-                        }
-                        noiseMessageIndex += 1;
-                        if (noiseMessageIndex >= noiseData.messages.length) {
-                            noiseButton.remove();
-                        }
-                    });
-
-                    item.appendChild(noiseButton);
-                }
             } else {
                 label.textContent = noiseData.cleanedText || 'Tâche sans titre';
                 item.appendChild(label);
@@ -585,6 +636,12 @@
         }
 
         const details = parseSessionDetails(entry.detailsText || '');
+        currentNoiseAlertMessages = Array.from(new Set(details.noiseMessages || []));
+        currentNoiseMessageIndex = 0;
+        if (noiseAlertButtonElement) {
+            noiseAlertButtonElement.hidden = currentNoiseAlertMessages.length === 0;
+        }
+        closeNoiseAlertPopup();
 
         taskContentElement.className = 'task-detail-description';
         taskContentElement.innerHTML = sanitizeSessionHtml(details.content) || 'Contenu non renseigné.';
@@ -790,6 +847,14 @@
     planningToggleCountButton?.addEventListener('click', () => {
         showAllPlanningDates = !showAllPlanningDates;
         renderSteps();
+    });
+
+    noiseAlertButtonElement?.addEventListener('click', handleNoiseAlertButtonClick);
+    closeNoiseAlertPopupButton?.addEventListener('click', closeNoiseAlertPopup);
+    noiseAlertPopupElement?.addEventListener('click', (event) => {
+        if (event.target === noiseAlertPopupElement) {
+            closeNoiseAlertPopup();
+        }
     });
 
     setupTaskSectionToggles();

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
                     <div class="datetime-header-actions">
                         <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir l'écran blanc">🗖</button>
                         <button id="roll-dice-button" type="button" class="datetime-icon-button" aria-label="Simuler un lancer de dés">🎲</button>
+                        <button id="ding-button" type="button" class="datetime-icon-button" aria-label="Faire sonner la cloche pour le calme">🔔 DING</button>
                     </div>
                     <p id="dice-result" class="dice-result" aria-live="polite"></p>
                 </div>
@@ -67,6 +68,7 @@
                             <h3>Tâches</h3>
                             <button type="button" class="task-toggle-button" data-toggle-target="progression-task-list" aria-expanded="true">Masquer</button>
                         </div>
+                        <button id="noise-alert-button" type="button" class="task-noise-button-global" hidden>Trop de bruit</button>
                         <div id="progression-task-list" class="task-detail-empty">
                             Aucune tâche à afficher.
                         </div>
@@ -120,6 +122,14 @@
             <h3>Équipes générées</h3>
             <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>
+        </div>
+    </div>
+
+    <div id="noise-alert-popup" class="noise-alert-popup" hidden>
+        <div class="noise-alert-popup-panel">
+            <button id="close-noise-alert-popup" type="button" class="noise-alert-popup-close">Fermer</button>
+            <h3>Trop de bruit.....</h3>
+            <p id="noise-alert-popup-message"></p>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1656,6 +1656,21 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(255, 255, 255, 0.24);
 }
 
+.task-noise-button-global {
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    padding: 6px 12px;
+    font-size: 0.88rem;
+    cursor: pointer;
+    margin: 8px 0 10px;
+}
+
+.task-noise-button-global:hover {
+    background: rgba(255, 255, 255, 0.24);
+}
+
 .task-detail-section.is-collapsed > #progression-task-content,
 .task-detail-section.is-collapsed > #progression-task-list {
     display: none;
@@ -1751,6 +1766,55 @@ svg.axe { display: block; margin: 0.5em 0; }
     grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
     gap: 10px;
     margin-top: 12px;
+}
+
+.noise-alert-popup {
+    position: fixed;
+    inset: 0;
+    background: rgba(120, 0, 0, 0.82);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5200;
+}
+
+.noise-alert-popup[hidden] {
+    display: none;
+}
+
+.noise-alert-popup-panel {
+    width: min(700px, 92vw);
+    background: #7a0000;
+    border: 1px solid rgba(255, 210, 210, 0.85);
+    border-radius: 14px;
+    padding: 20px;
+    color: #fff;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.45);
+    position: relative;
+    text-align: center;
+}
+
+.noise-alert-popup-panel h3 {
+    margin: 4px 0 12px;
+    font-size: clamp(1.5rem, 4vw, 2.2rem);
+}
+
+#noise-alert-popup-message {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.noise-alert-popup-close {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.45);
+    border-radius: 8px;
+    padding: 6px 10px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    cursor: pointer;
 }
 
 .team-card {


### PR DESCRIPTION
### Motivation
- Rendre visible et utilisable une alerte «Trop de bruit» au-dessus des tâches avec le même design que les autres boutons. 
- Autoriser les messages de bruit encodés avec `%...%` à être détectés en-dehors des tâches dans le contenu d’une séance. 
- Fournir une alerte visuelle/sonore cohérente avec le site (popup rouge, titre explicite) pour attirer l’attention malgré le bruit ambiant. 
- Pouvoir déclencher rapidement une sonnerie forte via le bloc heure pour capter l’attention des élèves.

### Description
- Ajout d’un bouton global `Trop de bruit` dans la section tâches (`index.html`) et d’une popup dédiée `#noise-alert-popup` avec titre «Trop de bruit.....». 
- Extension du parser de séance dans `home-progressions.js` pour extraire les messages `%...%` (`noiseMessages`) depuis tout le contenu de séance et les exposer au bouton global. 
- Remplacement de l’usage de `alert()` par une popup stylée (`.noise-alert-popup`) et lecture d’un son fort via Web Audio (`playLoudDing`) à l’ouverture de la popup; navigation cyclique entre messages conservés. 
- Ajout d’un bouton `🔔 DING` dans le bloc heure et implémentation d’une sonnerie puissante dans `home-datetime.js` via Web Audio; styles ajoutés dans `styles.css` pour bouton et popup afin de respecter la charte visuelle existante.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check home-progressions.js` a réussi. 
- Exécution de la vérification syntaxique JavaScript avec `node --check home-datetime.js` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c68f678788331b923c93c60ec79a7)