### PR TITLE
Ajuste l’accueil et l’UI de gestion des équipes

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -597,7 +597,9 @@
             setIndicatorLight(indicatorT1Element, null);
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
-            statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
+            if (statusElement) {
+                statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
+            }
             return;
         }
 
@@ -609,7 +611,9 @@
             setIndicatorLight(indicatorT1Element, null);
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
-            statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
+            if (statusElement) {
+                statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
+            }
             return;
         }
 
@@ -620,7 +624,9 @@
         setIndicatorLight(indicatorT1Element, null);
         setIndicatorLight(indicatorT2Element, null);
         setIndicatorLight(indicatorT3Element, null);
-        statusElement.textContent = `Lecture des données de l'onglet "${classConfig.sheetLabel}"...`;
+        if (statusElement) {
+            statusElement.textContent = `Lecture des données de l'onglet "${classConfig.sheetLabel}"...`;
+        }
 
         try {
             const classData = await fetchClassData(className, classConfig);
@@ -632,7 +638,9 @@
             setIndicatorLight(indicatorT2Element, classData.averageT2, getIndicatorDisplayConfig('t2'));
             setIndicatorLight(indicatorT3Element, classData.averageT3, getIndicatorDisplayConfig('t3'));
             lastClassStudents = classData.students;
-            statusElement.textContent = 'Données chargées avec succès.';
+            if (statusElement) {
+                statusElement.textContent = 'Données chargées avec succès.';
+            }
         } catch (error) {
             studentsCountElement.textContent = classConfig ? `Effectif (${classConfig.level}) : -` : 'Effectif : -';
             setIndicatorLight(indicatorBElement, null);
@@ -642,7 +650,9 @@
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
             lastClassStudents = [];
-            statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
+            if (statusElement) {
+                statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
+            }
         }
     }
 

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -382,6 +382,7 @@
         card.appendChild(timer);
         card.appendChild(actions);
 
+        setCompactMode(true);
         updateDisplay();
         return {
             element: card,

--- a/index.html
+++ b/index.html
@@ -9,21 +9,13 @@
 </head>
 
 <body>
-    <header class="home-header">
-        <h1>Accueil</h1>
-        <nav>
-            <ul>
-                <li><a href="techno.html">Technologie</a></li>
-            </ul>
-        </nav>
-    </header>
-
     <main>
         <section class="description-ateliers home-dashboard-grid">
             <article class="atelier sonometre-card home-card-sonometre">
                 <div class="atelier-content">
-                    <div class="card-header-with-toggle">
+                    <div class="card-header-with-toggle class-info-header">
                         <h2>Informations classe</h2>
+                        <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
                     </div>
                     <p id="selected-class-name">Classe sélectionnée : Aucune</p>
                     <p id="selected-class-students">Effectif (3E) : -</p>
@@ -35,8 +27,6 @@
                         <span id="selected-class-indicator-t2" class="indicator-light" role="img" aria-label="Indicateur T2"></span>
                         <span id="selected-class-indicator-t3" class="indicator-light" role="img" aria-label="Indicateur T3"></span>
                     </div>
-                    <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
-                    <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>
             <article class="atelier datetime-card home-card-datetime">
@@ -119,7 +109,7 @@
     <div id="teams-popup" class="teams-popup" hidden>
         <div class="teams-popup-panel">
             <button id="close-teams-popup" type="button" class="teams-popup-close">Fermer</button>
-            <h3>Équipes générées</h3>
+            <h3>Gestion des équipes</h3>
             <div class="teams-popup-actions">
                 <button id="save-teams-button" type="button" class="generate-teams-button">Sauvegarder les équipes</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button">Recharger les équipes</button>

--- a/styles.css
+++ b/styles.css
@@ -1487,6 +1487,11 @@ svg.axe { display: block; margin: 0.5em 0; }
     gap: 10px;
 }
 
+
+.class-info-header .generate-teams-button {
+    margin: 0;
+    margin-left: auto;
+}
 .agenda-card .card-header-with-toggle {
     margin-bottom: 8px;
 }


### PR DESCRIPTION
### Motivation
- Libérer de l’espace visuel sur la page d’accueil et rendre l’accès à la gestion des équipes plus visible et compact.
- Éliminer les messages de statut redondants du bloc « Informations classe » pour alléger l’interface lorsque cet élément n’est plus affiché.
- Réduire l’encombrement des minuteurs de tâches en les affichant en mode compact par défaut.

### Description
- Déplace et aligne le bouton `#generate-teams-button` dans l’en-tête du bloc « Informations classe », supprime l’en-tête global `home-header` et retire le paragraphe `#class-info-status` dans `index.html`, et renomme le titre de la popup en `Gestion des équipes`.
- Ajoute la règle CSS ciblée `.class-info-header .generate-teams-button` dans `styles.css` pour aligner le bouton à droite et supprimer sa marge verticale.
- Protège les assignations de texte de statut dans `class-info.js` en entourant les accès à `statusElement` par des vérifications `if (statusElement)` afin d’éviter les erreurs si l’élément a été retiré du DOM.
- Active le mode compact par défaut pour les cartes minuteurs en appelant `setCompactMode(true)` lors de la création des cartes dans `home-progressions.js` pour minimiser l’affichage des actions du minuteur.

### Testing
- Vérification par recherche de chaînes avec `rg` pour confirmer la présence/absence des éléments et libellés modifiés, et les occurrences attendues ont été trouvées.
- Inspection ciblée des fichiers modifiés avec `sed`/`nl` pour valider les lignes changées dans `index.html`, `styles.css`, `class-info.js` et `home-progressions.js` et constater l’application des modifications.
- Exécution des scripts de transformation utilisés pour appliquer les changements et vérification qu’ils se sont terminés sans erreur.
- Toutes les vérifications automatiques effectuées ont réussi et les fichiers modifiés contiennent les modifications attendues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0e1483fc833183d169d87d023afa)