### PR TITLE
Support 4E classes and session-dependent evaluation state; clamp evaluation scores

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -1,10 +1,12 @@
 (function () {
     const TROISIEME_CLASSES = new Set(['3E1', '3E2', '3E3', '3E4', '3E5']);
+    const QUATRIEME_CLASSES = new Set(['4E1', '4E2', '4E3', '4E4', '4E5']);
     const CINQUIEME_CLASSES = new Set(['5E1', '5E2', '5E3', '5E4', '5E5']);
 
     // Remplacer l'URL par le lien CSV publié du fichier "3E - Techno", onglet "Suivi Eleve 3E".
     // Format attendu : https://docs.google.com/spreadsheets/d/e/<ID>/pub?gid=<GID_ONGLET>&single=true&output=csv
     const SHEET_3E_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRgz3Y15bbDovMG-vtfT0rBMeR-BDMfSRZsj_m3vlzsbGybW6xe5qWEfzB7fFCQyHmf9qJ7lMsDIUY6/pub?gid=640829844&single=true&output=csv';
+    const SHEET_4E_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vTm93EOw24n1lgpSXfhmyjIQznJuYfBVuA0lD3QUP1dm6rRCMOQxhKgcTtaQI-dkSPl49szSFur0Uvd/pub?gid=823965694&single=true&output=csv';
     const SHEET_5E_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQz6hxElwi5l0-KHdWwVo98h8_UHKmPS3_07l7GbaqSAeof2I9U8sUBxm8VkQRbYcAoGQJgDqdpmGXO/pub?gid=1527557223&single=true&output=csv';
 
     const classNameElement = document.getElementById('selected-class-name');
@@ -43,6 +45,7 @@
     let lastClassStudents = [];
     let currentTeams = [];
     let pendingEvaluation = null;
+    let hasSelectedSession = false;
 
     if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element) {
         return;
@@ -444,6 +447,16 @@
         saveSessionScoresMap(sessionMap);
     }
 
+    function updateSessionDependentButtonsState() {
+        const shouldDisable = !hasSelectedSession;
+        if (classEvalButton) {
+            classEvalButton.disabled = shouldDisable;
+        }
+        if (exportBminusCsvButton) {
+            exportBminusCsvButton.disabled = shouldDisable;
+        }
+    }
+
     function renderSessionTable() {
         const sessionMap = getSessionScoresMap();
         const classComments = Array.isArray(sessionMap.__classComments) ? sessionMap.__classComments : [];
@@ -564,6 +577,9 @@
         if (TROISIEME_CLASSES.has(normalizedClass)) {
             return { level: '3E', csvUrl: SHEET_3E_CSV_URL, sheetLabel: 'Suivi Eleve 3E' };
         }
+        if (QUATRIEME_CLASSES.has(normalizedClass)) {
+            return { level: '4E', csvUrl: SHEET_4E_CSV_URL, sheetLabel: 'Suivi Eleve 4E' };
+        }
         if (CINQUIEME_CLASSES.has(normalizedClass)) {
             return { level: '5E', csvUrl: SHEET_5E_CSV_URL, sheetLabel: 'Suivi Eleve 5E' };
         }
@@ -664,7 +680,7 @@
             setIndicatorLight(indicatorT2Element, null);
             setIndicatorLight(indicatorT3Element, null);
             if (statusElement) {
-                statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E ou 5E).';
+                statusElement.textContent = 'Cette classe ne fait pas partie des classes prises en charge (3E, 4E ou 5E).';
             }
             return;
         }
@@ -826,9 +842,14 @@
                 if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
                     sessionMap[studentName] = { b: 3, t: 3, a: 3, comments: [] };
                 }
-                sessionMap[studentName].b = (Number(sessionMap[studentName].b) || 0) + pendingEvaluation.bDelta;
-                sessionMap[studentName].t = (Number(sessionMap[studentName].t) || 0) + pendingEvaluation.tDelta;
-                sessionMap[studentName].a = (Number(sessionMap[studentName].a) || 3) + pendingEvaluation.aDelta;
+                const currentB = Number(sessionMap[studentName].b) || 3;
+                const currentT = Number(sessionMap[studentName].t) || 3;
+                const currentA = Number(sessionMap[studentName].a) || 3;
+                const tentativeB = currentB + pendingEvaluation.bDelta;
+                const bonusTDeltaFromB = tentativeB < 3 ? -1 : 0;
+                sessionMap[studentName].b = Math.max(3, tentativeB);
+                sessionMap[studentName].t = Math.max(3, currentT + pendingEvaluation.tDelta + bonusTDeltaFromB);
+                sessionMap[studentName].a = Math.max(3, currentA + pendingEvaluation.aDelta);
                 if (!Array.isArray(sessionMap[studentName].comments)) {
                     sessionMap[studentName].comments = [];
                 }
