### PR TITLE
Refonte du popup d'évaluation — grille 3 colonnes, toggles, A++ et présélection « Absent »

### DIFF
--- a/class-info.js
+++ b/class-info.js
@@ -39,13 +39,12 @@
     const evalPopupTitle = document.getElementById('eval-popup-title');
     const evalBMinusButton = document.getElementById('eval-bminus');
     const evalTPlusButton = document.getElementById('eval-tplus');
-    const evalTPlus3Button = document.getElementById('eval-tplus3');
     const evalBMinus1Button = document.getElementById('eval-bminus1');
     const evalBPlusButton = document.getElementById('eval-bplus');
-    const evalTMinus2Button = document.getElementById('eval-tminus2');
     const evalTMinus1Button = document.getElementById('eval-tminus1');
     const evalTPlus2Button = document.getElementById('eval-tplus2');
     const evalAPlusButton = document.getElementById('eval-aplus');
+    const evalAPlus2Button = document.getElementById('eval-aplus2');
     const evalAMinusButton = document.getElementById('eval-aminus');
     const evalAbsentButton = document.getElementById('eval-absent');
     const evalSessionLedB = document.getElementById('eval-session-led-b');
@@ -525,11 +524,14 @@
         if (!evalPopupElement || !studentNames.length) {
             return;
         }
-        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0, aDelta: 0, markAbsent: false, isClassEvaluation: label === 'Classe' };
+        const sessionMap = getSessionScoresMap();
+        const shouldMarkAbsentByDefault = studentNames.length > 0 && studentNames.every((studentName) => Boolean(sessionMap[studentName] && sessionMap[studentName].absent));
+        pendingEvaluation = { studentNames, bDelta: 0, tDelta: 0, aDelta: 0, markAbsent: shouldMarkAbsentByDefault, isClassEvaluation: label === 'Classe' };
         const evaluatedSessionLabel = getEvaluatedSessionLabel();
         evalPopupTitle.textContent = `Évaluer : ${label} (${evaluatedSessionLabel})`;
         evalCommentElement.value = '';
-        [evalBMinusButton, evalBMinus1Button, evalBPlusButton, evalTMinus2Button, evalTMinus1Button, evalTPlusButton, evalTPlus2Button, evalTPlus3Button, evalAPlusButton, evalAMinusButton, evalAbsentButton].forEach((button) => button && button.classList.remove('selected'));
+        [evalBMinusButton, evalBMinus1Button, evalBPlusButton, evalTMinus1Button, evalTPlusButton, evalTPlus2Button, evalAPlusButton, evalAPlus2Button, evalAMinusButton, evalAbsentButton].forEach((button) => button && button.classList.remove('selected'));
+        evalAbsentButton.classList.toggle('selected', pendingEvaluation.markAbsent);
         updateSessionLeds(studentNames);
         evalPopupElement.hidden = false;
     }
@@ -1020,93 +1022,25 @@
         });
     }
     // Fermeture volontaire retirée : validation obligatoire pour fermer la fenêtre.
