### PR TITLE
Fix team score floor interactions and class info CSV parsing

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -143,8 +143,16 @@
     }
 
     function computeMergedIndicator(row, indexes) {
-        const values = indexes.map((idx) => parsePercentage(row[idx])).filter((value) => value !== null);
+        const values = indexes
+            .filter((idx) => Number.isInteger(idx) && idx >= 0)
+            .map((idx) => parsePercentage(row[idx]))
+            .filter((value) => value !== null);
         return computeAverage(values);
+    }
+
+    function numberOrDefault(value, defaultValue) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : defaultValue;
     }
 
     function parseStudentData(row, idxMap) {
@@ -177,6 +185,18 @@
         const byName = header.findIndex((col) => col === expectedName);
         if (byName !== -1) {
             return byName;
+        }
+        if (Number.isInteger(fallbackIndex) && fallbackIndex >= 0 && fallbackIndex < header.length) {
+            return fallbackIndex;
+        }
+        return -1;
+    }
+
+
+    function resolveFirstExistingColumn(header, expectedNames, fallbackIndex) {
+        for (const name of expectedNames) {
+            const idx = header.findIndex((col) => col === name);
+            if (idx !== -1) return idx;
         }
         if (Number.isInteger(fallbackIndex) && fallbackIndex >= 0 && fallbackIndex < header.length) {
             return fallbackIndex;
@@ -577,9 +597,9 @@
             return;
         }
         const tableRows = rows.length ? rows.map(([name, scores]) => {
-            const b = Number(scores.b) || 3;
-            const t = Number(scores.t) || 3;
-            const a = Number(scores.a) || 3;
+            const b = numberOrDefault(scores.b, 3);
+            const t = numberOrDefault(scores.t, 3);
+            const a = numberOrDefault(scores.a, 3);
             const bHue = ((clamp(b, -3, 3) + 3) / 6) * 120;
             const tHue = ((clamp(t, -3, 3) + 3) / 6) * 120;
             const aHue = ((clamp(a, -3, 3) + 3) / 6) * 120;
@@ -612,16 +632,21 @@
     function updateSessionLeds(studentNames) {
         const sessionMap = getSessionScoresMap();
         const first = studentNames.length ? (sessionMap[studentNames[0]] || { b: 3, t: 3, a: 3 }) : { b: 3, t: 3, a: 3 };
-        const baseB = Number(first.b) || 3;
-        const baseT = Number(first.t) || 3;
-        const baseA = Number(first.a) || 3;
+        const baseB = numberOrDefault(first.b, 3);
+        const baseT = numberOrDefault(first.t, 3);
+        const baseA = numberOrDefault(first.a, 3);
         const bDelta = pendingEvaluation ? pendingEvaluation.bDelta : 0;
         const tDelta = pendingEvaluation ? pendingEvaluation.tDelta : 0;
         const aDelta = pendingEvaluation ? pendingEvaluation.aDelta : 0;
-        const tentativeB = clamp(baseB + bDelta, -3, 3);
-        const bonusTDeltaFromB = tentativeB < 0 ? -1 : 0;
-        const tentativeT = clamp(baseT + tDelta + bonusTDeltaFromB, -3, 3);
+        let tentativeB = clamp(baseB + bDelta, -3, 3);
+        let tentativeT = clamp(baseT + tDelta, -3, 3);
         const tentativeA = clamp(baseA + aDelta, -3, 3);
+        if (tentativeB < 0) {
+            tentativeT = clamp(tentativeT - 1, -3, 3);
+        }
+        if (tentativeT < 0) {
+            tentativeB = clamp(tentativeB - 1, -3, 3);
+        }
         setSessionIndicatorLight(evalSessionLedB, tentativeB);
         setSessionIndicatorLight(evalSessionLedT, tentativeT);
         setSessionIndicatorLight(evalSessionLedA, tentativeA);
@@ -727,8 +752,8 @@
         }
 
         const header = rows[0].map((cell) => normalize(cell));
-        const classIdx = header.findIndex((col) => col === 'classe');
-        const nameIdx = header.findIndex((col) => col === 'nom');
+        const classIdx = resolveFirstExistingColumn(header, ['classe', 'class', 'classegroupe'], 0);
+        const nameIdx = resolveFirstExistingColumn(header, ['nom', 'eleve', 'nomprenom', 'nom prenom'], 1);
         const indicatorT1BIdx = resolveCsvColumnIndex(header, 't1b', 2);
         const indicatorT1TIdx = resolveCsvColumnIndex(header, 't1t', 3);
         const indicatorT1AIdx = resolveCsvColumnIndex(header, 't1a', 4);
@@ -1009,14 +1034,24 @@
                 if (!sessionMap[studentName] || typeof sessionMap[studentName] !== 'object') {
                     sessionMap[studentName] = { b: 3, t: 3, a: 3, comments: [] };
                 }
-                const currentB = Number(sessionMap[studentName].b) || 3;
-                const currentT = Number(sessionMap[studentName].t) || 3;
-                const currentA = Number(sessionMap[studentName].a) || 3;
-                const tentativeB = currentB + pendingEvaluation.bDelta;
-                const bonusTDeltaFromB = tentativeB < 0 ? -1 : 0;
-                sessionMap[studentName].b = clamp(tentativeB, -3, 3);
-                sessionMap[studentName].t = clamp(currentT + pendingEvaluation.tDelta + bonusTDeltaFromB, -3, 3);
-                sessionMap[studentName].a = clamp(currentA + pendingEvaluation.aDelta, -3, 3);
+                const currentB = numberOrDefault(sessionMap[studentName].b, 3);
+                const currentT = numberOrDefault(sessionMap[studentName].t, 3);
+                const currentA = numberOrDefault(sessionMap[studentName].a, 3);
+
+                let nextB = clamp(currentB + pendingEvaluation.bDelta, -3, 3);
+                let nextT = clamp(currentT + pendingEvaluation.tDelta, -3, 3);
+                const nextA = clamp(currentA + pendingEvaluation.aDelta, -3, 3);
+
+                if (nextB < 0) {
+                    nextT = clamp(nextT - 1, -3, 3);
+                }
+                if (nextT < 0) {
+                    nextB = clamp(nextB - 1, -3, 3);
+                }
+
+                sessionMap[studentName].b = nextB;
+                sessionMap[studentName].t = nextT;
+                sessionMap[studentName].a = nextA;
                 if (!Array.isArray(sessionMap[studentName].comments)) {
                     sessionMap[studentName].comments = [];
                 }


### PR DESCRIPTION
### Motivation
- Prevent session scores B/T/A from being incorrectly reset when they are zero or negative and enforce the lower bound of `-3` instead of silently reverting to `3`.
- Apply the requested cross-impact rules so a negative `B` reduces `T` by 1 and a negative `T` reduces `B` by 1 in both preview and persisted evaluations.
- Make class information loading more robust against slightly different CSV headers and against invalid column indexes that previously caused the class panel to fail to load.

### Description
- Updated `class-info.js` to use a `numberOrDefault` helper and removed `Number(...) || 3` patterns so legitimate `0`/negative values are preserved and clamped with `clamp(..., -3, 3)`.
- Implemented mutual-impact logic in the live preview (`updateSessionLeds`) and on validation (`evalValidate` handler) so that when `B < 0` then `T -= 1`, and when `T < 0` then `B -= 1`, with both values clamped to `-3`.
- Hardened CSV parsing: added `resolveFirstExistingColumn` to accept alternative header names for `classe`/`nom` and made `computeMergedIndicator` ignore invalid column indexes so malformed CSV headers no longer cause a crash.
- Replaced fragile merges and display defaults in the session table rendering and scoring persistence to use the new helpers and rules (all changes are in `class-info.js`).

### Testing
- Ran a JavaScript syntax check with `node --check class-info.js`, which failed due to a pre-existing string-escaping issue elsewhere in the same file and not caused by these changes (syntax error unrelated to modified logic). (failed)
- Verified the code diff to confirm the intended changes were applied to `class-info.js`. (inspection)
- Committed the updated `class-info.js` after making the changes. (operation succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1047f5dc048331a69e788bb08171e0)