### PR TITLE
Add A session indicator, export/reset session scores, and session selection metadata

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -37,8 +37,10 @@
     const evalAMinusButton = document.getElementById('eval-aminus');
     const evalSessionLedB = document.getElementById('eval-session-led-b');
     const evalSessionLedT = document.getElementById('eval-session-led-t');
+    const evalSessionLedA = document.getElementById('eval-session-led-a');
     const evalCommentElement = document.getElementById('eval-comment');
     const evalValidateButton = document.getElementById('eval-validate');
+    const classInfoExportButton = document.getElementById('class-info-export-button');
     const TEAMS_COOKIE_PREFIX = 'savedTeams_';
     const SESSION_SCORES_COOKIE_PREFIX = 'sessionScores_';
 
@@ -46,6 +48,8 @@
     let currentTeams = [];
     let pendingEvaluation = null;
     let hasSelectedSession = false;
+    let selectedSessionKey = '';
+    let selectedSessionLabel = '';
 
     if (!classNameElement || !studentsCountElement || !indicatorBElement || !indicatorTElement || !indicatorAElement || !indicatorT1Element || !indicatorT2Element || !indicatorT3Element) {
         return;
@@ -405,7 +409,7 @@
         evalPopupElement.hidden = false;
     }
 
-    function getSessionDateKey() {
+    function getActiveSessionKey() {
         const now = new Date();
         const yyyy = now.getFullYear();
         const mm = String(now.getMonth() + 1).padStart(2, '0');
@@ -415,7 +419,7 @@
 
     function getSessionScoresCookieName() {
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
-        return `${SESSION_SCORES_COOKIE_PREFIX}${selectedClass}_${getSessionDateKey()}`;
+        return `${SESSION_SCORES_COOKIE_PREFIX}${selectedClass}_${getActiveSessionKey()}`;
     }
 
     function getSessionScoresMap() {
@@ -451,9 +455,11 @@
         const shouldDisable = !hasSelectedSession;
         if (classEvalButton) {
             classEvalButton.disabled = shouldDisable;
+            classEvalButton.hidden = shouldDisable;
         }
         if (exportBminusCsvButton) {
             exportBminusCsvButton.disabled = shouldDisable;
+            exportBminusCsvButton.hidden = shouldDisable;
         }
     }
 
@@ -461,7 +467,7 @@
         const sessionMap = getSessionScoresMap();
         const classComments = Array.isArray(sessionMap.__classComments) ? sessionMap.__classComments : [];
         const rows = lastClassStudents.map((student) => [student.name, sessionMap[student.name] || { b: 3, t: 3, a: 3, comments: [] }]);
-        const sessionDate = getSessionDateKey();
+        const sessionDate = selectedSessionLabel || getActiveSessionKey();
         const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
         const viewWindow = window.open('', '_blank');
         if (!viewWindow) {
@@ -481,7 +487,7 @@
         const classCommentsHtml = classComments.length
             ? `<div style="border:1px solid #ccc;padding:10px;margin:12px 0 16px 0;background:#f8fafc"><strong>Commentaire classe</strong><br>${classComments.join('<br>')}</div>`
             : `<div style="border:1px solid #ccc;padding:10px;margin:12px 0 16px 0;background:#f8fafc"><strong>Commentaire classe</strong><br>Aucun commentaire classe.</div>`;
-        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3>${classCommentsHtml}<p>Ordre export: Classe, Équipe, Élève, B, T, A et commentaire.</p><table><thead><tr><th>Classe</th><th>Équipe</th><th>Élève</th><th>B</th><th>T</th><th>A</th><th>Commentaire</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`);
+        viewWindow.document.write(`<html><head><title>Tableau séance ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:680px}th,td{border:1px solid #ccc;padding:8px 10px}th{background:#111827;color:#fff;text-align:left}</style></head><body><h3>Tableau séance ${selectedClass} (${sessionDate})</h3><p><button id="reset-session">Réinitialiser</button></p>${classCommentsHtml}<p>Ordre export: Classe, Équipe, Élève, B, T, A et commentaire.</p><table><thead><tr><th>Classe</th><th>Équipe</th><th>Élève</th><th>B</th><th>T</th><th>A</th><th>Commentaire</th></tr></thead><tbody>${tableRows}</tbody></table><script>document.getElementById('reset-session').addEventListener('click',()=>{if(window.opener){window.opener.postMessage({type:'reset-session-scores'}, '*');}window.close();});</script></body></html>`);
         viewWindow.document.close();
     }
 
@@ -506,6 +512,7 @@
         const first = studentNames.length ? (sessionMap[studentNames[0]] || { b: 3, t: 3 }) : { b: 3, t: 3 };
         setSessionIndicatorLight(evalSessionLedB, Number(first.b) || 3);
         setSessionIndicatorLight(evalSessionLedT, Number(first.t) || 3);
+        setSessionIndicatorLight(evalSessionLedA, Number(first.a) || 3);
     }
 
     function updateTeamStatusMessage() {
@@ -872,10 +879,41 @@
     if (classFilterElement) {
         classFilterElement.addEventListener('change', refreshClassInfo);
     }
+    if (classInfoExportButton) {
+        classInfoExportButton.addEventListener('click', () => {
+            const selectedClass = (getSelectedClass() || 'inconnue').toUpperCase().trim();
+            const sessionMap = getSessionScoresMap();
+            const rows = lastClassStudents.map((student) => {
+                const score = sessionMap[student.name] || {};
+                return `<tr><td>${student.name}</td><td>${Number(score.b) || 3}</td><td>${Number(score.t) || 3}</td><td>${Number(score.a) || 3}</td></tr>`;
+            }).join('');
+            const viewWindow = window.open('', '_blank');
+            if (!viewWindow) return;
+            viewWindow.document.write(`<html><head><title>Export voyants ${selectedClass}</title><style>body{font-family:Arial,sans-serif;padding:20px}table{border-collapse:collapse;width:100%;max-width:520px}th,td{border:1px solid #ccc;padding:8px}</style></head><body><h3>Voyants ${selectedClass} (${selectedSessionLabel || getActiveSessionKey()})</h3><table><thead><tr><th>Élève</th><th>B</th><th>T</th><th>A</th></tr></thead><tbody>${rows}</tbody></table></body></html>`);
+            viewWindow.document.close();
+        });
+    }
 
     window.addEventListener('session-selection-change', (event) => {
         hasSelectedSession = Boolean(event.detail && event.detail.hasSelection);
+        selectedSessionKey = event.detail && event.detail.sessionKey ? event.detail.sessionKey : '';
+        selectedSessionLabel = event.detail && event.detail.sessionLabel ? event.detail.sessionLabel : '';
         updateSessionDependentButtonsState();
+        refreshClassInfo();
+    });
+
+    
+    window.addEventListener('message', (event) => {
+        if (!event.data || event.data.type !== 'reset-session-scores') {
+            return;
+        }
+        const sessionMap = getSessionScoresMap();
+        Object.keys(sessionMap).forEach((key) => {
+            if (key === '__classComments') return;
+            sessionMap[key] = { b: 3, t: 3, a: 3, comments: [] };
+        });
+        sessionMap.__classComments = [];
+        saveSessionScoresMap(sessionMap);
     });
 
     window.addEventListener('storage', (event) => {

--- a/home-progressions.js
+++ b/home-progressions.js
@@ -769,7 +769,7 @@
                 }
                 localStorage.setItem('userClasse', entry.classText);
                 window.dispatchEvent(new CustomEvent('session-selection-change', {
-                    detail: { hasSelection: true, selectedClass: entry.classText }
+                    detail: { hasSelection: true, selectedClass: entry.classText, sessionKey: entry.dateText || '', sessionLabel: entry.dateText || '' }
                 }));
                 renderSteps();
                 renderTaskDetail(entry);
@@ -783,7 +783,7 @@
             selectedEntryKey = '';
             renderTaskDetail(null);
             window.dispatchEvent(new CustomEvent('session-selection-change', {
-                detail: { hasSelection: false, selectedClass: classFilterElement.value || '' }
+                detail: { hasSelection: false, selectedClass: classFilterElement.value || '', sessionKey: '', sessionLabel: '' }
             }));
         }
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
                 <div class="atelier-content">
                     <div class="card-header-with-toggle class-info-header">
                         <h2>Informations classe</h2>
-                        <button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button>
+                        <div class="class-info-actions"><button id="class-info-export-button" type="button" class="generate-teams-button" aria-label="Exporter les voyants de la classe" title="Exporter les voyants de la classe">Export</button><button id="generate-teams-button" type="button" class="generate-teams-button">Gestion des équipes</button></div>
                     </div>
                     <p id="selected-class-name">Classe sélectionnée : Aucune</p>
                     <p id="selected-class-students">Effectif (3E) : -</p>
@@ -129,6 +129,7 @@
                 <div class="eval-popup-session-leds">
                 <span><span id="eval-session-led-b" class="indicator-light" aria-label="Voyant B séance"></span></span>
                 <span><span id="eval-session-led-t" class="indicator-light" aria-label="Voyant T séance"></span></span>
+                <span><span id="eval-session-led-a" class="indicator-light" aria-label="Voyant A séance"></span></span>
                 </div>
             </div>
             <div class="eval-popup-actions">

--- a/styles.css
+++ b/styles.css
@@ -2010,3 +2010,10 @@ svg.axe { display: block; margin: 0.5em 0; }
     background: rgba(22, 163, 74, 0.95);
     border-color: #bbf7d0;
 }
+
+
+.class-info-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+}


