### PR TITLE
Accueil : simplification du bouton cloche et sonnerie adoucie

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -84,23 +84,23 @@
         const oscillator = audioContext.createOscillator();
         const gainNode = audioContext.createGain();
 
-        oscillator.type = 'triangle';
-        oscillator.frequency.setValueAtTime(1120, now);
-        oscillator.frequency.exponentialRampToValueAtTime(1680, now + 0.08);
-        oscillator.frequency.exponentialRampToValueAtTime(900, now + 1.1);
+        oscillator.type = 'sine';
+        oscillator.frequency.setValueAtTime(1046, now);
+        oscillator.frequency.exponentialRampToValueAtTime(1319, now + 0.05);
+        oscillator.frequency.exponentialRampToValueAtTime(988, now + 0.42);
 
         gainNode.gain.setValueAtTime(0.0001, now);
-        gainNode.gain.exponentialRampToValueAtTime(1, now + 0.02);
-        gainNode.gain.exponentialRampToValueAtTime(0.5, now + 0.2);
-        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 1.1);
+        gainNode.gain.exponentialRampToValueAtTime(0.35, now + 0.015);
+        gainNode.gain.exponentialRampToValueAtTime(0.09, now + 0.16);
+        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.45);
 
         oscillator.connect(gainNode);
         gainNode.connect(audioContext.destination);
         oscillator.start(now);
-        oscillator.stop(now + 1.15);
+        oscillator.stop(now + 0.5);
 
         setTimeout(() => {
             audioContext.close();
-        }, 1400);
+        }, 700);
     });
 })();

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
                     <div class="datetime-header-actions">
                         <button id="open-datetime-popup" type="button" class="datetime-icon-button" aria-label="Ouvrir l'écran blanc">🗖</button>
                         <button id="roll-dice-button" type="button" class="datetime-icon-button" aria-label="Simuler un lancer de dés">🎲</button>
-                        <button id="ding-button" type="button" class="datetime-icon-button" aria-label="Faire sonner la cloche pour le calme">🔔 DING</button>
+                        <button id="ding-button" type="button" class="datetime-icon-button" aria-label="Faire sonner la cloche pour le calme">🔔</button>
                     </div>
                     <p id="dice-result" class="dice-result" aria-live="polite"></p>
                 </div>


### PR DESCRIPTION
### Motivation
- Rendre le bouton cloche du bloc heure plus sobre (laisser uniquement l'emoji) et remplacer le DING sonore par un signal court, plus neutre et moins agressif.

### Description
- `index.html` : suppression du texte `DING` dans le bouton `#ding-button` pour n'afficher que `🔔`; `home-datetime.js` : passage de l'oscillateur de `triangle` à `sine`, ajustement des fréquences et de l'enveloppe de gain, réduction de la durée du son à `0.5s` et fermeture plus rapide de l'`AudioContext`.

### Testing
- Exécutés avec succès : recherche de références via `rg -n "DING|ding|cloche|heure|home|accueil|clock|bell" .`, inspection des fichiers avec `sed`/`nl`, et visualisation du diff des fichiers modifiés (`index.html`, `home-datetime.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6df398708331813aab54d06c784d)