### PR TITLE
Corrige crash au démarrage si userBadgeProgress local corrompu

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -127,7 +127,17 @@
         const score = parseInt(localStorage.getItem('userScore')||'0',10);
         const badges = (localStorage.getItem('userBadges')||'');
         const classe = (localStorage.getItem('userClasse')||'');
-        const badgeProgress = JSON.parse(localStorage.getItem('userBadgeProgress') || '{}');
+        let badgeProgress = {};
+        const rawBadgeProgress = localStorage.getItem('userBadgeProgress');
+        if(rawBadgeProgress){
+            try {
+                const parsed = JSON.parse(rawBadgeProgress);
+                badgeProgress = parsed && typeof parsed === 'object' ? parsed : {};
+            } catch(e){
+                console.warn('userBadgeProgress invalide dans le stockage local, valeur réinitialisée.');
+                localStorage.removeItem('userBadgeProgress');
+            }
+        }
         return {pseudo, score, badges, classe, badgeProgress};
     }
 


### PR DESCRIPTION
### Motivation
- Empêcher une exception levée par `JSON.parse` sur la clé `userBadgeProgress` en `localStorage` qui pouvait planter l'initialisation de l'application en mode normal alors qu'en navigation privée, avec un stockage vide, le problème n'apparaissait pas.

### Description
- Ajout d'un parsing défensif dans `getUser()` (fichier `auth.js`) qui tente de `JSON.parse` la valeur stockée, retombe sur `{}` si la valeur est invalide et supprime la clé corrompue avec `localStorage.removeItem('userBadgeProgress')` pour éviter les relances de l'erreur.

### Testing
- Exécutées les commandes `git add auth.js && git commit -m "Fix crash on invalid local badgeProgress cache"` et `git rev-parse --short HEAD`, la commit a été créée avec succès (SHA `5a168b6`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11aba11ad08331a6d5e80543c3424c)