### PR TITLE
Accueil: ajustements gestion des équipes et évaluation classe

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -27,7 +27,6 @@
     const classEvalButton = document.getElementById('class-eval-button');
     const exportBminusCsvButton = document.getElementById('export-bminus-csv-button');
     const evalPopupElement = document.getElementById('eval-popup');
-    const closeEvalPopupButton = document.getElementById('close-eval-popup');
     const evalPopupTitle = document.getElementById('eval-popup-title');
     const evalBMinusButton = document.getElementById('eval-bminus');
     const evalTPlusButton = document.getElementById('eval-tplus');
@@ -369,7 +368,7 @@
         let changed = false;
         studentNames.forEach((studentName) => {
             if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-                sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
+                sessionMap[studentName] = { b: 3, t: 3, a: 3, comments: [] };
                 changed = true;
             } else {
                 if (!Array.isArray(sessionMap[studentName].comments)) {
@@ -395,7 +394,7 @@
         if (!evalPopupElement || !studentNames.length) {
             return;
         }
-        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0, aDelta: 0 };
+        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0, aDelta: 0, isClassEvaluation: label === 'Classe' };
         evalPopupTitle.textContent = `Évaluer : ${label}`;
         evalCommentElement.value = '';
         [evalBMinusButton, evalTPlusButton, evalTMinusButton, evalAPlusButton, evalAMinusButton].forEach((button) => button.classList.remove('selected'));
@@ -439,7 +438,7 @@
         }
         const sessionMap = getSessionScoresMap();
         if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-            sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
+            sessionMap[studentName] = { b: 3, t: 3, a: 3, comments: [] };
         }
         sessionMap[studentName][indicator] = (Number(sessionMap[studentName][indicator]) || 0) + delta;
         saveSessionScoresMap(sessionMap);
@@ -447,7 +446,8 @@
 
     function renderSessionTable() {
         const sessionMap = getSessionScoresMap();
-        const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 3, t: 3, a: 0, comments: [] }]);
+        const classComments = Array.isArray(sessionMap.__classComments) ? sessionMap.__classComments : [];
+        const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 3, t: 3, a: 3, comments: [] }]);
         const sessionDate = getSessionDateKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
         const viewWindow = window.open('', '_blank');
@@ -458,14 +458,17 @@
         const tableRows = rows.length ? rows.map(([name, scores]) => {
             const b = Number(scores.b) || 3;
             const t = Number(scores.t) || 3;
-            const a = Number(scores.a) || 0;
+            const a = Number(scores.a) || 3;
             const bHue = ((clamp(b, -3, 3) + 3) / 6) * 120;
             const tHue = ((clamp(t, -3, 3) + 3) / 6) * 120;
             const aHue = ((clamp(a, -3, 3) + 3) / 6) * 120;
             const comments = Array.isArray(scores.comments) ? scores.comments.join(' | ') : '';
             return `<tr><td>${selectedClass}</td><td>${getTeamLabelForStudent(name)}</td><td>${name}</td><td style="background:hsl(${bHue} 90% 50% / .2);color:hsl(${bHue} 90% 38%)">${b}</td><td style="background:hsl(${tHue} 90% 50% / .2);color:hsl(${tHue} 90% 38%)">${t}</td><td style="background:hsl(${aHue} 90% 50% / .2);color:hsl(${aHue} 90% 38%)">${a}</td><td>${comments}</td></tr>`;
         }).join('') : '<tr><td colspan="7">Aucune donnée de séance.</td></tr>';
-        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3><p>Ordre export: Classe, Équipe, Élève, B, T, A et commentaire.</p><table><thead><tr><th>Classe</th><th>Équipe</th><th>Élève</th><th>B</th><th>T</th><th>A</th><th>Commentaire</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
+        const classCommentsHtml = classComments.length
+            ? `<div style="border:1px solid #ccc;padding:10px;margin:12px 0 16px 0;background:#f8fafc"><strong>Commentaire classe</strong><br>${classComments.join('<br>')}</div>`
+            : `<div style="border:1px solid #ccc;padding:10px;margin:12px 0 16px 0;background:#f8fafc"><strong>Commentaire classe</strong><br>Aucun commentaire classe.</div>`;
+        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3>${classCommentsHtml}<p>Ordre export: Classe, Équipe, Élève, B, T, A et commentaire.</p><table><thead><tr><th>Classe</th><th>Équipe</th><th>Élève</th><th>B</th><th>T</th><th>A</th><th>Commentaire</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
         viewWindow.document.close();
     }
 
@@ -778,16 +781,7 @@
             renderSessionTable();
         });
     }
