### PR TITLE
Améliore l'écran « Gestion des équipes » et remplace l'export CSV par un tableau B/T copiable

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -24,9 +24,11 @@
     const teamsPopupStatusElement = document.getElementById('teams-popup-status');
     const saveTeamsButton = document.getElementById('save-teams-button');
     const loadTeamsButton = document.getElementById('load-teams-button');
+    const classBMinusButton = document.getElementById('class-bminus-button');
+    const classTMinusButton = document.getElementById('class-tminus-button');
     const exportBminusCsvButton = document.getElementById('export-bminus-csv-button');
     const TEAMS_COOKIE_PREFIX = 'savedTeams_';
-    const BMINUS_COOKIE_PREFIX = 'bminusSession_';
+    const SESSION_SCORES_COOKIE_PREFIX = 'sessionScores_';
 
     let lastClassStudents = [];
     let currentTeams = [];
@@ -247,13 +249,28 @@
             const teamBMinusButton = document.createElement('button');
             teamBMinusButton.type = 'button';
             teamBMinusButton.className = 'team-details-button';
-            teamBMinusButton.textContent = 'B';
+            teamBMinusButton.textContent = 'B-';
             teamBMinusButton.title = 'Enregistrer B- pour toute l’équipe (séance en cours)';
             teamBMinusButton.addEventListener('click', () => {
-                team.forEach((student) => recordBMinusForStudent(student.name));
-                teamsPopupStatusElement.textContent = `B- enregistré pour l'équipe ${index + 1} (${team.length} élèves).`;
+                team.forEach((student) => updateSessionScore(student.name, 'b', -1));
             });
             teamHeader.appendChild(teamBMinusButton);
