### PR TITLE
Refonte de l’évaluation des équipes : popup d’évaluation, initialisation des scores et export ordonné

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -24,14 +24,22 @@
     const teamsPopupStatusElement = document.getElementById('teams-popup-status');
     const saveTeamsButton = document.getElementById('save-teams-button');
     const loadTeamsButton = document.getElementById('load-teams-button');
-    const classBMinusButton = document.getElementById('class-bminus-button');
-    const classTMinusButton = document.getElementById('class-tminus-button');
+    const classEvalButton = document.getElementById('class-eval-button');
     const exportBminusCsvButton = document.getElementById('export-bminus-csv-button');
+    const evalPopupElement = document.getElementById('eval-popup');
+    const closeEvalPopupButton = document.getElementById('close-eval-popup');
+    const evalPopupTitle = document.getElementById('eval-popup-title');
+    const evalBMinusButton = document.getElementById('eval-bminus');
+    const evalTPlusButton = document.getElementById('eval-tplus');
+    const evalTMinusButton = document.getElementById('eval-tminus');
+    const evalCommentElement = document.getElementById('eval-comment');
+    const evalValidateButton = document.getElementById('eval-validate');
     const TEAMS_COOKIE_PREFIX = 'savedTeams_';
     const SESSION_SCORES_COOKIE_PREFIX = 'sessionScores_';
 
     let lastClassStudents = [];
     let currentTeams = [];