-    if (evalPopupElement && closeEvalPopupButton) {
-        closeEvalPopupButton.addEventListener('click', () => {
-            evalPopupElement.hidden = true;
-        });
-        evalPopupElement.addEventListener('click', (event) => {
-            if (event.target === evalPopupElement) {
-                evalPopupElement.hidden = true;
-            }
-        });
-    }
+    // Fermeture volontaire retirée : validation obligatoire pour fermer la fenêtre.
     if (evalBMinusButton) {
         evalBMinusButton.addEventListener('click', () => {
             if (!pendingEvaluation) return;
@@ -830,18 +824,24 @@
             const sessionMap = getSessionScoresMap();
             pendingEvaluation.studentNames.forEach((studentName) => {
                 if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
-                    sessionMap[studentName] = { b: 3, t: 3, a: 0, comments: [] };
+                    sessionMap[studentName] = { b: 3, t: 3, a: 3, comments: [] };
                 }
                 sessionMap[studentName].b = (Number(sessionMap[studentName].b) || 0) + pendingEvaluation.bDelta;
                 sessionMap[studentName].t = (Number(sessionMap[studentName].t) || 0) + pendingEvaluation.tDelta;
-                sessionMap[studentName].a = (Number(sessionMap[studentName].a) || 0) + pendingEvaluation.aDelta;
+                sessionMap[studentName].a = (Number(sessionMap[studentName].a) || 3) + pendingEvaluation.aDelta;
                 if (!Array.isArray(sessionMap[studentName].comments)) {
                     sessionMap[studentName].comments = [];
                 }
-                if (comment) {
+                if (comment && !pendingEvaluation.isClassEvaluation) {
                     sessionMap[studentName].comments.push(comment);
                 }
             });
+            if (comment && pendingEvaluation.isClassEvaluation) {
+                if (!Array.isArray(sessionMap.__classComments)) {
+                    sessionMap.__classComments = [];
+                }
+                sessionMap.__classComments.push(comment);
+            }
             saveSessionScoresMap(sessionMap);
             evalPopupElement.hidden = true;
             pendingEvaluation = null;

--- a/index.html
+++ b/index.html
@@ -124,11 +124,12 @@
     </div>
     <div id="eval-popup" class="eval-popup" hidden>
         <div class="eval-popup-panel">
-            <button id="close-eval-popup" type="button" class="eval-popup-close">Fermer</button>
-            <h3 id="eval-popup-title">Évaluer</h3>
-            <div class="eval-popup-session-leds">
+            <div class="eval-popup-header">
+                <h3 id="eval-popup-title">Évaluer</h3>
+                <div class="eval-popup-session-leds">
                 <span>B séance: <span id="eval-session-led-b" class="indicator-light" aria-label="Voyant B séance"></span></span>
                 <span>T séance: <span id="eval-session-led-t" class="indicator-light" aria-label="Voyant T séance"></span></span>
+                </div>
             </div>
             <div class="eval-popup-actions">
                 <button id="eval-bminus" type="button" class="eval-action-button">B-</button>

--- a/styles.css
+++ b/styles.css
@@ -1961,16 +1961,18 @@ svg.axe { display: block; margin: 0.5em 0; }
     gap: 10px;
 }
 
-.eval-popup-close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
+.eval-popup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
 }
 
 .eval-popup-session-leds {
     display: flex;
-    gap: 18px;
+    gap: 10px;
     align-items: center;
+    justify-content: flex-end;
 }
 
 .eval-popup-session-leds span {


### PR DESCRIPTION
### Motivation
- Harmoniser le comportement des indicateurs B/T/A et améliorer l’ergonomie de la fenêtre d’évaluation pour la gestion des équipes sur la page d’accueil.
- Empêcher la duplication du commentaire classe dans les commentaires individuels et fournir un emplacement dédié pour l’export.

### Description
- Définit la valeur par défaut du critère `a` à `3` dans l’initialisation et les valeurs de secours de séance dans `class-info.js` afin d’aligner A sur B/T.
- Remplace la croix et la fermeture par clic extérieur de la fenêtre d’évaluation par une en-tête (`div.eval-popup-header`) et empêche la fermeture automatique pour ne permettre la fermeture qu’avec le bouton `Valider` dans `index.html` et `class-info.js`.
- Déplace et aligne les voyants B/T en haut à droite de la fenêtre d’évaluation via la nouvelle structure d’en-tête et les règles CSS `.eval-popup-header` et `.eval-popup-session-leds` dans `styles.css`.
- Ajoute la gestion d’un commentaire de classe stocké dans `sessionMap.__classComments`, empêche la copie du commentaire classe dans chaque élève lors d’une évaluation « Classe », et injecte un bloc « Commentaire classe » au-dessus du tableau d’export dans la fonction `renderSessionTable` de `class-info.js`.
- Étend l’objet `pendingEvaluation` avec la propriété `isClassEvaluation` pour distinguer les évaluations individuelles des évaluations de classe dans `class-info.js`.

### Testing
- Exécuté `node --check class-info.js` pour vérifier la validité syntaxique du fichier modifié, et la vérification est passée.
- Vérification automatique du diff des fichiers modifiés (`class-info.js`, `index.html`, `styles.css`) pour confirmer les changements structurels appliqués.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e8f444a5483319e61eb965fb28770)