### PR TITLE
Améliore la popup d'évaluation et l'export séance

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -32,6 +32,10 @@
     const evalBMinusButton = document.getElementById('eval-bminus');
     const evalTPlusButton = document.getElementById('eval-tplus');
     const evalTMinusButton = document.getElementById('eval-tminus');
+    const evalAPlusButton = document.getElementById('eval-aplus');
+    const evalAMinusButton = document.getElementById('eval-aminus');
+    const evalSessionLedB = document.getElementById('eval-session-led-b');
+    const evalSessionLedT = document.getElementById('eval-session-led-t');
     const evalCommentElement = document.getElementById('eval-comment');
     const evalValidateButton = document.getElementById('eval-validate');
     const TEAMS_COOKIE_PREFIX = 'savedTeams_';
@@ -365,7 +369,7 @@
         let changed = false;
         studentNames.forEach((studentName) => {
             if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-                sessionMap[studentName] = { b: 0, t: 0, comments: [] };
+                sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
                 changed = true;
             } else {
                 if (!Array.isArray(sessionMap[studentName].comments)) {
@@ -391,10 +395,11 @@
         if (!evalPopupElement || !studentNames.length) {
             return;
         }
-        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0 };
+        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0, aDelta: 0 };
         evalPopupTitle.textContent = `Évaluer : ${label}`;
         evalCommentElement.value = '';
-        [evalBMinusButton, evalTPlusButton, evalTMinusButton].forEach((button) => button.classList.remove('selected'));
+        [evalBMinusButton, evalTPlusButton, evalTMinusButton, evalAPlusButton, evalAMinusButton].forEach((button) => button.classList.remove('selected'));
+        updateSessionLeds(studentNames);
         evalPopupElement.hidden = false;
     }
 
@@ -434,7 +439,7 @@
         }
         const sessionMap = getSessionScoresMap();
         if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-            sessionMap[studentName] = { b: 0, t: 0, comments: [] };
+            sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
         }
         sessionMap[studentName][indicator] = (Number(sessionMap[studentName][indicator]) || 0) + delta;
         saveSessionScoresMap(sessionMap);
@@ -442,7 +447,7 @@
 
     function renderSessionTable() {
         const sessionMap = getSessionScoresMap();
-        const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 0, t: 0 }]);
+        const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 3, t: 3, a: 0, comments: [] }]);
         const sessionDate = getSessionDateKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
         const viewWindow = window.open('', '_blank');
@@ -451,14 +456,40 @@
             return;
         }
         const tableRows = rows.length ? rows.map(([name, scores]) => {
-            const b = Number(scores.b) || 0;
-            const t = Number(scores.t) || 0;
-            const bHue = ((clamp(b, -5, 5) + 5) / 10) * 120;
-            const tHue = ((clamp(t, -5, 5) + 5) / 10) * 120;
-            return `<tr><td>${name}</td><td style="background:hsl(${bHue} 90% 50% / .2);color:hsl(${bHue} 90% 38%)">${b}</td><td style="background:hsl(${tHue} 90% 50% / .2);color:hsl(${tHue} 90% 38%)">${t}</td></tr>`;
-        }).join('') : '<tr><td colspan="3">Aucune donnée de séance.</td></tr>';
-        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3><p>Copiez-collez ce tableau dans Excel ou Google Sheets.</p><table><thead><tr><th>Nom</th><th>B</th><th>T</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
+            const b = Number(scores.b) || 3;
+            const t = Number(scores.t) || 3;
+            const a = Number(scores.a) || 0;
+            const bHue = ((clamp(b, -3, 3) + 3) / 6) * 120;
+            const tHue = ((clamp(t, -3, 3) + 3) / 6) * 120;
+            const aHue = ((clamp(a, -3, 3) + 3) / 6) * 120;
+            const comments = Array.isArray(scores.comments) ? scores.comments.join(' | ') : '';
+            return `<tr><td>${selectedClass}</td><td>${getTeamLabelForStudent(name)}</td><td>${name}</td><td style="background:hsl(${bHue} 90% 50% / .2);color:hsl(${bHue} 90% 38%)">${b}</td><td style="background:hsl(${tHue} 90% 50% / .2);color:hsl(${tHue} 90% 38%)">${t}</td><td style="background:hsl(${aHue} 90% 50% / .2);color:hsl(${aHue} 90% 38%)">${a}</td><td>${comments}</td></tr>`;
+        }).join('') : '<tr><td colspan="7">Aucune donnée de séance.</td></tr>';
+        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3><p>Ordre export: Classe, Équipe, Élève, B, T, A et commentaire.</p><table><thead><tr><th>Classe</th><th>Équipe</th><th>Élève</th><th>B</th><th>T</th><th>A</th><th>Commentaire</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
         viewWindow.document.close();