@@ -852,11 +873,17 @@
         classFilterElement.addEventListener('change', refreshClassInfo);
     }
 
+    window.addEventListener('session-selection-change', (event) => {
+        hasSelectedSession = Boolean(event.detail && event.detail.hasSelection);
+        updateSessionDependentButtonsState();
+    });
+
     window.addEventListener('storage', (event) => {
         if (event.key === 'userClasse') {
             refreshClassInfo();
         }
     });
 
+    updateSessionDependentButtonsState();
     refreshClassInfo();
 })();

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -764,6 +764,13 @@
             taskButton.appendChild(details);
             taskButton.addEventListener('click', () => {
                 selectedEntryKey = entryKey;
+                if (classFilterElement.value !== entry.classText) {
+                    classFilterElement.value = entry.classText;
+                }
+                localStorage.setItem('userClasse', entry.classText);
+                window.dispatchEvent(new CustomEvent('session-selection-change', {
+                    detail: { hasSelection: true, selectedClass: entry.classText }
+                }));
                 renderSteps();
                 renderTaskDetail(entry);
             });
@@ -775,6 +782,9 @@
         if (!displayedEntries.some((entry) => getEntryKey(entry) === selectedEntryKey)) {
             selectedEntryKey = '';
             renderTaskDetail(null);
+            window.dispatchEvent(new CustomEvent('session-selection-change', {
+                detail: { hasSelection: false, selectedClass: classFilterElement.value || '' }
+            }));
         }
 
         setStatus('');

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@
             <div class="eval-popup-header">
                 <h3 id="eval-popup-title">Évaluer</h3>
                 <div class="eval-popup-session-leds">
-                <span>B séance: <span id="eval-session-led-b" class="indicator-light" aria-label="Voyant B séance"></span></span>
-                <span>T séance: <span id="eval-session-led-t" class="indicator-light" aria-label="Voyant T séance"></span></span>
+                <span><span id="eval-session-led-b" class="indicator-light" aria-label="Voyant B séance"></span></span>
+                <span><span id="eval-session-led-t" class="indicator-light" aria-label="Voyant T séance"></span></span>
                 </div>
             </div>
             <div class="eval-popup-actions">

--- a/styles.css
+++ b/styles.css
@@ -2005,3 +2005,8 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(22, 163, 74, 0.95);
     border-color: #bbf7d0;
 }
+
+#eval-aplus.selected {
+    background: rgba(22, 163, 74, 0.95);
+    border-color: #bbf7d0;
+}


### PR DESCRIPTION
### Motivation
- Add support for 4E classes and their CSV source so the UI can display metrics for those classes. 
- Prevent evaluation/export actions when no session is selected to avoid exporting or editing session data unintentionally. 
- Ensure session score updates are clamped and consistent (no values below baseline) and apply a small T adjustment when B drops below baseline.

### Description
- Added `QUATRIEME_CLASSES` and `SHEET_4E_CSV_URL`, and updated `getClassConfig` to return `4E` configuration for matching classes. 
- Updated status text to mention support for `3E, 4E ou 5E`. 
- Introduced `hasSelectedSession` state, `updateSessionDependentButtonsState()` and a `session-selection-change` event listener to enable/disable the `class-eval-button` and `export-bminus-csv-button` based on session selection. 
- Emitted `session-selection-change` from the session list in `home-progressions.js` when an entry is selected or when selection is cleared, and synchronized `userClasse`/localStorage updates on selection. 
- Changed evaluation commit logic to compute current values with defaults of `3`, clamp updated `b`, `t`, and `a` to a minimum of `3`, and apply a `-1` penalty to `t` when the tentative `b` falls below `3`. 
- Adjusted `index.html` markup for the evaluation session LEDs and added CSS to style the `#eval-aplus.selected` state.

### Testing
- No automated tests are configured in the repository, so no automated test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb2f848b083319e3e869ad523cdda)