+            const teamTPlusButton = document.createElement('button');
+            teamTPlusButton.type = 'button';
+            teamTPlusButton.className = 'team-details-button';
+            teamTPlusButton.textContent = 'T+';
+            teamTPlusButton.addEventListener('click', () => {
+                team.forEach((student) => updateSessionScore(student.name, 't', 1));
+            });
+            teamHeader.appendChild(teamTPlusButton);
+            const teamTMinusButton = document.createElement('button');
+            teamTMinusButton.type = 'button';
+            teamTMinusButton.className = 'team-details-button';
+            teamTMinusButton.textContent = 'T-';
+            teamTMinusButton.addEventListener('click', () => {
+                team.forEach((student) => updateSessionScore(student.name, 't', -1));
+            });
+            teamHeader.appendChild(teamTMinusButton);
 
             const teamIndicators = createIndicatorsRow({
                 b: computeAverage(team.map((student) => student.b).filter((value) => value !== null)),
@@ -279,6 +296,7 @@
 
             const detailsList = document.createElement('ul');
             detailsList.className = 'team-students-list';
+            detailsList.classList.add('hide-action-buttons');
             detailsList.dataset.teamIndex = String(index);
             detailsList.addEventListener('dragover', (event) => {
                 event.preventDefault();
@@ -311,12 +329,21 @@
                 const studentBMinusButton = document.createElement('button');
                 studentBMinusButton.type = 'button';
                 studentBMinusButton.className = 'team-details-button';
-                studentBMinusButton.textContent = 'B';
+                studentBMinusButton.textContent = 'B-';
                 studentBMinusButton.title = `Enregistrer B- pour ${student.name} (séance en cours)`;
                 studentBMinusButton.addEventListener('click', () => {
-                    recordBMinusForStudent(student.name);
-                    teamsPopupStatusElement.textContent = `B- enregistré pour ${student.name}.`;
+                    updateSessionScore(student.name, 'b', -1);
                 });
+                const studentTPlusButton = document.createElement('button');
+                studentTPlusButton.type = 'button';
+                studentTPlusButton.className = 'team-details-button';
+                studentTPlusButton.textContent = 'T+';
+                studentTPlusButton.addEventListener('click', () => updateSessionScore(student.name, 't', 1));
+                const studentTMinusButton = document.createElement('button');
+                studentTMinusButton.type = 'button';
+                studentTMinusButton.className = 'team-details-button';
+                studentTMinusButton.textContent = 'T-';
+                studentTMinusButton.addEventListener('click', () => updateSessionScore(student.name, 't', -1));
 
                 const studentIndicators = createIndicatorsRow({
                     b: student.b,
@@ -330,6 +357,8 @@
 
                 item.appendChild(name);
                 item.appendChild(studentBMinusButton);
+                item.appendChild(studentTPlusButton);
+                item.appendChild(studentTMinusButton);
                 item.appendChild(studentIndicators);
                 detailsList.appendChild(item);
             });
@@ -340,6 +369,7 @@
                 const showIndicators = detailsPanel.classList.toggle('indicators-hidden') === false;
                 detailsButton.setAttribute('aria-pressed', String(showIndicators));
                 detailsButton.textContent = showIndicators ? '−' : '+';
+                detailsList.classList.toggle('hide-action-buttons', showIndicators);
             });
 
             card.appendChild(teamHeader);
@@ -358,13 +388,13 @@
         return `${yyyy}-${mm}-${dd}`;
     }
 
-    function getBMinusCookieName() {
+    function getSessionScoresCookieName() {
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
-        return `${BMINUS_COOKIE_PREFIX}${selectedClass}_${getSessionDateKey()}`;
+        return `${SESSION_SCORES_COOKIE_PREFIX}${selectedClass}_${getSessionDateKey()}`;
     }
 
-    function getBMinusSessionMap() {
-        const raw = getCookie(getBMinusCookieName());
+    function getSessionScoresMap() {
+        const raw = getCookie(getSessionScoresCookieName());
         if (!raw) {
             return {};
         }
@@ -376,35 +406,41 @@
         }
     }
 
-    function saveBMinusSessionMap(sessionMap) {
-        setCookie(getBMinusCookieName(), JSON.stringify(sessionMap), 30);
+    function saveSessionScoresMap(sessionMap) {
+        setCookie(getSessionScoresCookieName(), JSON.stringify(sessionMap), 30);
     }
 
-    function recordBMinusForStudent(studentName) {
-        if (!studentName) {
+    function updateSessionScore(studentName, indicator, delta) {
+        if (!studentName || !['b', 't'].includes(indicator)) {
             return;
         }
-        const sessionMap = getBMinusSessionMap();
-        sessionMap[studentName] = (Number(sessionMap[studentName]) || 0) + 1;
-        saveBMinusSessionMap(sessionMap);
+        const sessionMap = getSessionScoresMap();
+        if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
+            sessionMap[studentName] = { b: 0, t: 0 };
+        }
+        sessionMap[studentName][indicator] = (Number(sessionMap[studentName][indicator]) || 0) + delta;
+        saveSessionScoresMap(sessionMap);
     }
 
-    function renderBMinusCsv() {
-        const sessionMap = getBMinusSessionMap();
-        const rows = Object.entries(sessionMap)
-            .sort((lhs, rhs) => lhs[0].localeCompare(rhs[0], 'fr'))
-            .map(([studentName, count]) => `${studentName},${count}`);
-        const csvContent = ['Nom,B-', ...rows].join('\n');
+    function renderSessionTable() {
+        const sessionMap = getSessionScoresMap();
+        const rows = Object.entries(sessionMap).sort((lhs, rhs) => lhs[0].localeCompare(rhs[0], 'fr'));
         const sessionDate = getSessionDateKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
-        const csvWindow = window.open('', '_blank');
-        if (!csvWindow) {
-            teamsPopupStatusElement.textContent = 'Impossible d’ouvrir la fenêtre CSV (popup bloquée).';
+        const viewWindow = window.open('', '_blank');
+        if (!viewWindow) {
+            teamsPopupStatusElement.textContent = 'Impossible d’ouvrir la fenêtre du tableau (popup bloquée).';
             return;
         }
-        csvWindow.document.write(`<pre>${csvContent}</pre>`);
-        csvWindow.document.title = `CSV B- ${selectedClass} ${sessionDate}`;
-        teamsPopupStatusElement.textContent = `CSV B- affiché pour ${selectedClass} (${sessionDate}).`;
+        const tableRows = rows.length ? rows.map(([name, scores]) => {
+            const b = Number(scores.b) || 0;
+            const t = Number(scores.t) || 0;
+            const bHue = ((clamp(b, -5, 5) + 5) / 10) * 120;
+            const tHue = ((clamp(t, -5, 5) + 5) / 10) * 120;
+            return `<tr><td>${name}</td><td style="background:hsl(${bHue} 90% 50% / .2);color:hsl(${bHue} 90% 38%)">${b}</td><td style="background:hsl(${tHue} 90% 50% / .2);color:hsl(${tHue} 90% 38%)">${t}</td></tr>`;
+        }).join('') : '<tr><td colspan="3">Aucune donnée de séance.</td></tr>';
+        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3><p>Copiez-collez ce tableau dans Excel ou Google Sheets.</p><table><thead><tr><th>Nom</th><th>B</th><th>T</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
+        viewWindow.document.close();
     }
 
     function updateTeamStatusMessage() {
@@ -636,6 +672,16 @@
                 teamsPopupStatusElement.textContent = 'Équipes sauvegardées.';
             });
         }
+        if (classBMinusButton) {
+            classBMinusButton.addEventListener('click', () => {
+                currentTeams.flat().forEach((student) => updateSessionScore(student.name, 'b', -1));
+            });
+        }
+        if (classTMinusButton) {
+            classTMinusButton.addEventListener('click', () => {
+                currentTeams.flat().forEach((student) => updateSessionScore(student.name, 't', -1));
+            });
+        }
     if (loadTeamsButton) {
             loadTeamsButton.addEventListener('click', () => {
                 const className = getSelectedClass();
@@ -674,7 +720,7 @@
 
     if (exportBminusCsvButton) {
         exportBminusCsvButton.addEventListener('click', () => {
-            renderBMinusCsv();
+            renderSessionTable();
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -123,7 +123,9 @@
             <div class="teams-popup-actions">
                 <button id="save-teams-button" type="button" class="generate-teams-button">Sauvegarder les équipes</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button">Recharger les équipes</button>
-                <button id="export-bminus-csv-button" type="button" class="generate-teams-button">Afficher CSV B- (séance)</button>
+                <button id="class-bminus-button" type="button" class="generate-teams-button">Classe B-</button>
+                <button id="class-tminus-button" type="button" class="generate-teams-button">Classe T-</button>
+                <button id="export-bminus-csv-button" type="button" class="generate-teams-button">Afficher tableau B/T (séance)</button>
             </div>
             <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1738,8 +1738,8 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .teams-popup-panel {
-    width: min(920px, 95vw);
-    max-height: 88vh;
+    width: min(1120px, 96vw);
+    max-height: 92vh;
     overflow-y: auto;
     background: #0f172a;
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -1763,8 +1763,8 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .teams-popup-list {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
-    gap: 10px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
     margin-top: 12px;
 }
 
@@ -1827,7 +1827,7 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 10px;
-    padding: 10px;
+    padding: 8px;
 }
 
 .team-card h4 {
@@ -1847,8 +1847,9 @@ svg.axe { display: block; margin: 0.5em 0; }
 .team-details-button {
     border: 1px solid rgba(255, 255, 255, 0.25);
     border-radius: 999px;
-    width: 22px;
-    height: 22px;
+    min-width: 28px;
+    height: 24px;
+    padding: 0 6px;
     padding: 0;
     background: rgba(255, 255, 255, 0.06);
     color: rgba(255, 255, 255, 0.85);
@@ -1882,7 +1883,7 @@ svg.axe { display: block; margin: 0.5em 0; }
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
+    gap: 6px;
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 8px;
@@ -1896,5 +1897,13 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .team-details-panel.indicators-hidden .team-student-indicators {
+    display: none;
+}
+
+.team-students-list.hide-action-buttons .team-details-button {
+    display: inline-flex;
+}
+
+.team-details-panel:not(.indicators-hidden) .team-details-button {
     display: none;
 }


### PR DESCRIPTION
### Motivation
- Corriger le comportement du bouton B qui appliquait le mauvais sens d'effet et ajouter le suivi simple des scores de séance pour B et T (niveau élève, équipe et classe). 
- Ajouter des contrôles T+ / T- pour piloter l'indicateur T au niveau équipe et élève, et pouvoir appliquer B-/T- à toute la classe depuis la fenêtre de gestion des équipes. 
- Remplacer l'export CSV par une vue copiable plus pratique (tableau Nom / B / T avec dégradés) et ajuster le design pour que la popup tienne sur un écran tout en masquant les boutons d'action lorsque les voyants sont affichés.

### Description
- `class-info.js` : remplacement du stockage/gestion B- par une structure `sessionScores_<CLASSE>_<DATE>` et ajout de `updateSessionScore(...)` pour incrémenter/décrémenter `b` et `t`; suppression des messages de statut affichés au clic; implémentation de la génération d'une fenêtre HTML affichant un tableau copiable `Nom / B / T` avec couleurs dégradées selon les scores via `renderSessionTable()`; ajout des boutons T+/T- au niveau équipe et élève et adaptation des boutons B en B-.
- `index.html` : renommage du bouton d'export et ajout des boutons `Classe B-` et `Classe T-` dans la barre d'actions de la popup de gestion des équipes.
- `styles.css` : ajustements visuels pour la popup (`width`/`max-height`), grille en 3 colonnes, cartes plus compactes et boutons redimensionnés; ajout d'une règle pour masquer/afficher les boutons d'action élèves suivant l'état des voyants.

### Testing
- `node --check class-info.js` a été exécuté et n'a retourné aucune erreur.
- Aucune suite de tests automatisés supplémentaire n'a été exécutée dans cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e08a2eba4833191ef0f765fbb1c9d)