-    if (evalBMinusButton) {
-        evalBMinusButton.addEventListener('click', () => {
+    function toggleEvalDelta(button, key, deltaValue) {
+        if (!button) return;
+        button.addEventListener('click', () => {
             if (!pendingEvaluation) return;
-            pendingEvaluation.bDelta -= 2;
-            evalBMinusButton.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-    if (evalTPlusButton) {
-        evalTPlusButton.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.tDelta += 1;
-            evalTPlusButton.classList.add('selected');
+            const isSelected = button.classList.toggle('selected');
+            pendingEvaluation[key] += isSelected ? deltaValue : -deltaValue;
             updateSessionLeds(pendingEvaluation.studentNames);
         });
     }
 
-    if (evalTPlus3Button) {
-        evalTPlus3Button.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.tDelta += 3;
-            evalTPlus3Button.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalBMinus1Button) {
-        evalBMinus1Button.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.bDelta -= 1;
-            evalBMinus1Button.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalBPlusButton) {
-        evalBPlusButton.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.bDelta += 1;
-            evalBPlusButton.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalTMinus2Button) {
-        evalTMinus2Button.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.tDelta -= 2;
-            evalTMinus2Button.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalTMinus1Button) {
-        evalTMinus1Button.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.tDelta -= 1;
-            evalTMinus1Button.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalTPlus2Button) {
-        evalTPlus2Button.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.tDelta += 2;
-            evalTPlus2Button.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-
-    if (evalAPlusButton) {
-        evalAPlusButton.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.aDelta += 1;
-            evalAPlusButton.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
-    if (evalAMinusButton) {
-        evalAMinusButton.addEventListener('click', () => {
-            if (!pendingEvaluation) return;
-            pendingEvaluation.aDelta -= 1;
-            evalAMinusButton.classList.add('selected');
-            updateSessionLeds(pendingEvaluation.studentNames);
-        });
-    }
+    toggleEvalDelta(evalBMinusButton, 'bDelta', -2);
+    toggleEvalDelta(evalBMinus1Button, 'bDelta', -1);
+    toggleEvalDelta(evalBPlusButton, 'bDelta', 1);
+    toggleEvalDelta(evalTMinus1Button, 'tDelta', -1);
+    toggleEvalDelta(evalTPlusButton, 'tDelta', 1);
+    toggleEvalDelta(evalTPlus2Button, 'tDelta', 2);
+    toggleEvalDelta(evalAMinusButton, 'aDelta', -1);
+    toggleEvalDelta(evalAPlusButton, 'aDelta', 1);
+    toggleEvalDelta(evalAPlus2Button, 'aDelta', 2);
 
     if (evalAbsentButton) {
         evalAbsentButton.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -143,13 +143,12 @@
                 <button id="eval-bminus" type="button" class="eval-action-button">B--</button>
                 <button id="eval-bminus1" type="button" class="eval-action-button">B-</button>
                 <button id="eval-bplus" type="button" class="eval-action-button">B+</button>
-                <button id="eval-tminus2" type="button" class="eval-action-button">T--</button>
                 <button id="eval-tminus1" type="button" class="eval-action-button">T-</button>
                 <button id="eval-tplus" type="button" class="eval-action-button">T+</button>
                 <button id="eval-tplus2" type="button" class="eval-action-button">T++</button>
-                <button id="eval-tplus3" type="button" class="eval-action-button">T+++</button>
-                <button id="eval-aplus" type="button" class="eval-action-button">A+</button>
                 <button id="eval-aminus" type="button" class="eval-action-button">A-</button>
+                <button id="eval-aplus" type="button" class="eval-action-button">A+</button>
+                <button id="eval-aplus2" type="button" class="eval-action-button">A++</button>
                 <button id="eval-absent" type="button" class="eval-action-button">Absent</button>
             </div>
             <label for="eval-comment">Commentaire</label>

--- a/styles.css
+++ b/styles.css
@@ -1995,9 +1995,9 @@ svg.axe { display: block; margin: 0.5em 0; }
 }
 
 .eval-popup-actions {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
-    flex-wrap: wrap;
 }
 
 .eval-action-button {
@@ -2009,7 +2009,8 @@ svg.axe { display: block; margin: 0.5em 0; }
     cursor: pointer;
     font-weight: 700;
     letter-spacing: 0.01em;
-    min-width: 64px;
+    min-width: 0;
+    width: 100%;
     transition: transform .12s ease, filter .12s ease, background .12s ease;
 }
 .eval-action-button:hover {
@@ -2017,17 +2018,19 @@ svg.axe { display: block; margin: 0.5em 0; }
     transform: translateY(-1px);
 }
 
-.eval-action-button.selected {
+#eval-bminus.selected,
+#eval-bminus1.selected,
+#eval-tminus1.selected,
+#eval-aminus.selected {
     background: rgba(220, 38, 38, 0.92);
     border-color: #fecaca;
 }
 
-#eval-tplus.selected {
-    background: rgba(22, 163, 74, 0.95);
-    border-color: #bbf7d0;
-}
-
-#eval-aplus.selected {
+#eval-bplus.selected,
+#eval-tplus.selected,
+#eval-tplus2.selected,
+#eval-aplus.selected,
+#eval-aplus2.selected {
     background: rgba(22, 163, 74, 0.95);
     border-color: #bbf7d0;
 }


### PR DESCRIPTION
### Motivation
- Réorganiser la fenêtre d'évaluation pour présenter les options sous forme de matrice 3 colonnes afin de correspondre à la grille demandée (`B--/B-/B+`, `T-/T+/T++`, `A-/A+/A++`, `Absent`).
- Simplifier l'interaction en faisant en sorte que chaque bouton applique un bonus/malus une seule fois par saisie via un comportement toggle.
- Rendre l'état visuel des boutons plus clair avec des couleurs distinctes pour négatif/positif/absent.
- Pré-sélectionner le bouton `Absent` à l'ouverture si l'élève (ou tous les élèves ciblés) est déjà marqué absent pour la séance.

### Description
- Réorganise le markup dans `index.html` pour supprimer `T--` et `T+++`, ajouter `A++` et placer les boutons en grille 3 colonnes dans le bloc `#eval-popup`.
- Met à jour `styles.css` pour afficher la grille (`.eval-popup-actions` => `display: grid; grid-template-columns: repeat(3, ...)`) et pour appliquer des sélecteurs ciblés qui colorent les boutons négatifs en rouge, positifs en vert et `Absent` en orange, et rendre les boutons pleine largeur dans la grille.
- Modifie `class-info.js` pour introduire `evalAPlus2Button`, calculer `shouldMarkAbsentByDefault` à l'ouverture et initialiser `pendingEvaluation.markAbsent` en conséquence, et pré-cocher le bouton `Absent` si nécessaire.
- Remplace les gestionnaires individuels par une fonction utilitaire `toggleEvalDelta(button, key, deltaValue)` afin que chaque bouton soit toggle et que son delta soit appliqué ou retiré une seule fois lors de la saisie.

### Testing
- Exécution de la vérification de diff `git diff --check` qui a réussi without reported whitespace or merge issues. 
- Vérification d'état avec `git status --short` montrant les fichiers modifiés. 
- Validation en commit avec `git commit` (message "Refondre la grille d'évaluation élève et sélection des bonus/malus") qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10b91283308331aea2832df1dfc03e)