+    let pendingEvaluation = null;
 
     if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element) {
         return;
@@ -246,31 +254,13 @@
             title.textContent = `Équipe ${index + 1} (${team.length} élèves)`;
             teamHeader.appendChild(title);
 
-            const teamBMinusButton = document.createElement('button');
-            teamBMinusButton.type = 'button';
-            teamBMinusButton.className = 'team-details-button';
-            teamBMinusButton.textContent = '🔵➖';
-            teamBMinusButton.title = 'Enregistrer B- pour toute l’équipe (séance en cours)';
-            teamBMinusButton.addEventListener('click', () => {
-                team.forEach((student) => updateSessionScore(student.name, 'b', -1));
-            });
-            teamHeader.appendChild(teamBMinusButton);
-            const teamTPlusButton = document.createElement('button');
-            teamTPlusButton.type = 'button';
-            teamTPlusButton.className = 'team-details-button';
-            teamTPlusButton.textContent = '🟠➕';
-            teamTPlusButton.addEventListener('click', () => {
-                team.forEach((student) => updateSessionScore(student.name, 't', 1));
-            });
-            teamHeader.appendChild(teamTPlusButton);
-            const teamTMinusButton = document.createElement('button');
-            teamTMinusButton.type = 'button';
-            teamTMinusButton.className = 'team-details-button';
-            teamTMinusButton.textContent = '🟠➖';
-            teamTMinusButton.addEventListener('click', () => {
-                team.forEach((student) => updateSessionScore(student.name, 't', -1));
-            });
-            teamHeader.appendChild(teamTMinusButton);
+            const teamEvalButton = document.createElement('button');
+            teamEvalButton.type = 'button';
+            teamEvalButton.className = 'team-details-button';
+            teamEvalButton.textContent = '📝';
+            teamEvalButton.title = 'Évaluer toute l’équipe';
+            teamEvalButton.addEventListener('click', () => openEvaluationPopup(`Équipe ${index + 1}`, team.map((student) => student.name)));
+            teamHeader.appendChild(teamEvalButton);
 
             const teamIndicators = createIndicatorsRow({
                 b: computeAverage(team.map((student) => student.b).filter((value) => value !== null)),
@@ -327,24 +317,12 @@
                 const name = document.createElement('span');
                 name.className = 'team-student-name';
                 name.textContent = student.name;
-                const studentBMinusButton = document.createElement('button');
-                studentBMinusButton.type = 'button';
-                studentBMinusButton.className = 'team-details-button';
-                studentBMinusButton.textContent = '🔵➖';
-                studentBMinusButton.title = `Enregistrer B- pour ${student.name} (séance en cours)`;
-                studentBMinusButton.addEventListener('click', () => {
-                    updateSessionScore(student.name, 'b', -1);
-                });
-                const studentTPlusButton = document.createElement('button');
-                studentTPlusButton.type = 'button';
-                studentTPlusButton.className = 'team-details-button';
-                studentTPlusButton.textContent = '🟠➕';
-                studentTPlusButton.addEventListener('click', () => updateSessionScore(student.name, 't', 1));
-                const studentTMinusButton = document.createElement('button');
-                studentTMinusButton.type = 'button';
-                studentTMinusButton.className = 'team-details-button';
-                studentTMinusButton.textContent = '🟠➖';
-                studentTMinusButton.addEventListener('click', () => updateSessionScore(student.name, 't', -1));
+                const studentEvalButton = document.createElement('button');
+                studentEvalButton.type = 'button';
+                studentEvalButton.className = 'team-details-button';
+                studentEvalButton.textContent = '📝';
+                studentEvalButton.title = `Évaluer ${student.name}`;
+                studentEvalButton.addEventListener('click', () => openEvaluationPopup(student.name, [student.name]));
 
                 const studentIndicators = createIndicatorsRow({
                     b: student.b,
@@ -358,9 +336,7 @@
 
                 const studentActions = document.createElement('div');
                 studentActions.className = 'team-student-actions';
-                studentActions.appendChild(studentBMinusButton);
-                studentActions.appendChild(studentTPlusButton);
-                studentActions.appendChild(studentTMinusButton);
+                studentActions.appendChild(studentEvalButton);
 
                 item.appendChild(name);
                 item.appendChild(studentActions);
@@ -383,6 +359,43 @@
             card.appendChild(detailsPanel);
             teamsPopupListElement.appendChild(card);
         });
+    }
+    function ensureSessionScoresInitialized(studentNames) {
+        const sessionMap = getSessionScoresMap();
+        let changed = false;
+        studentNames.forEach((studentName) => {
+            if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
+                sessionMap[studentName] = { b: 0, t: 0, comments: [] };
+                changed = true;
+            } else {
+                if (!Array.isArray(sessionMap[studentName].comments)) {
+                    sessionMap[studentName].comments = [];
+                    changed = true;
+                }
+                if (!Number.isFinite(Number(sessionMap[studentName].b))) {
+                    sessionMap[studentName].b = 0;
+                    changed = true;
+                }
+                if (!Number.isFinite(Number(sessionMap[studentName].t))) {
+                    sessionMap[studentName].t = 0;
+                    changed = true;
+                }
+            }
+        });
+        if (changed) {
+            saveSessionScoresMap(sessionMap);
+        }
+    }
+
+    function openEvaluationPopup(label, studentNames) {
+        if (!evalPopupElement || !studentNames.length) {
+            return;
+        }
+        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0 };
+        evalPopupTitle.textContent = `Évaluer : ${label}`;
+        evalCommentElement.value = '';
+        [evalBMinusButton, evalTPlusButton, evalTMinusButton].forEach((button) => button.classList.remove('selected'));
+        evalPopupElement.hidden = false;
     }
 
     function getSessionDateKey() {
@@ -421,7 +434,7 @@
         }
         const sessionMap = getSessionScoresMap();
         if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-            sessionMap[studentName] = { b: 0, t: 0 };
+            sessionMap[studentName] = { b: 0, t: 0, comments: [] };
         }
         sessionMap[studentName][indicator] = (Number(sessionMap[studentName][indicator]) || 0) + delta;
         saveSessionScoresMap(sessionMap);
@@ -429,15 +442,7 @@
 
     function renderSessionTable() {
         const sessionMap = getSessionScoresMap();
-        const originalOrder = new Map(lastClassStudents.map((student, idx) => [student.name, idx]));
-        const rows = Object.entries(sessionMap).sort((lhs, rhs) => {
-            const lIdx = originalOrder.has(lhs[0]) ? originalOrder.get(lhs[0]) : Number.POSITIVE_INFINITY;
-            const rIdx = originalOrder.has(rhs[0]) ? originalOrder.get(rhs[0]) : Number.POSITIVE_INFINITY;
-            if (lIdx !== rIdx) {
-                return lIdx - rIdx;
-            }
-            return lhs[0].localeCompare(rhs[0], 'fr');
-        });
+        const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 0, t: 0 }]);
         const sessionDate = getSessionDateKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
         const viewWindow = window.open('', '_blank');
