### PR TITLE
Améliore la fenêtre “Gestion de classe” (emojis, alignements) et tri d’export

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -249,7 +249,7 @@
             const teamBMinusButton = document.createElement('button');
             teamBMinusButton.type = 'button';
             teamBMinusButton.className = 'team-details-button';
-            teamBMinusButton.textContent = 'B-';
+            teamBMinusButton.textContent = '🔵➖';
             teamBMinusButton.title = 'Enregistrer B- pour toute l’équipe (séance en cours)';
             teamBMinusButton.addEventListener('click', () => {
                 team.forEach((student) => updateSessionScore(student.name, 'b', -1));
@@ -258,7 +258,7 @@
             const teamTPlusButton = document.createElement('button');
             teamTPlusButton.type = 'button';
             teamTPlusButton.className = 'team-details-button';
-            teamTPlusButton.textContent = 'T+';
+            teamTPlusButton.textContent = '🟠➕';
             teamTPlusButton.addEventListener('click', () => {
                 team.forEach((student) => updateSessionScore(student.name, 't', 1));
             });
@@ -266,7 +266,7 @@
             const teamTMinusButton = document.createElement('button');
             teamTMinusButton.type = 'button';
             teamTMinusButton.className = 'team-details-button';
-            teamTMinusButton.textContent = 'T-';
+            teamTMinusButton.textContent = '🟠➖';
             teamTMinusButton.addEventListener('click', () => {
                 team.forEach((student) => updateSessionScore(student.name, 't', -1));
             });
@@ -325,11 +325,12 @@
                 });
 
                 const name = document.createElement('span');
+                name.className = 'team-student-name';
                 name.textContent = student.name;
                 const studentBMinusButton = document.createElement('button');
                 studentBMinusButton.type = 'button';
                 studentBMinusButton.className = 'team-details-button';
-                studentBMinusButton.textContent = 'B-';
+                studentBMinusButton.textContent = '🔵➖';
                 studentBMinusButton.title = `Enregistrer B- pour ${student.name} (séance en cours)`;
                 studentBMinusButton.addEventListener('click', () => {
                     updateSessionScore(student.name, 'b', -1);
@@ -337,12 +338,12 @@
                 const studentTPlusButton = document.createElement('button');
                 studentTPlusButton.type = 'button';
                 studentTPlusButton.className = 'team-details-button';
-                studentTPlusButton.textContent = 'T+';
+                studentTPlusButton.textContent = '🟠➕';
                 studentTPlusButton.addEventListener('click', () => updateSessionScore(student.name, 't', 1));
                 const studentTMinusButton = document.createElement('button');
                 studentTMinusButton.type = 'button';
                 studentTMinusButton.className = 'team-details-button';
-                studentTMinusButton.textContent = 'T-';
+                studentTMinusButton.textContent = '🟠➖';
                 studentTMinusButton.addEventListener('click', () => updateSessionScore(student.name, 't', -1));
 
                 const studentIndicators = createIndicatorsRow({
@@ -355,10 +356,14 @@
                 });
                 studentIndicators.classList.add('team-student-indicators');
 
+                const studentActions = document.createElement('div');
+                studentActions.className = 'team-student-actions';
+                studentActions.appendChild(studentBMinusButton);
+                studentActions.appendChild(studentTPlusButton);
+                studentActions.appendChild(studentTMinusButton);
+
                 item.appendChild(name);
-                item.appendChild(studentBMinusButton);
-                item.appendChild(studentTPlusButton);
-                item.appendChild(studentTMinusButton);
+                item.appendChild(studentActions);
                 item.appendChild(studentIndicators);
                 detailsList.appendChild(item);
             });