### PR DESCRIPTION
### Motivation
- Surface the session "A" indicator alongside existing B/T indicators in the evaluation UI so the full B/T/A set is visible when evaluating a session. 
- Allow exporting the class indicators (voyants) and embed session metadata so exports show the active session label. 
- Provide a way to reset session scores from the exported session table and carry session selection details across components to enable session-scoped actions.

### Description
- Added `eval-session-led-a` element handling in `index.html`, `class-info.js` and UI wiring so the A LED is updated with `updateSessionLeds` and `setSessionIndicatorLight`. 
- Introduced `class-info-export-button` and `.class-info-actions` styling, and implemented an export view that shows B/T/A per student using `selectedSessionLabel` or the active session key. 
- Propagated session metadata from `home-progressions.js` via the `session-selection-change` event with `sessionKey` and `sessionLabel`, and stored them in `selectedSessionKey`/`selectedSessionLabel` in `class-info.js`. 
- Reworked session cookie key logic to use `getActiveSessionKey()` and made session-dependent buttons (`classEvalButton`, `exportBminusCsvButton`) hidden/disabled when no session is selected. 
- Added a `Réinitialiser` button to the exported session table that posts a `reset-session-scores` message to the opener, and added a `message` listener that resets all student session scores and `__classComments` to defaults and saves them.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eb9b351f08331b9c665e78139b661)