### PR TITLE
Renforce le son de cloche sur la page d'accueil

### DIFF
--- a/home-datetime.js
+++ b/home-datetime.js
@@ -84,23 +84,23 @@
         const oscillator = audioContext.createOscillator();
         const gainNode = audioContext.createGain();
 
-        oscillator.type = 'sine';
-        oscillator.frequency.setValueAtTime(1046, now);
-        oscillator.frequency.exponentialRampToValueAtTime(1319, now + 0.05);
-        oscillator.frequency.exponentialRampToValueAtTime(988, now + 0.42);
+        oscillator.type = 'triangle';
+        oscillator.frequency.setValueAtTime(1050, now);
+        oscillator.frequency.exponentialRampToValueAtTime(1520, now + 0.14);
+        oscillator.frequency.exponentialRampToValueAtTime(860, now + 1.35);
 
         gainNode.gain.setValueAtTime(0.0001, now);
-        gainNode.gain.exponentialRampToValueAtTime(0.35, now + 0.015);
-        gainNode.gain.exponentialRampToValueAtTime(0.09, now + 0.16);
-        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 0.45);
+        gainNode.gain.exponentialRampToValueAtTime(1, now + 0.03);
+        gainNode.gain.exponentialRampToValueAtTime(0.55, now + 0.2);
+        gainNode.gain.exponentialRampToValueAtTime(0.0001, now + 1.35);
 
         oscillator.connect(gainNode);
         gainNode.connect(audioContext.destination);
         oscillator.start(now);
-        oscillator.stop(now + 0.5);
+        oscillator.stop(now + 1.4);
 
         setTimeout(() => {
             audioContext.close();
-        }, 700);
+        }, 1600);
     });
 })();


### PR DESCRIPTION
### Motivation
- Le clic sur la cloche (`🔔`) ou l’action « Trop de bruit » doit produire un son de cloche plus fort et plus long pour être clairement audible.

### Description
- Modifie `home-datetime.js` pour remplacer l’oscillateur `sine` par un `triangle` et élargir la courbe de fréquences pour un rendu plus « cloche ». 
- Augmente l’enveloppe de gain (pic à `1`) et allonge le sustain pour rendre le son plus percutant. 
- Étend la durée de lecture à `1.4s` et le délai de fermeture de l’`AudioContext` à `1600ms`. 
- Ce profil sonore est désormais cohérent avec la fonction d’alerte `playLoudDing` utilisée ailleurs.

### Testing
- Recherche du code impacté avec `rg` pour vérifier les points d’appel et usages, commande exécutée avec succès. 
- Remplacement ciblé du bloc audio via script Python s’est exécuté et a mis à jour `home-datetime.js` avec succès. 
- Vérification du diff avec `git diff -- home-datetime.js` a montré les modifications attendues. 
- Ajout et commit avec `git add` / `git commit` se sont déroulés avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d402d43688331b6c6f80a6ebca1ec)