### PR TITLE
Déplacer le bouton + d'équipe à côté du bouton Évaluer

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -378,9 +378,9 @@
                 detailsList.classList.toggle('hide-action-buttons', showIndicators);
             });
 
+            teamHeader.appendChild(detailsButton);
             card.appendChild(teamHeader);
             card.appendChild(teamIndicators);
-            card.appendChild(detailsButton);
             card.appendChild(detailsPanel);
             teamsPopupListElement.appendChild(card);
         });


### PR DESCRIPTION
### Motivation
- Déplacer le bouton d'extension (`+`/`−`) de chaque carte d'équipe dans l'en-tête afin qu'il apparaisse juste à côté du bouton `📝` «Évaluer» dans la fenêtre de gestion des équipes.

### Description
- Dans `class-info.js` (fonction `renderTeams`) le `detailsButton` est maintenant inséré dans `teamHeader` au lieu d'être ajouté sous les indicateurs, ce qui change uniquement l'ordre DOM sans modifier le comportement d'ouverture/fermeture.

### Testing
- Exécutions de vérification statique réalisées : recherche de textes avec `rg`, inspection de la plage modifiée avec `sed`/`nl` et vérification d'état du dépôt avec `git status --short`, et toutes les vérifications ont réussi; il n'y a pas de tests unitaires automatisés liés à ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f029997088331812870c5f251be85)