### PR TITLE
Make class status optional, move teams button into header, default timers to compact

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -33,7 +33,7 @@
     let lastClassStudents = [];
     let currentTeams = [];
 
-    if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element || !statusElement) {
+    if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element) {
         return;
     }
 
@@ -597,7 +597,9 @@
             setIndicatorLight(indicatorT1Element, null);
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
-            statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
+            if (statusElement) {
+                statusElement.textContent = 'Sélectionnez une classe pour afficher ses informations.';
+            }
             return;
         }
 
@@ -609,7 +611,9 @@
             setIndicatorLight(indicatorT1Element, null);
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
-            statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
+            if (statusElement) {
+                statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
+            }
             return;
         }
 
@@ -620,7 +624,9 @@
         setIndicatorLight(indicatorT1Element, null);
         setIndicatorLight(indicatorT2Element, null);
         setIndicatorLight(indicatorT3Element, null);
-        statusElement.textContent = `Lecture des données de l'onglet "${classConfig.sheetLabel}"...`;
+        if (statusElement) {
+            statusElement.textContent = `Lecture des données de l'onglet "${classConfig.sheetLabel}"...`;
+        }
 
         try {
             const classData = await fetchClassData(className, classConfig);
@@ -632,7 +638,9 @@
             setIndicatorLight(indicatorT2Element, classData.averageT2, getIndicatorDisplayConfig('t2'));
             setIndicatorLight(indicatorT3Element, classData.averageT3, getIndicatorDisplayConfig('t3'));
             lastClassStudents = classData.students;
-            statusElement.textContent = 'Données chargées avec succès.';
+            if (statusElement) {
+                statusElement.textContent = 'Données chargées avec succès.';
+            }
         } catch (error) {
             studentsCountElement.textContent = classConfig ? `Effectif (${classConfig.level}) : -` : 'Effectif : -';
             setIndicatorLight(indicatorBElement, null);
@@ -642,7 +650,9 @@
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
             lastClassStudents = [];
-            statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
+            if (statusElement) {
+                statusElement.textContent = error instanceof Error ? error.message : 'Erreur lors du chargement des données.';
+            }
         }
     }
 

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -382,6 +382,7 @@
         card.appendChild(timer);
         card.appendChild(actions);
 
+        setCompactMode(true);
         updateDisplay();
         return {
             element: card,

--- a/index.html
+++ b/index.html
@@ -9,21 +9,13 @@
 </head>
 
 <body>
-    <header class="home-header">
-        <h1>Accueil</h1>
-        <nav>
-            <ul>
-                <li><a href="techno.html">Technologie</a></li>
-            </ul>
-        </nav>
-    </header>
-
     <main>
         <section class="description-ateliers home-dashboard-grid">
             <article class="atelier sonometre-card home-card-sonometre">
                 <div class="atelier-content">
-                    <div class="card-header-with-toggle">
+                    <div class="card-header-with-toggle class-info-header">
                         <h2>Informations classe</h2>
+                        <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
                     </div>
                     <p id="selected-class-name">Classe sélectionnée : Aucune</p>
                     <p id="selected-class-students">Effectif (3E) : -</p>
@@ -35,8 +27,6 @@
                         <span id="selected-class-indicator-t2" class="indicator-light" role="img" aria-label="Indicateur T2"></span>
                         <span id="selected-class-indicator-t3" class="indicator-light" role="img" aria-label="Indicateur T3"></span>
                     </div>
-                    <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
-                    <p id="class-info-status">Sélectionnez une classe pour afficher ses informations.</p>
                 </div>
             </article>
             <article class="atelier datetime-card home-card-datetime">
@@ -119,7 +109,7 @@
     <div id="teams-popup" class="teams-popup" hidden>
         <div class="teams-popup-panel">
             <button id="close-teams-popup" type="button" class="teams-popup-close">Fermer</button>
-            <h3>Équipes générées</h3>
+            <h3>Gestion des équipes</h3>
             <div class="teams-popup-actions">
                 <button id="save-teams-button" type="button" class="generate-teams-button">Sauvegarder les équipes</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button">Recharger les équipes</button>

--- a/styles.css
+++ b/styles.css
@@ -1487,6 +1487,11 @@ svg.axe { display: block; margin: 0.5em 0; }
     gap: 10px;
 }
 
+
+.class-info-header .generate-teams-button {
+    margin: 0;
+    margin-left: auto;
+}
 .agenda-card .card-header-with-toggle {
     margin-bottom: 8px;
 }


### PR DESCRIPTION
### Motivation
- Allow the class information UI to be simplified by making the optional status element non-mandatory. 
- Improve the layout and discoverability of the teams flow by moving the "Gestion des équipes" button into the class card header. 
- Ensure newly created timer cards use the compact display mode by default for a consistent UI. 
- Provide a small style rule to align the moved button in the header.

### Description
- Removed the strict requirement for `statusElement` during initialization and wrapped all `statusElement.textContent` assignments with `if (statusElement)` guards in `class-info.js` so the element can be omitted from the DOM. 
- Moved the `#generate-teams-button` into the class card header by adding a `class-info-header` wrapper in `index.html`, removed the duplicate button placement, and updated the teams popup title to "Gestion des équipes". 
- Set timer cards to compact mode by default by calling `setCompactMode(true)` in `home-progressions.js`. 
- Added `.class-info-header .generate-teams-button` CSS in `styles.css` to adjust button alignment.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0e1483fc833183d169d87d023afa)