@@ -424,7 +429,15 @@
 
     function renderSessionTable() {
         const sessionMap = getSessionScoresMap();
-        const rows = Object.entries(sessionMap).sort((lhs, rhs) => lhs[0].localeCompare(rhs[0], 'fr'));
+        const originalOrder = new Map(lastClassStudents.map((student, idx) => [student.name, idx]));
+        const rows = Object.entries(sessionMap).sort((lhs, rhs) => {
+            const lIdx = originalOrder.has(lhs[0]) ? originalOrder.get(lhs[0]) : Number.POSITIVE_INFINITY;
+            const rIdx = originalOrder.has(rhs[0]) ? originalOrder.get(rhs[0]) : Number.POSITIVE_INFINITY;
+            if (lIdx !== rIdx) {
+                return lIdx - rIdx;
+            }
+            return lhs[0].localeCompare(rhs[0], 'fr');
+        });
         const sessionDate = getSessionDateKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
         const viewWindow = window.open('', '_blank');

--- a/index.html
+++ b/index.html
@@ -108,14 +108,16 @@
 
     <div id="teams-popup" class="teams-popup" hidden>
         <div class="teams-popup-panel">
-            <button id="close-teams-popup" type="button" class="teams-popup-close">Fermer</button>
-            <h3>Gestion des équipes</h3>
-            <div class="teams-popup-actions">
-                <button id="save-teams-button" type="button" class="generate-teams-button">Sauvegarder les équipes</button>
-                <button id="load-teams-button" type="button" class="generate-teams-button">Recharger les équipes</button>
-                <button id="class-bminus-button" type="button" class="generate-teams-button">Classe B-</button>
-                <button id="class-tminus-button" type="button" class="generate-teams-button">Classe T-</button>
-                <button id="export-bminus-csv-button" type="button" class="generate-teams-button">Afficher tableau B/T (séance)</button>
+            <button id="close-teams-popup" type="button" class="teams-popup-close" aria-label="Fermer">✖️</button>
+            <div class="teams-popup-header">
+                <h3>Gestion de classe</h3>
+                <div class="teams-popup-actions">
+                <button id="save-teams-button" type="button" class="generate-teams-button" aria-label="Sauvegarder les équipes" title="Sauvegarder les équipes">💾</button>
+                <button id="load-teams-button" type="button" class="generate-teams-button" aria-label="Recharger les équipes" title="Recharger les équipes">📥</button>
+                <button id="class-bminus-button" type="button" class="generate-teams-button" aria-label="Classe B-" title="Classe B-">🔵➖</button>
+                <button id="class-tminus-button" type="button" class="generate-teams-button" aria-label="Classe T-" title="Classe T-">🟠➖</button>
+                <button id="export-bminus-csv-button" type="button" class="generate-teams-button" aria-label="Afficher tableau B/T (séance)" title="Afficher tableau B/T (séance)">📊</button>
+                </div>
             </div>
             <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>

--- a/styles.css
+++ b/styles.css
@@ -1773,6 +1773,18 @@ svg.axe { display: block; margin: 0.5em 0; }
     margin-top: 12px;
 }
 
+.teams-popup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-right: 50px;
+}
+
+.teams-popup-header h3 {
+    margin: 0;
+}
+
 .teams-popup-actions {
     display: flex;
     gap: 10px;
@@ -1911,4 +1923,15 @@ svg.axe { display: block; margin: 0.5em 0; }
 
 .team-details-panel:not(.indicators-hidden) .team-details-button {
     display: none;
+}
+
+.team-student-name {
+    margin-right: auto;
+}
+
+.team-student-actions {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
 }


### PR DESCRIPTION
### Motivation
- Rendre la fenêtre de gestion des équipes plus lisible visuellement en remplaçant des libellés textuels par des pictogrammes simples. 
- Regrouper les actions principales sur la même ligne que le titre pour une interface plus compacte et cohérente. 
- Conserver l’ordre d’affichage des noms dans l’export tableau pour qu’il reflète l’ordre de la liste de la classe chargée.

### Description
- Remplacement des boutons textuels (Sauvegarder, Recharger, Classe B-/T-, Afficher tableau) par des boutons emoji accessibles et annotés (`aria-label`/`title`) dans `index.html`.
- Regroupement du titre et des actions dans un conteneur `teams-popup-header` et ajout de règles CSS correspondantes dans `styles.css` pour afficher le titre et les actions sur la même ligne.
- Réorganisation de l’affichage des boutons par élève en enveloppant les actions dans un conteneur `.team-student-actions` et ajout de `.team-student-name`/`.team-student-actions` en CSS pour aligner les boutons à droite dans `class-info.js` et `styles.css`.
- Remplacement des libellés B-/T+/T- par des emoji cohérents dans l’UI de l’équipe et de l’élève, et modification de `renderSessionTable` pour trier les lignes selon l’ordre d’origine (`lastClassStudents`) avec repli alphabétique dans `class-info.js`.

### Testing
- Vérifications statiques et inspection des fichiers modifiés pour cohérence DOM/CSS/JS via `rg -n` et `sed -n`/`nl -ba` ciblés, et ces inspections ont retourné les changements attendus.
- Exécution de contrôles locaux sur les blocs modifiés pour s’assurer que les sélecteurs et classes nouvellement ajoutés existent et sont utilisés correctement.
- Validation automatique (recherche/affichage des sections modifiées) concluante, sans erreurs de parsing JS/HTML visibles lors des inspections.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1243f5d8833192971d54921e596b)