### PR TITLE
Handle corrupted localStorage and cookie data; add cookie deletion and teams validation

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -127,7 +127,17 @@
         const score = parseInt(localStorage.getItem('userScore')||'0',10);
         const badges = (localStorage.getItem('userBadges')||'');
         const classe = (localStorage.getItem('userClasse')||'');
-        const badgeProgress = JSON.parse(localStorage.getItem('userBadgeProgress') || '{}');
+        let badgeProgress = {};
+        const rawBadgeProgress = localStorage.getItem('userBadgeProgress');
+        if(rawBadgeProgress){
+            try {
+                const parsed = JSON.parse(rawBadgeProgress);
+                badgeProgress = parsed && typeof parsed === 'object' ? parsed : {};
+            } catch(e){
+                console.warn('userBadgeProgress invalide dans le stockage local, valeur réinitialisée.');
+                localStorage.removeItem('userBadgeProgress');
+            }
+        }
         return {pseudo, score, badges, classe, badgeProgress};
     }
 

--- a/class-info.js
+++ b/class-info.js
@@ -718,10 +718,23 @@
         document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`;
     }
 
+    function deleteCookie(name) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax`;
+    }
+
     function getCookie(name) {
         const prefix = `${name}=`;
         const cookie = document.cookie.split('; ').find((entry) => entry.startsWith(prefix));
-        return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : null;
+        if (!cookie) {
+            return null;
+        }
+        try {
+            return decodeURIComponent(cookie.slice(prefix.length));
+        } catch (error) {
+            console.warn(`Cookie ${name} invalide, suppression de la valeur corrompue.`);
+            deleteCookie(name);
+            return null;
+        }
     }
 
 
@@ -949,6 +962,9 @@
         }
         try {
             const savedTeams = JSON.parse(raw);
+            if (!Array.isArray(savedTeams) || !savedTeams.every((team) => Array.isArray(team))) {
+                throw new Error('invalid teams structure');
+            }
             const byName = new Map(lastClassStudents.map((student) => [student.name, student]));
             currentTeams = savedTeams.map((team) => team.map((name) => byName.get(name)).filter(Boolean));
             renderTeams(currentTeams);
@@ -957,6 +973,7 @@
             return true;
         } catch (error) {
             teamsPopupStatusElement.textContent = 'Sauvegarde invalide.';
+            deleteCookie(`${TEAMS_COOKIE_PREFIX}${className.toUpperCase()}`);
             return false;
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and broken UI when `userBadgeProgress` in `localStorage` or team cookies contain invalid/corrupted data.
- Ensure corrupted cookie values are cleaned up to avoid repeated parsing failures.

### Description
- In `auth.js` updated `getUser` to safely parse `userBadgeProgress` inside a `try/catch`, reset to `{}` on parse errors, remove the invalid `localStorage` entry, and emit a console warning.
- In `class-info.js` added a `deleteCookie` helper and updated `getCookie` to catch `decodeURIComponent` errors, remove corrupted cookies, and return `null` instead of throwing.
- Added validation in `loadSavedTeamsForSelectedClass` to ensure the parsed teams structure is an array of arrays and delete the corresponding cookie when the saved data is invalid, and improved error handling and status messages.
- No functional changes to team generation or navigation logic beyond making input data handling more robust.

### Testing
- Ran the project's automated lint checks without errors.
- Executed the existing automated unit tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11aba11ad08331a6d5e80543c3424c)