@@ -651,6 +656,7 @@
             setIndicatorLight(indicatorT2Element, classData.averageT2, getIndicatorDisplayConfig('t2'));
             setIndicatorLight(indicatorT3Element, classData.averageT3, getIndicatorDisplayConfig('t3'));
             lastClassStudents = classData.students;
+            ensureSessionScoresInitialized(lastClassStudents.map((student) => student.name));
             if (statusElement) {
                 statusElement.textContent = 'Données chargées avec succès.';
             }
@@ -695,14 +701,9 @@
                 teamsPopupStatusElement.textContent = 'Équipes sauvegardées.';
             });
         }
-        if (classBMinusButton) {
-            classBMinusButton.addEventListener('click', () => {
-                currentTeams.flat().forEach((student) => updateSessionScore(student.name, 'b', -1));
-            });
-        }
-        if (classTMinusButton) {
-            classTMinusButton.addEventListener('click', () => {
-                currentTeams.flat().forEach((student) => updateSessionScore(student.name, 't', -1));
+        if (classEvalButton) {
+            classEvalButton.addEventListener('click', () => {
+                openEvaluationPopup('Classe', currentTeams.flat().map((student) => student.name));
             });
         }
     if (loadTeamsButton) {
@@ -744,6 +745,60 @@
     if (exportBminusCsvButton) {
         exportBminusCsvButton.addEventListener('click', () => {
             renderSessionTable();
+        });
+    }
+    if (evalPopupElement && closeEvalPopupButton) {
+        closeEvalPopupButton.addEventListener('click', () => {
+            evalPopupElement.hidden = true;
+        });
+        evalPopupElement.addEventListener('click', (event) => {
+            if (event.target === evalPopupElement) {
+                evalPopupElement.hidden = true;
+            }
+        });
+    }
+    if (evalBMinusButton) {
+        evalBMinusButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            pendingEvaluation.bDelta -= 1;
+            evalBMinusButton.classList.add('selected');
+        });
+    }
+    if (evalTPlusButton) {
+        evalTPlusButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            pendingEvaluation.tDelta += 1;
+            evalTPlusButton.classList.add('selected');
+        });
+    }
+    if (evalTMinusButton) {
+        evalTMinusButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            pendingEvaluation.tDelta -= 1;
+            evalTMinusButton.classList.add('selected');
+        });
+    }
+    if (evalValidateButton) {
+        evalValidateButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            const comment = (evalCommentElement.value || '').trim();
+            const sessionMap = getSessionScoresMap();
+            pendingEvaluation.studentNames.forEach((studentName) => {
+                if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
+                    sessionMap[studentName] = { b: 0, t: 0, comments: [] };
+                }
+                sessionMap[studentName].b = (Number(sessionMap[studentName].b) || 0) + pendingEvaluation.bDelta;
+                sessionMap[studentName].t = (Number(sessionMap[studentName].t) || 0) + pendingEvaluation.tDelta;
+                if (!Array.isArray(sessionMap[studentName].comments)) {
+                    sessionMap[studentName].comments = [];
+                }
+                if (comment) {
+                    sessionMap[studentName].comments.push(comment);
+                }
+            });
+            saveSessionScoresMap(sessionMap);
+            evalPopupElement.hidden = true;
+            pendingEvaluation = null;
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -110,17 +110,30 @@
         <div class="teams-popup-panel">
             <button id="close-teams-popup" type="button" class="teams-popup-close" aria-label="Fermer">✖️</button>
             <div class="teams-popup-header">
-                <h3>Gestion de classe</h3>
+                <h3></h3>
                 <div class="teams-popup-actions">
                 <button id="save-teams-button" type="button" class="generate-teams-button" aria-label="Sauvegarder les équipes" title="Sauvegarder les équipes">💾</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button" aria-label="Recharger les équipes" title="Recharger les équipes">📥</button>
