### PR TITLE
Ajout de la gestion des "B-" par séance dans la popup de gestion des équipes

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -24,7 +24,9 @@
     const teamsPopupStatusElement = document.getElementById('teams-popup-status');
     const saveTeamsButton = document.getElementById('save-teams-button');
     const loadTeamsButton = document.getElementById('load-teams-button');
+    const exportBminusCsvButton = document.getElementById('export-bminus-csv-button');
     const TEAMS_COOKIE_PREFIX = 'savedTeams_';
+    const BMINUS_COOKIE_PREFIX = 'bminusSession_';
 
     let lastClassStudents = [];
     let currentTeams = [];
@@ -236,8 +238,22 @@
         teams.forEach((team, index) => {
             const card = document.createElement('article');
             card.className = 'team-card';
+            const teamHeader = document.createElement('div');
+            teamHeader.className = 'card-header-with-toggle';
             const title = document.createElement('h4');
             title.textContent = `Équipe ${index + 1} (${team.length} élèves)`;
+            teamHeader.appendChild(title);
+
+            const teamBMinusButton = document.createElement('button');
+            teamBMinusButton.type = 'button';
+            teamBMinusButton.className = 'team-details-button';
+            teamBMinusButton.textContent = 'B';
+            teamBMinusButton.title = 'Enregistrer B- pour toute l’équipe (séance en cours)';
+            teamBMinusButton.addEventListener('click', () => {
+                team.forEach((student) => recordBMinusForStudent(student.name));
+                teamsPopupStatusElement.textContent = `B- enregistré pour l'équipe ${index + 1} (${team.length} élèves).`;
+            });
+            teamHeader.appendChild(teamBMinusButton);
 
             const teamIndicators = createIndicatorsRow({
                 b: computeAverage(team.map((student) => student.b).filter((value) => value !== null)),
@@ -292,6 +308,15 @@
 
                 const name = document.createElement('span');
                 name.textContent = student.name;
+                const studentBMinusButton = document.createElement('button');
+                studentBMinusButton.type = 'button';
+                studentBMinusButton.className = 'team-details-button';
+                studentBMinusButton.textContent = 'B';
+                studentBMinusButton.title = `Enregistrer B- pour ${student.name} (séance en cours)`;
+                studentBMinusButton.addEventListener('click', () => {
+                    recordBMinusForStudent(student.name);
+                    teamsPopupStatusElement.textContent = `B- enregistré pour ${student.name}.`;
+                });
 
                 const studentIndicators = createIndicatorsRow({
                     b: student.b,
@@ -304,6 +329,7 @@
                 studentIndicators.classList.add('team-student-indicators');
 
                 item.appendChild(name);
+                item.appendChild(studentBMinusButton);
                 item.appendChild(studentIndicators);
                 detailsList.appendChild(item);
             });
@@ -316,12 +342,69 @@
                 detailsButton.textContent = showIndicators ? '−' : '+';
             });
 
-            card.appendChild(title);
+            card.appendChild(teamHeader);
             card.appendChild(teamIndicators);
             card.appendChild(detailsButton);
             card.appendChild(detailsPanel);
             teamsPopupListElement.appendChild(card);
         });