+    }
+
+    
+
+    function getTeamLabelForStudent(studentName) {
+        const idx = currentTeams.findIndex((team) => team.some((student) => student.name === studentName));
+        return idx >= 0 ? `Équipe ${idx + 1}` : 'Sans équipe';
+    }
+
+    function setSessionIndicatorLight(indicatorElement, value) {
+        if (!indicatorElement) return;
+        const boundedValue = clamp(Number(value) || 0, -3, 3);
+        const hue = ((boundedValue + 3) / 6) * 120;
+        indicatorElement.style.setProperty('--indicator-color', `hsl(${hue} 88% 48%)`);
+        indicatorElement.style.setProperty('--indicator-glow', `hsl(${hue} 92% 55% / 0.6)`);
+        indicatorElement.title = `${boundedValue}`;
+    }
+
+    function updateSessionLeds(studentNames) {
+        const sessionMap = getSessionScoresMap();
+        const first = studentNames.length ? (sessionMap[studentNames[0]] || { b: 3, t: 3 }) : { b: 3, t: 3 };
+        setSessionIndicatorLight(evalSessionLedB, Number(first.b) || 3);
+        setSessionIndicatorLight(evalSessionLedT, Number(first.t) || 3);
     }
 
     function updateTeamStatusMessage() {
@@ -778,6 +809,20 @@
             evalTMinusButton.classList.add('selected');
         });
     }
