### PR TITLE
Améliore le fallback des données de la page d'accueil pour éviter le message “I/O error”

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -846,11 +846,21 @@
             header = parsed.shift() || [];
             rows = parsed;
         } catch (error) {
-            const localResponse = await fetch('suivi_projet_data.json');
-            const localData = await localResponse.json();
-            header = localData.cols || [];
-            rows = localData.rows || [];
-            setStatus('Google Sheets indisponible : affichage des données locales.', true);
+            try {
+                const localResponse = await fetch('suivi_projet_data.json');
+                if (!localResponse.ok) {
+                    throw new Error(`HTTP ${localResponse.status}`);
+                }
+                const localData = await localResponse.json();
+                header = localData.cols || [];
+                rows = localData.rows || [];
+                setStatus('Google Sheets indisponible : affichage des données locales.', true);
+            } catch (localError) {
+                const hint = location.protocol === 'file:'
+                    ? 'Ouvrez le site via un serveur web local (http://...) pour autoriser le chargement des fichiers.'
+                    : 'Vérifiez la connexion réseau et la disponibilité des sources de données.';
+                throw new Error(`Impossible de charger les données distantes et locales. ${hint}`);
+            }
         }
 
         classIdx = header.findIndex((col) => normalize(col) === 'classe');


### PR DESCRIPTION
### Motivation
- Empêcher l’affichage d’un message d’erreur bas‑niveau (par ex. “I/O error”) quand le chargement depuis Google Sheets échoue et que la récupération locale échoue ou est bloquée par `file://`.

### Description
- Dans `home-progressions.js` la fonction `loadRows()` encapsule désormais l’appel de secours local (`suivi_projet_data.json`) dans un `try/catch`, vérifie `localResponse.ok` avant de parser le JSON et, si les deux sources échouent, renvoie une erreur explicite incluant un indice pour les cas `file://` (conseil d’utiliser un serveur HTTP local).

### Testing
- Vérification de syntaxe JavaScript avec `node --check home-progressions.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1166f7dd0c8331b42c49bfe25016a9)