-                <button id="class-bminus-button" type="button" class="generate-teams-button" aria-label="Classe B-" title="Classe B-">🔵➖</button>
-                <button id="class-tminus-button" type="button" class="generate-teams-button" aria-label="Classe T-" title="Classe T-">🟠➖</button>
+                <button id="class-eval-button" type="button" class="generate-teams-button" aria-label="Évaluer la classe" title="Évaluer la classe">📝</button>
                 <button id="export-bminus-csv-button" type="button" class="generate-teams-button" aria-label="Afficher tableau B/T (séance)" title="Afficher tableau B/T (séance)">📊</button>
                 </div>
             </div>
             <p id="teams-popup-status"></p>
             <div id="teams-popup-list" class="teams-popup-list"></div>
+        </div>
+    </div>
+    <div id="eval-popup" class="eval-popup" hidden>
+        <div class="eval-popup-panel">
+            <button id="close-eval-popup" type="button" class="eval-popup-close">Fermer</button>
+            <h3 id="eval-popup-title">Évaluer</h3>
+            <div class="eval-popup-actions">
+                <button id="eval-bminus" type="button" class="eval-action-button">B-</button>
+                <button id="eval-tplus" type="button" class="eval-action-button">T+</button>
+                <button id="eval-tminus" type="button" class="eval-action-button">T-</button>
+            </div>
+            <label for="eval-comment">Commentaire</label>
+            <textarea id="eval-comment" rows="3" placeholder="Ajouter un commentaire..."></textarea>
+            <button id="eval-validate" type="button" class="generate-teams-button">Valider</button>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1935,3 +1935,53 @@ svg.axe { display: block; margin: 0.5em 0; }
     align-items: center;
     gap: 6px;
 }
+
+.eval-popup {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 5300;
+}
+
+.eval-popup[hidden] {
+    display: none;
+}
+
+.eval-popup-panel {
+    width: min(460px, 92vw);
+    background: #0f172a;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 14px;
+    padding: 18px;
+    position: relative;
+    display: grid;
+    gap: 10px;
+}
+
+.eval-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+}
+
+.eval-popup-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.eval-action-button {
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+    border-radius: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.eval-action-button.selected {
+    background: rgba(220, 38, 38, 0.92);
+    border-color: #fecaca;
+}


### PR DESCRIPTION
### Motivation
- Remplacer les actions directes B-/T+/T- pour la classe, l’équipe et l’élève par une interface d’évaluation plus explicite et sûre.  
- S’assurer que les scores de séance démarrent à `0` par défaut pour tous les élèves de la classe.  
- Faire en sorte que l’export de la séance suive l’ordre des élèves tel qu’il apparaît dans le CSV source.  
- Retirer le titre « Gestion des équipes » visible dans l’en-tête pour alléger l’UI.

### Description
- Remplacement de l’entête et des boutons dans `index.html` : suppression du libellé visible, ajout d’un bouton `class-eval-button` (`📝`) et ajout d’une nouvelle fenêtre `eval-popup` contenant les boutons texte `B- / T+ / T-`, un champ `textarea` `eval-comment` et un bouton `eval-validate`.
- JS (`class-info.js`) : suppression des actions directes `B-/T+/T-` au niveau classe/équipe/élève et ajout d’un bouton d’évaluation (emoji) qui ouvre la popup via la nouvelle fonction `openEvaluationPopup`; gestion d’un état `pendingEvaluation` pour accumuler `bDelta`/`tDelta` et le commentaire jusqu’à la validation.
- Initialisation et stockage : ajout de `ensureSessionScoresInitialized` et extension de la structure de session pour inclure `comments`, et garantie que chaque élève a des scores `b` et `t` initialisés à `0` lors du chargement de la classe.
- Export séance : `renderSessionTable` utilise désormais explicitement l’ordre de `lastClassStudents` pour construire le tableau exporté (préserve l’ordre du CSV source).
- Styles (`styles.css`) : ajout des styles pour la popup d’évaluation `.eval-popup`, des boutons `.eval-action-button` et de l’état sélectionné `.selected` pour afficher en rouge les actions choisies avant validation.
- Fichiers modifiés : `index.html`, `class-info.js`, `styles.css`.

### Testing
- Aucun test automatisé exécuté pour cette modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e162e90708331832e85ea354b3187)