+    if (evalAPlusButton) {
+        evalAPlusButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            pendingEvaluation.aDelta += 1;
+            evalAPlusButton.classList.add('selected');
+        });
+    }
+    if (evalAMinusButton) {
+        evalAMinusButton.addEventListener('click', () => {
+            if (!pendingEvaluation) return;
+            pendingEvaluation.aDelta -= 1;
+            evalAMinusButton.classList.add('selected');
+        });
+    }
     if (evalValidateButton) {
         evalValidateButton.addEventListener('click', () => {
             if (!pendingEvaluation) return;
@@ -785,10 +830,11 @@
             const sessionMap = getSessionScoresMap();
             pendingEvaluation.studentNames.forEach((studentName) => {
                 if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-                    sessionMap[studentName] = { b: 0, t: 0, comments: [] };
+                    sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
                 }
                 sessionMap[studentName].b = (Number(sessionMap[studentName].b) || 0) + pendingEvaluation.bDelta;
                 sessionMap[studentName].t = (Number(sessionMap[studentName].t) || 0) + pendingEvaluation.tDelta;
+                sessionMap[studentName].a = (Number(sessionMap[studentName].a) || 0) + pendingEvaluation.aDelta;
                 if (!Array.isArray(sessionMap[studentName].comments)) {
                     sessionMap[studentName].comments = [];
                 }

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                 <button id="save-teams-button" type="button" class="generate-teams-button" aria-label="Sauvegarder les équipes" title="Sauvegarder les équipes">💾</button>
                 <button id="load-teams-button" type="button" class="generate-teams-button" aria-label="Recharger les équipes" title="Recharger les équipes">📥</button>
                 <button id="class-eval-button" type="button" class="generate-teams-button" aria-label="Évaluer la classe" title="Évaluer la classe">📝</button>
-                <button id="export-bminus-csv-button" type="button" class="generate-teams-button" aria-label="Afficher tableau B/T (séance)" title="Afficher tableau B/T (séance)">📊</button>
+                <button id="export-bminus-csv-button" type="button" class="generate-teams-button" aria-label="Afficher tableau B/T/A (séance)" title="Afficher tableau B/T/A (séance)">📊</button>
                 </div>
             </div>
             <p id="teams-popup-status"></p>
@@ -126,10 +126,16 @@
         <div class="eval-popup-panel">
             <button id="close-eval-popup" type="button" class="eval-popup-close">Fermer</button>
             <h3 id="eval-popup-title">Évaluer</h3>
+            <div class="eval-popup-session-leds">
+                <span>B séance: <span id="eval-session-led-b" class="indicator-light" aria-label="Voyant B séance"></span></span>
+                <span>T séance: <span id="eval-session-led-t" class="indicator-light" aria-label="Voyant T séance"></span></span>
+            </div>
             <div class="eval-popup-actions">
                 <button id="eval-bminus" type="button" class="eval-action-button">B-</button>
                 <button id="eval-tplus" type="button" class="eval-action-button">T+</button>
                 <button id="eval-tminus" type="button" class="eval-action-button">T-</button>
+                <button id="eval-aplus" type="button" class="eval-action-button">A+</button>
+                <button id="eval-aminus" type="button" class="eval-action-button">A-</button>
             </div>
             <label for="eval-comment">Commentaire</label>
             <textarea id="eval-comment" rows="3" placeholder="Ajouter un commentaire..."></textarea>

--- a/styles.css
+++ b/styles.css
@@ -1967,9 +1967,22 @@ svg.axe { display: block; margin: 0.5em 0; }
     right: 10px;
 }
 
+.eval-popup-session-leds {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+}
+
+.eval-popup-session-leds span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .eval-popup-actions {
     display: flex;
     gap: 8px;
+    flex-wrap: wrap;
 }
 
 .eval-action-button {
@@ -1984,4 +1997,9 @@ svg.axe { display: block; margin: 0.5em 0; }
 .eval-action-button.selected {
     background: rgba(220, 38, 38, 0.92);
     border-color: #fecaca;
+}
+
+#eval-tplus.selected {
+    background: rgba(22, 163, 74, 0.95);
+    border-color: #bbf7d0;
 }


### PR DESCRIPTION
### Motivation
- Implémenter la gestion de séance demandée : par défaut les élèves doivent débuter avec B=3 et T=3.  
- Afficher des voyants LED dans la popup d’évaluation pour visualiser B et T avec un dégradé rouge→vert sur la plage -3 à 3.  
- Rendre le bouton `T+` visuellement distinct (fond vert) lorsqu’il est sélectionné et ajouter les actions `A+` / `A-`.  
- Fournir un export séance complet incluant les colonnes dans l’ordre demandé (Classe, Équipe, Élève, B, T, A, Commentaire).

### Description
- `index.html` : ajout des voyants de séance (`#eval-session-led-b`, `#eval-session-led-t`) et des boutons `A+` / `A-`, et mise à jour du libellé du bouton d’export pour indiquer `B/T/A` dans la popup d’équipes.  
- `styles.css` : styles pour afficher les LED de séance dans la popup (`.eval-popup-session-leds`) et style spécial `#eval-tplus.selected` pour rendre `T+` vert quand sélectionné.  
- `class-info.js` : initialisation par défaut des scores de séance à `b:3`, `t:3`, `a:0` dans `ensureSessionScoresInitialized` et lors de création d’entrées; ajout de la gestion de `aDelta` (A+/A-) et stockage de `a` lors de la validation; fonctions `setSessionIndicatorLight` et `updateSessionLeds` pour afficher le dégradé -3→3; ajout de `getTeamLabelForStudent` et enrichissement de `renderSessionTable` pour exporter les colonnes `Classe, Équipe, Élève, B, T, A, Commentaire`.  

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check class-info.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e18a1a2448331bf9404fb5ffac6be)