### PR TITLE
Fix global export LED column mapping and appreciation placement

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -1045,7 +1045,7 @@
             const viewWindow = window.open('', '_blank');
             if (!viewWindow) return;
             const exportRows = lastClassStudents.map((student) => {
-                const cells = ['b', 't', 'a', 'cpc', 'c3d', 'cmq', 't1', 't2', 't3'].map((key) => {
+                const cells = ['t1b', 't1t', 't1a', 't2b', 't2t', 't2a', 't3b', 't3t', 't3a', 'cpc', 'c3d', 'cmq', 't1', 't2', 't3'].map((key) => {
                     const config = getIndicatorDisplayConfig(key);
                     const rawValue = student[key];
                     if (rawValue === null || rawValue === undefined) {


### PR DESCRIPTION
### Motivation
- Aligner les voyants LED de l'export global avec l'ordre des colonnes affichées pour que les indicateurs T1/T2/T3 apparaissent avant le bouton d'Appréciation. 
- Corriger le décalage qui rendait l'action d'`Appréciation` incohérente en affichage. 
- Rétablir la lisibilité et la cohérence du bilan exporté de la classe.

### Description
- Modifié l'indexation des voyants dans `class-info.js` en remplaçant le tableau `['b','t','a','cpc','c3d','cmq','t1','t2','t3']` par `['t1b','t1t','t1a','t2b','t2t','t2a','t3b','t3t','t3a','cpc','c3d','cmq','t1','t2','t3']` dans la génération des cellules d'export. 
- Cette mise à jour aligne les cellules LED générées (`<td><span class="led">…`) avec l'en-tête du tableau d'export. 
- Aucun autre changement fonctionnel n'a été effectué.

### Testing
- Exécution de `node --check class-info.js` réussie sans erreur de syntaxe. 
- Vérification du diff pour confirmer que seule l'ordre des clés LED a été modifié. 
- Aucun test automatisé d'interface utilisateur présent dans le dépôt pour valider visuellement l'export.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103143bc308331af8432d75624efe8)