+    }
+
+    function getSessionDateKey() {
+        const now = new Date();
+        const yyyy = now.getFullYear();
+        const mm = String(now.getMonth() + 1).padStart(2, '0');
+        const dd = String(now.getDate()).padStart(2, '0');
+        return `${yyyy}-${mm}-${dd}`;
+    }
+
+    function getBMinusCookieName() {
+        const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
+        return `${BMINUS_COOKIE_PREFIX}${selectedClass}_${getSessionDateKey()}`;
+    }
+
+    function getBMinusSessionMap() {
+        const raw = getCookie(getBMinusCookieName());
+        if (!raw) {
+            return {};
+        }
+        try {
+            const parsed = JSON.parse(raw);
+            return parsed && typeof parsed === 'object' ? parsed : {};
+        } catch (error) {
+            return {};
+        }
+    }
+
+    function saveBMinusSessionMap(sessionMap) {
+        setCookie(getBMinusCookieName(), JSON.stringify(sessionMap), 30);
+    }
+
+    function recordBMinusForStudent(studentName) {
+        if (!studentName) {
+            return;
+        }
+        const sessionMap = getBMinusSessionMap();
+        sessionMap[studentName] = (Number(sessionMap[studentName]) || 0) + 1;
+        saveBMinusSessionMap(sessionMap);
+    }
+
+    function renderBMinusCsv() {
+        const sessionMap = getBMinusSessionMap();
+        const rows = Object.entries(sessionMap)
+            .sort((lhs, rhs) => lhs[0].localeCompare(rhs[0], 'fr'))
+            .map(([studentName, count]) => `${studentName},${count}`);
+        const csvContent = ['Nom,B-', ...rows].join('\n');
+        const sessionDate = getSessionDateKey();
+        const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
+        const csvWindow = window.open('', '_blank');
+        if (!csvWindow) {
+            teamsPopupStatusElement.textContent = 'Impossible d’ouvrir la fenêtre CSV (popup bloquée).';
+            return;
+        }
+        csvWindow.document.write(`<pre>${csvContent}</pre>`);
+        csvWindow.document.title = `CSV B- ${selectedClass} ${sessionDate}`;
+        teamsPopupStatusElement.textContent = `CSV B- affiché pour ${selectedClass} (${sessionDate}).`;
     }
 
     function updateTeamStatusMessage() {
@@ -553,7 +636,7 @@
                 teamsPopupStatusElement.textContent = 'Équipes sauvegardées.';
             });
         }
-        if (loadTeamsButton) {
+    if (loadTeamsButton) {
             loadTeamsButton.addEventListener('click', () => {
                 const className = getSelectedClass();
                 if (!className) {
@@ -586,6 +669,12 @@
             if (event.target === teamsPopupElement) {
                 teamsPopupElement.hidden = true;
             }
+        });
+    }
+
+    if (exportBminusCsvButton) {
+        exportBminusCsvButton.addEventListener('click', () => {
+            renderBMinusCsv();
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                         <span id="selected-class-indicator-t2" class="indicator-light" role="img" aria-label="Indicateur T2"></span>
                         <span id="selected-class-indicator-t3" class="indicator-light" role="img" aria-label="Indicateur T3"></span>
                     </div>
-                    <button id="generate-teams-button" type="button" class="generate-teams-button">Générer les équipes</button>
+                    <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
                     <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>
@@ -123,6 +123,7 @@
             <div class="teams-popup-actions">
                 <button id="save-teams-button" type="button" class="generate-teams-button">Sauvegarder les équipes</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button">Recharger les équipes</button>
+                <button id="export-bminus-csv-button" type="button" class="generate-teams-button">Afficher CSV B- (séance)</button>
             </div>
             <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>


### PR DESCRIPTION
### Motivation
- Permettre d’enregistrer rapidement des sanctions/points `B-` pendant une séance pour un élève ou toute une équipe depuis la fenêtre de gestion des équipes. 
- Pouvoir exporter/consulter en CSV le décompte de `B-` par élève pour la séance courante.

### Description
- Renomme le bouton d’accueil `Générer les équipes` en `Gestion des équipes` dans `index.html`.
- Ajoute un bouton `Afficher CSV B- (séance)` dans la popup de gestion des équipes dans `index.html`.
- Dans `class-info.js` ajoute un stockage par cookie des `B-` pour la séance (clé `bminusSession_<CLASSE>_<YYYY-MM-DD>`), et implémente les fonctions `getSessionDateKey`, `getBMinusCookieName`, `getBMinusSessionMap`, `saveBMinusSessionMap`, `recordBMinusForStudent` et `renderBMinusCsv`.
- Ajoute un bouton `B` à côté de chaque élève et un bouton `B` dans l’en-tête de chaque équipe qui incrémentent le compteur `B-` des élèves concernés et mettent à jour le cookie; le bouton d’export ouvre une nouvelle fenêtre affichant un CSV `Nom,B-` trié par nom.

### Testing
- Exécution de la vérification de syntaxe avec `node --check class-info.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de9cd7dfc833180db30cf3ae4443a)