### PR TITLE
Improve fallback when Google Sheets and local JSON fail in home-progressions.js

### DIFF
--- a/home-progressions.js
+++ b/home-progressions.js
@@ -846,11 +846,25 @@
             header = parsed.shift() || [];
             rows = parsed;
         } catch (error) {
-            const localResponse = await fetch('suivi_projet_data.json');
-            const localData = await localResponse.json();
-            header = localData.cols || [];
-            rows = localData.rows || [];
-            setStatus('Google Sheets indisponible : affichage des données locales.', true);
+            try {
+                const localResponse = await fetch('suivi_projet_data.json');
+                if (!localResponse.ok) {
+                    throw new Error(`HTTP ${localResponse.status}`);
+                }
+                const localData = await localResponse.json();
+                header = localData.cols || [];
+                rows = localData.rows || [];
+                setStatus('Google Sheets indisponible : affichage des données locales.', true);
+            } catch (localError) {
+                const fileProtocol = location.protocol === 'file:';
+                const hint = fileProtocol
+                    ? 'Mode fichier détecté : ouvrez le site via un serveur web local (http://...) pour autoriser le chargement des fichiers.'
+                    : 'Vérifiez la connexion réseau et la disponibilité des sources de données.';
+
+                header = ['Classe', 'Projet', 'Date', 'Tâche'];
+                rows = [];
+                setStatus(`Impossible de charger les données distantes et locales. ${hint}`, true);
+            }
         }
 
         classIdx = header.findIndex((col) => normalize(col) === 'classe');


### PR DESCRIPTION
### Motivation
- Make data loading more robust by handling failures when the Google Sheets CSV is unavailable and the local `suivi_projet_data.json` also cannot be fetched, and provide a helpful hint when the app is opened via the `file:` protocol.

### Description
- Wrap the local JSON fetch in its own `try/catch` and check `localResponse.ok` to avoid silent failures and clearer error handling when local data is unavailable.
- Provide a fallback default `header` (`['Classe', 'Projet', 'Date', 'Tâche']`) with empty `rows` and call `setStatus` with a contextual hint that detects `location.protocol === 'file:'` to suggest running the site via a local web server.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1166f7dd0c8331b42c49bfe25016a9)